### PR TITLE
registry/assemble-metadata: change filename according to the ocp-release repo

### DIFF
--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -175,7 +175,7 @@ fn find_first_release(
             .map_err(|e| format_err!("{}", e))
             .into_stream()
             .filter_map(move |blob| {
-                let metadata_filename = "release-metadata";
+                let metadata_filename = "release-manifests/release-metadata";
 
                 trace!(
                     "{}: Looking for {} in archive {} with {} bytes",


### PR DESCRIPTION
Look through all subdirectories to find the metadata file in the
archive.

I changed the tests in #11 to use the new filename.

/cc @smarterclayton 

---

Continuing the OOB discussion here, I don't know how flexible we need to be on finding the release-metadata. Here are some options to make cincinnati work with [the ocp-release repository](https://quay.io/repository/openshift-release-dev/ocp-release) which has its metadata at `/release-manifests/release-metadata`.

a) Hardcode the filename and look through all sub-directories
b) Make the filename configurable and require to provide an absolute path (relative to the archive's root)
c) Hardcode the filename and change it accordingly to match the full path (**implemented in this PR**)