### PR TITLE
*: introduce path-namespace CLI argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
+ "commons 0.1.0",
  "dkregistry 0.2.2-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=b6573b0e2c18da6f1e50ebfc1a0d6b7ec3c8accf)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1164,6 +1165,7 @@ dependencies = [
  "actix 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
+ "commons 0.1.0",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "commons"
+version = "0.1.0"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
 	"cincinnati",
+	"commons",
 	"graph-builder",
 	"policy-engine",
 ]

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "commons"
+version = "0.1.0"
+authors = ["Stefan Junker <mail@stefanjunker.de>"]
+
+[dependencies]

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -1,0 +1,12 @@
+/// Strip any leading and trailing slashes
+pub fn parse_path_namespace(path_namespace: &str) -> String {
+    path_namespace.to_string().trim_matches('/').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parse_path_namespace() {
+        assert_eq!(super::parse_path_namespace("//a/b/c/"), "a/b/c");
+    }
+}

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Alex Crawford <crawford@redhat.com>"]
 [dependencies]
 actix-web = "^0.7.8"
 cincinnati = { path = "../cincinnati" }
+commons = { path = "../commons" }
 env_logger = "^0.6.0"
 itertools = "^0.7.8"
 failure = "^0.1.1"

--- a/graph-builder/src/config.rs
+++ b/graph-builder/src/config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use commons::parse_path_namespace;
 use std::net::IpAddr;
 use std::num::ParseIntError;
 use std::path::PathBuf;
@@ -51,6 +52,14 @@ pub struct Options {
     /// Credentials file for authentication against the image registry
     #[structopt(long = "credentials-file", parse(from_os_str))]
     pub credentials_path: Option<PathBuf>,
+
+    /// Path namespace prefix for all paths. Shall be given without leading and trailing slashes.
+    #[structopt(
+        long = "path-namespace",
+        default_value = "",
+        parse(from_str = "parse_path_namespace")
+    )]
+    pub path_namespace: String,
 }
 
 fn parse_duration(src: &str) -> Result<Duration, ParseIntError> {

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate cincinnati;
+extern crate commons;
 extern crate dkregistry;
 extern crate env_logger;
 extern crate flate2;

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<(), Error> {
 
     let state = graph::State::new();
     let addr = (opts.address, opts.port);
+    let graph_path = format!("/{}/v1/graph", opts.path_namespace);
 
     {
         let state = state.clone();
@@ -52,7 +53,7 @@ fn main() -> Result<(), Error> {
     server::new(move || {
         App::with_state(state.clone())
             .middleware(Logger::default())
-            .route("/v1/graph", Method::GET, graph::index)
+            .route(&graph_path, Method::GET, graph::index)
     })
     .bind(addr)?
     .run();

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Alex Crawford <crawford@redhat.com>"]
 actix = "^0.7.6"
 actix-web = "^0.7.8"
 cincinnati = { path = "../cincinnati" }
+commons = { path = "../commons" }
 env_logger = "^0.6.0"
 failure = "^0.1.1"
 futures = "^0.1.23"

--- a/policy-engine/src/config.rs
+++ b/policy-engine/src/config.rs
@@ -1,5 +1,6 @@
 //! Command-line options for policy-engine.
 
+use commons::parse_path_namespace;
 use hyper::Uri;
 use std::net::IpAddr;
 
@@ -28,4 +29,12 @@ pub struct Options {
     /// Port to which the metrics server will bind.
     #[structopt(long = "metrics_port", default_value = "9081")]
     pub metrics_port: u16,
+
+    /// Path namespace prefix for all paths. Must be given without leading and ending '/'
+    #[structopt(
+        long = "path-namespace",
+        default_value = "",
+        parse(from_str = "parse_path_namespace")
+    )]
+    pub path_namespace: String,
 }

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -3,6 +3,7 @@
 extern crate actix;
 extern crate actix_web;
 extern crate cincinnati;
+extern crate commons;
 extern crate env_logger;
 #[macro_use]
 extern crate failure;
@@ -56,10 +57,12 @@ fn main() -> Result<(), Error> {
     let state = graph::State {
         upstream: opts.upstream,
     };
+
+    let graph_path = format!("/{}/v1/graph", opts.path_namespace);
     server::new(move || {
         App::with_state(state.clone())
             .middleware(Logger::default())
-            .route("/v1/graph", Method::GET, graph::index)
+            .route(&graph_path, Method::GET, graph::index)
     })
     .bind((opts.address, opts.port))?
     .start();


### PR DESCRIPTION
This gives the option to prefix all paths with a given namespace.

Contributes to https://jira.coreos.com/browse/CORS-957.