### PR TITLE
cincinnati: check for mandatory parameters in client query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,10 @@ dependencies = [
 [[package]]
 name = "commons"
 version = "0.1.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "constant_time_eq"

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 authors = ["Stefan Junker <mail@stefanjunker.de>"]
 
 [dependencies]
+failure = "^0.1.5"
+url = "^1.7.2"

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -5,11 +5,13 @@ pub fn parse_path_prefix(path_prefix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn test_parse_path_prefix() {
-        assert_eq!(super::parse_path_prefix("//a/b/c//"), "/a/b/c");
-        assert_eq!(super::parse_path_prefix("/a/b/c/"), "/a/b/c");
-        assert_eq!(super::parse_path_prefix("/a/b/c"), "/a/b/c");
-        assert_eq!(super::parse_path_prefix("a/b/c"), "/a/b/c");
+        assert_eq!(parse_path_prefix("//a/b/c//"), "/a/b/c");
+        assert_eq!(parse_path_prefix("/a/b/c/"), "/a/b/c");
+        assert_eq!(parse_path_prefix("/a/b/c"), "/a/b/c");
+        assert_eq!(parse_path_prefix("a/b/c"), "/a/b/c");
     }
 }

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -1,6 +1,51 @@
+#[macro_use]
+extern crate failure;
+extern crate url;
+
+use failure::Fallible;
+use std::collections::HashSet;
+use url::form_urlencoded;
+
 /// Strip all but one leading slash and all trailing slashes
 pub fn parse_path_prefix(path_prefix: &str) -> String {
     format!("/{}", path_prefix.to_string().trim_matches('/'))
+}
+
+/// Parse a comma-separated set of client parameters keys.
+pub fn parse_params_set(params: &str) -> HashSet<String> {
+    params
+        .split(',')
+        .filter_map(|key| {
+            let trimmed = key.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .collect()
+}
+
+/// Make sure `query` string contains all `params` keys.
+pub fn ensure_query_params(params: &HashSet<String>, query: &str) -> Fallible<()> {
+    // No mandatory parameters, always fine.
+    if params.is_empty() {
+        return Ok(());
+    }
+
+    // Extract and de-duplicate keys from input query.
+    let query_keys: HashSet<String> = form_urlencoded::parse(query.as_bytes())
+        .into_owned()
+        .map(|(k, _)| k)
+        .collect();
+
+    // Make sure all mandatory parameters are present.
+    ensure!(
+        params.is_subset(&query_keys),
+        "mandatory parameters missing"
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -13,5 +58,35 @@ mod tests {
         assert_eq!(parse_path_prefix("/a/b/c/"), "/a/b/c");
         assert_eq!(parse_path_prefix("/a/b/c"), "/a/b/c");
         assert_eq!(parse_path_prefix("a/b/c"), "/a/b/c");
+    }
+
+    #[test]
+    fn test_parse_params_set() {
+        assert_eq!(parse_params_set(""), HashSet::new());
+
+        let basic = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(parse_params_set("a,b,c"), basic.into_iter().collect());
+
+        let dedup = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(parse_params_set("a,b,a"), dedup.into_iter().collect());
+
+        let trimmed = vec!["foo".to_string(), "bar".to_string()];
+        assert_eq!(
+            parse_params_set("foo , , bar"),
+            trimmed.into_iter().collect()
+        );
+    }
+
+    #[test]
+    fn test_ensure_query_params() {
+        let empty = HashSet::new();
+        ensure_query_params(&empty, "").unwrap();
+        ensure_query_params(&empty, "a=b").unwrap();
+
+        let simple = vec!["a".to_string()].into_iter().collect();
+        ensure_query_params(&simple, "a=b").unwrap();
+        ensure_query_params(&simple, "a=b&a=c").unwrap();
+        ensure_query_params(&simple, "").unwrap_err();
+        ensure_query_params(&simple, "c=d").unwrap_err();
     }
 }

--- a/graph-builder/src/config.rs
+++ b/graph-builder/src/config.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use commons::parse_path_prefix;
+use commons::{parse_params_set, parse_path_prefix};
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::num::ParseIntError;
 use std::path::PathBuf;
@@ -60,6 +61,14 @@ pub struct Options {
         parse(from_str = "parse_path_prefix")
     )]
     pub path_prefix: String,
+
+    /// Comma-separated set of mandatory client parameters.
+    #[structopt(
+        long = "mandatory-client-parameters",
+        default_value = "",
+        parse(from_str = "parse_params_set")
+    )]
+    pub mandatory_client_parameters: HashSet<String>,
 }
 
 fn parse_duration(src: &str) -> Result<Duration, ParseIntError> {

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), Error> {
         )
         .init();
 
-    let state = graph::State::new();
+    let state = graph::State::new(opts.mandatory_client_parameters.clone());
     let addr = (opts.address, opts.port);
     let app_prefix = opts.path_prefix.clone();
 

--- a/policy-engine/src/config.rs
+++ b/policy-engine/src/config.rs
@@ -1,7 +1,8 @@
 //! Command-line options for policy-engine.
 
-use commons::parse_path_prefix;
+use commons::{parse_params_set, parse_path_prefix};
 use hyper::Uri;
+use std::collections::HashSet;
 use std::net::IpAddr;
 
 #[derive(Debug, StructOpt)]
@@ -37,4 +38,12 @@ pub struct Options {
         parse(from_str = "parse_path_prefix")
     )]
     pub path_prefix: String,
+
+    /// Comma-separated set of mandatory client parameters.
+    #[structopt(
+        long = "mandatory-client-parameters",
+        default_value = "",
+        parse(from_str = "parse_params_set")
+    )]
+    pub mandatory_client_parameters: HashSet<String>,
 }

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -29,6 +29,7 @@ mod openapi;
 use actix_web::{http::Method, middleware::Logger, server, App};
 use failure::Error;
 use log::LevelFilter;
+use std::collections::HashSet;
 use structopt::StructOpt;
 
 fn main() -> Result<(), Error> {
@@ -58,6 +59,7 @@ fn main() -> Result<(), Error> {
 
     // Main service.
     let state = AppState {
+        mandatory_params: opts.mandatory_client_parameters.clone(),
         upstream: opts.upstream.clone(),
         path_prefix: opts.path_prefix.clone(),
     };
@@ -79,6 +81,8 @@ fn main() -> Result<(), Error> {
 
 #[derive(Debug, Clone)]
 pub struct AppState {
+    /// Query parameters that must be present in all client requests.
+    pub mandatory_params: HashSet<String>,
     pub upstream: hyper::Uri,
     pub path_prefix: String,
 }


### PR DESCRIPTION
Cincinnati instances may require by specs a mandatory set of parameters
that must be part of client request. This adds configuration knobs to
all components so that the mandatory set can be configured and enforced
at runtime.

Ref: https://jira.coreos.com/projects/CORS/issues/CORS-966

/cc @steveeJ 