### PR TITLE
graph-builder: log update completion

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -122,6 +122,11 @@ impl Graph {
             dag: &self.dag,
         }
     }
+
+    /// Return the number of releases (nodes) in the graph.
+    pub fn releases_count(&self) -> u64 {
+        self.dag.node_count() as u64
+    }
 }
 
 impl<'a> Deserialize<'a> for Graph {
@@ -271,9 +276,11 @@ mod tests {
     #[test]
     fn deserialize_graph() {
         let json = r#"{"nodes":[{"version":"1.0.0","payload":"image/1.0.0","metadata":{}},{"version":"2.0.0","payload":"image/2.0.0","metadata":{}},{"version":"3.0.0","payload":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#;
-        assert_eq!(
-            serde_json::to_string(&serde_json::from_str::<Graph>(json).unwrap()).unwrap(),
-            json
-        );
+
+        let de: Graph = serde_json::from_str(json).unwrap();
+        assert_eq!(de.releases_count(), 3);
+
+        let ser = serde_json::to_string(&de).unwrap();
+        assert_eq!(ser, json);
     }
 }

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -61,7 +61,7 @@ pub fn run(opts: &config::Options, state: &State) -> ! {
             .expect("could not read credentials");
 
     loop {
-        debug!("Updating graph...");
+        debug!("graph update triggered");
         match create_graph(
             &opts,
             username.as_ref().map(String::as_ref),
@@ -69,7 +69,13 @@ pub fn run(opts: &config::Options, state: &State) -> ! {
             &mut cache,
         ) {
             Ok(graph) => match serde_json::to_string(&graph) {
-                Ok(json) => *state.json.write().expect("json lock has been poisoned") = json,
+                Ok(json) => {
+                    *state.json.write().expect("json lock has been poisoned") = json;
+                    debug!(
+                        "graph update completed, {} valid releases",
+                        graph.releases_count()
+                    );
+                }
                 Err(err) => error!("Failed to serialize graph: {}", err),
             },
             Err(err) => err.iter_chain().for_each(|cause| error!("{}", cause)),


### PR DESCRIPTION
This adds support for emitting a debug message once a graph update
completes, recording the total number of releases being served.