### PR TITLE
graph-builder/registry: use stream instead of loop

### DIFF
--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -83,6 +83,7 @@ fn create_graph(
     registry::fetch_releases(&opts.registry, &opts.repository, username, password)
         .context("failed to fetch all release metadata")?
         .into_iter()
+        .inspect(|release| trace!("Adding a release to the graph '{:?}'", release))
         .try_for_each(|release| {
             let previous = release.metadata.previous.clone();
             let next = release.metadata.next.clone();


### PR DESCRIPTION
This refactor intorduces the use of Stream throughout the whole chain in
which simplifies the termination of the execution in case a Release was
found for a set of layer digests.

Besides the technical change there is also the semantic change of not
returning any errors, and instead return an empty `Vec<Release>` in case
no release could be found.