### PR TITLE
add scripts for CI/CD integration

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,18 +1,10 @@
-FROM centos
+FROM centos:7
 
 RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install openssl-devel
 
-ADD https://static.rust-lang.org/dist/rust-1.30.1-x86_64-unknown-linux-gnu.tar.gz rust.tar.gz
-RUN tar -xf rust.tar.gz --strip 1
-RUN ./install.sh
-
-RUN mkdir app
-WORKDIR app
-COPY . .
-RUN cargo build --release
-
-FROM centos
 ENV RUST_LOG=actix_web=error,dkregistry=error
+
+COPY target/x86_64-unknown-linux-musl/release/graph-builder target/x86_64-unknown-linux-musl/release/policy-engine /usr/bin/
+
 ENTRYPOINT ["/usr/bin/graph-builder"]
-COPY --from=0 /app/target/release/graph-builder /app/target/release/policy-engine /usr/bin/

--- a/dist/build_deploy.sh
+++ b/dist/build_deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_BUILD="${IMAGE_BUILD:-ekidd/rust-musl-builder:1.30.1}"
+IMAGE="quay.io/app-sre/cincinnati"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+PROJECT_PARENT_DIR=$ABSOLUTE_PATH/../
+DOCKERFILE_DEPLOY="$ABSOLUTE_PATH/Dockerfile"
+
+docker run --rm -v $PROJECT_PARENT_DIR:/home/rust/src $IMAGE_BUILD cargo build --release
+
+docker build -f $DOCKERFILE_DEPLOY -t "${IMAGE}:${IMAGE_TAG}" $PROJECT_PARENT_DIR
+
+if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
+    DOCKER_CONF="$PWD/.docker"
+    mkdir -p "$DOCKER_CONF"
+    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+fi

--- a/dist/pr_check.sh
+++ b/dist/pr_check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_BUILD="${IMAGE_BUILD:-ekidd/rust-musl-builder:1.30.1}"
+PROJECT_PARENT_DIR=$ABSOLUTE_PATH/../
+
+docker run --rm -v $PROJECT_PARENT_DIR:/home/rust/src $IMAGE_BUILD cargo test


### PR DESCRIPTION
add scripts for CI/CD integration

note I've used `ekidd/rust-musl-builder:1.30.1` for rust static builds in docker container.

this is needed for: https://jira.coreos.com/browse/APPSRE-252

cc: @crawford @steveeJ @pbergene