### PR TITLE
*: add files for (proper) openshift/release integration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - installer-approvers
+reviewers:
+  - cincinnati-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,10 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  cincinnati-approvers:
+    - aaronlevy
+    - crawford
+    - smarterclayton
+    - steveeJ
+  cincinnati-reviewers:
+    - lucab

--- a/dist/openshift-release/Dockerfile.builder
+++ b/dist/openshift-release/Dockerfile.builder
@@ -1,0 +1,15 @@
+FROM centos:7 as builder
+
+RUN yum -y groupinstall 'Development Tools'
+RUN yum -y install openssl-devel
+
+ADD https://static.rust-lang.org/dist/rust-1.31.0-x86_64-unknown-linux-gnu.tar.gz rust.tar.gz
+RUN tar -xf rust.tar.gz --strip 1
+RUN ./install.sh
+
+ENV HOME="/root"
+
+RUN \
+  mkdir -p $HOME/.cargo/git/ && \
+  find $HOME/. -type d -exec chmod 777 {} \; && \
+  find $HOME/. -type f -exec chmod ugo+rw {} \;


### PR DESCRIPTION
This should allow the prow CI jobs to work properly after it was enabled in https://github.com/openshift/release/pull/2452.

/cc @crawford 