### PR TITLE
graph-builder: use high-level tokio API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -20,4 +20,5 @@ structopt = "^0.2.10"
 tar = "^0.4.16"
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "b6573b0e2c18da6f1e50ebfc1a0d6b7ec3c8accf" }
 tokio-core = "0.1"
+tokio = "0.1"
 futures = "0.1"

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -33,6 +33,7 @@ extern crate serde_json;
 extern crate structopt;
 extern crate tar;
 extern crate tokio_core;
+extern crate tokio;
 
 mod config;
 mod graph;


### PR DESCRIPTION
The lower-level tokio_core API is leaking memory in the way we've been
using it.