### PR TITLE
use another build image that does not require special permissions on project files

### DIFF
--- a/dist/build_deploy.sh
+++ b/dist/build_deploy.sh
@@ -3,13 +3,13 @@
 set -e
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE_BUILD="${IMAGE_BUILD:-ekidd/rust-musl-builder:1.30.1}"
+IMAGE_BUILD="${IMAGE_BUILD:-clux/muslrust:1.30.0-stable}"
 IMAGE="quay.io/app-sre/cincinnati"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 PROJECT_PARENT_DIR=$ABSOLUTE_PATH/../
 DOCKERFILE_DEPLOY="$ABSOLUTE_PATH/Dockerfile"
 
-docker run --rm -v $PROJECT_PARENT_DIR:/home/rust/src $IMAGE_BUILD cargo build --release
+docker run -t --rm -v $PROJECT_PARENT_DIR:/volume:Z $IMAGE_BUILD cargo build --release
 
 docker build -f $DOCKERFILE_DEPLOY -t "${IMAGE}:${IMAGE_TAG}" $PROJECT_PARENT_DIR
 

--- a/dist/pr_check.sh
+++ b/dist/pr_check.sh
@@ -3,7 +3,7 @@
 set -e
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE_BUILD="${IMAGE_BUILD:-ekidd/rust-musl-builder:1.30.1}"
+IMAGE_BUILD="${IMAGE_BUILD:-clux/muslrust:1.30.0-stable}"
 PROJECT_PARENT_DIR=$ABSOLUTE_PATH/../
 
-docker run --rm -v $PROJECT_PARENT_DIR:/home/rust/src $IMAGE_BUILD cargo test
+docker run -t --rm -v $PROJECT_PARENT_DIR:/volume:Z $IMAGE_BUILD cargo test


### PR DESCRIPTION
`ekidd/rust-musl-builder:1.30.1` image does not work on ci as it requires all mountd files to have 1000:1000 permissions. new image does not have such requirements and even more popular 1M downloads.

I've tested new image locally and on CI.