### PR TITLE
cincinnati: get rid of a few unwraps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ version = "0.1.0"
 dependencies = [
  "daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Alex Crawford <crawford@redhat.com>"]
 [dependencies]
 daggy = { version = "^0.6.0", features = [ "serde-1" ] }
 failure = "^0.1.1"
+log = "^0.4.3"
 semver = { version = "^0.9.0", features = [ "serde" ] }
 serde = "1.0.70"
 serde_derive = "1.0.70"


### PR DESCRIPTION
This gets rid of a couple of panic points (unwraps) in favor of plain
error bubbling and iterator shortening.