### PR TITLE
dist: optimize build script and Dockerfile

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,8 +1,5 @@
 FROM centos:7
 
-RUN yum -y groupinstall 'Development Tools'
-RUN yum -y install openssl-devel
-
 ENV RUST_LOG=actix_web=error,dkregistry=error
 
 COPY graph-builder policy-engine /usr/bin/

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -5,6 +5,6 @@ RUN yum -y install openssl-devel
 
 ENV RUST_LOG=actix_web=error,dkregistry=error
 
-COPY target/x86_64-unknown-linux-musl/release/graph-builder target/x86_64-unknown-linux-musl/release/policy-engine /usr/bin/
+COPY graph-builder policy-engine /usr/bin/
 
 ENTRYPOINT ["/usr/bin/graph-builder"]

--- a/dist/build_deploy.sh
+++ b/dist/build_deploy.sh
@@ -3,26 +3,27 @@
 set -e
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE_BUILD="${IMAGE_BUILD:-clux/muslrust:1.30.0-stable}"
+source "${ABSOLUTE_PATH}/commons.sh"
+
 IMAGE="quay.io/app-sre/cincinnati"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
-PROJECT_PARENT_DIR=$ABSOLUTE_PATH/../
 DOCKERFILE_DEPLOY="$ABSOLUTE_PATH/Dockerfile"
 RELEASE_DIR="${PROJECT_PARENT_DIR}/target/x86_64-unknown-linux-musl/release"
 RELEASE_OUTPUT_DIR="${PROJECT_PARENT_DIR}/release-$(date +'%Y%m%d.%H%M%S')"
 
 function cleanup() {
+    set +e
     if [[ ! -n "$KEEP_RELEASE_OUTPUT" ]]; then
         rm -f ${RELEASE_OUTPUT_DIR}/{graph-builder,policy-engine}
         rmdir ${RELEASE_OUTPUT_DIR}
     fi
+    docker_cargo clean
 }
+trap cleanup EXIT
 
-docker run -t --rm -v $PROJECT_PARENT_DIR:/volume:Z $IMAGE_BUILD cargo build --release
-
+docker_cargo build --release
 mkdir $RELEASE_OUTPUT_DIR
 cp ${RELEASE_DIR}/{graph-builder,policy-engine} $RELEASE_OUTPUT_DIR/
-trap cleanup EXIT
 
 docker build -f $DOCKERFILE_DEPLOY -t "${IMAGE}:${IMAGE_TAG}" $RELEASE_OUTPUT_DIR
 

--- a/dist/commons.sh
+++ b/dist/commons.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+IMAGE_BUILD="${IMAGE_BUILD:-clux/muslrust:1.30.0-stable}"
+PROJECT_PARENT_DIR="${ABSOLUTE_PATH:?need ABSOLUTE_PATH set}/../"
+
+function docker_cargo () {
+    docker run -t --rm \
+        --user "$UID:$GID" \
+        --tmpfs "/tmp/cargo:rw" \
+        --env "CARGO_HOME=/tmp/cargo" \
+        -v $PROJECT_PARENT_DIR:/volume:Z \
+        $IMAGE_BUILD cargo ${@}
+}

--- a/dist/pr_check.sh
+++ b/dist/pr_check.sh
@@ -3,7 +3,12 @@
 set -e
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE_BUILD="${IMAGE_BUILD:-clux/muslrust:1.30.0-stable}"
-PROJECT_PARENT_DIR=$ABSOLUTE_PATH/../
+source "${ABSOLUTE_PATH}/commons.sh"
 
-docker run -t --rm -v $PROJECT_PARENT_DIR:/volume:Z $IMAGE_BUILD cargo test
+function cleanup() {
+    set +e
+    docker_cargo clean
+}
+trap cleanup EXIT
+
+docker_cargo test


### PR DESCRIPTION
This change removes the overhead of sending the whole target directory
to the Docker daemon as the build context. Instead we can create a
mininum build context which contains only the desired static binaries.

Also removes the obsolete runtime deps.

/cc @riuvshin 