### PR TITLE
*: bugfix and refactor prefix semantics

### DIFF
--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -1,12 +1,15 @@
-/// Strip any leading and trailing slashes
-pub fn parse_path_namespace(path_namespace: &str) -> String {
-    path_namespace.to_string().trim_matches('/').to_string()
+/// Strip all but one leading slash and all trailing slashes
+pub fn parse_path_prefix(path_prefix: &str) -> String {
+    format!("/{}", path_prefix.to_string().trim_matches('/'))
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_parse_path_namespace() {
-        assert_eq!(super::parse_path_namespace("//a/b/c/"), "a/b/c");
+    fn test_parse_path_prefix() {
+        assert_eq!(super::parse_path_prefix("//a/b/c//"), "/a/b/c");
+        assert_eq!(super::parse_path_prefix("/a/b/c/"), "/a/b/c");
+        assert_eq!(super::parse_path_prefix("/a/b/c"), "/a/b/c");
+        assert_eq!(super::parse_path_prefix("a/b/c"), "/a/b/c");
     }
 }

--- a/graph-builder/src/config.rs
+++ b/graph-builder/src/config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use commons::parse_path_namespace;
+use commons::parse_path_prefix;
 use std::net::IpAddr;
 use std::num::ParseIntError;
 use std::path::PathBuf;
@@ -53,13 +53,13 @@ pub struct Options {
     #[structopt(long = "credentials-file", parse(from_os_str))]
     pub credentials_path: Option<PathBuf>,
 
-    /// Path namespace prefix for all paths. Shall be given without leading and trailing slashes.
+    /// Path prefix for all paths.
     #[structopt(
-        long = "path-namespace",
+        long = "path-prefix",
         default_value = "",
-        parse(from_str = "parse_path_namespace")
+        parse(from_str = "parse_path_prefix")
     )]
-    pub path_namespace: String,
+    pub path_prefix: String,
 }
 
 fn parse_duration(src: &str) -> Result<Duration, ParseIntError> {

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Error> {
 
     let state = graph::State::new();
     let addr = (opts.address, opts.port);
-    let graph_path = format!("/{}/v1/graph", opts.path_namespace);
+    let app_prefix = opts.path_prefix.clone();
 
     {
         let state = state.clone();
@@ -51,9 +51,12 @@ fn main() -> Result<(), Error> {
     }
 
     server::new(move || {
-        App::with_state(state.clone())
+        let app_prefix = app_prefix.clone();
+        let state = state.clone();
+        App::with_state(state)
             .middleware(Logger::default())
-            .route(&graph_path, Method::GET, graph::index)
+            .prefix(app_prefix)
+            .route("/v1/graph", Method::GET, graph::index)
     })
     .bind(addr)?
     .run();

--- a/policy-engine/src/config.rs
+++ b/policy-engine/src/config.rs
@@ -1,6 +1,6 @@
 //! Command-line options for policy-engine.
 
-use commons::parse_path_namespace;
+use commons::parse_path_prefix;
 use hyper::Uri;
 use std::net::IpAddr;
 
@@ -30,11 +30,11 @@ pub struct Options {
     #[structopt(long = "metrics_port", default_value = "9081")]
     pub metrics_port: u16,
 
-    /// Path namespace prefix for all paths. Must be given without leading and ending '/'
+    /// Path prefix for all paths.
     #[structopt(
-        long = "path-namespace",
+        long = "path-prefix",
         default_value = "",
-        parse(from_str = "parse_path_namespace")
+        parse(from_str = "parse_path_prefix")
     )]
-    pub path_namespace: String,
+    pub path_prefix: String,
 }

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -5,9 +5,10 @@ use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use cincinnati::{Graph, CONTENT_TYPE};
 use failure::Error;
 use futures::{future, Future, Stream};
-use hyper::{Body, Client, Request, Uri};
+use hyper::{Body, Client, Request};
 use prometheus::{Counter, Histogram};
 use serde_json;
+use AppState;
 
 lazy_static! {
     static ref HTTP_GRAPH_REQS: Counter = register_counter!(
@@ -38,7 +39,7 @@ lazy_static! {
 }
 
 /// Serve Cincinnati graph requests.
-pub(crate) fn index(req: HttpRequest<State>) -> Box<Future<Item = HttpResponse, Error = Error>> {
+pub(crate) fn index(req: HttpRequest<AppState>) -> Box<Future<Item = HttpResponse, Error = Error>> {
     HTTP_GRAPH_REQS.inc();
     match req.headers().get(header::ACCEPT) {
         Some(entry) if entry == HeaderValue::from_static(CONTENT_TYPE) => {
@@ -83,9 +84,4 @@ pub(crate) fn index(req: HttpRequest<State>) -> Box<Future<Item = HttpResponse, 
             Box::new(future::ok(HttpResponse::NotAcceptable().finish()))
         }
     }
-}
-
-#[derive(Clone)]
-pub struct State {
-    pub upstream: Uri,
 }


### PR DESCRIPTION
The bugfix and semantic change is that the prefix keeps, and if
necessary adds, a leading slash. This simplifies the logic of dealing
with prefixes because it doesn't require special-casing for emtpy
namespaces which was buggy before.

Using actix-web's prefix method removes the need to specify the prefix
for every new route.

Fixes up #38.