### PR TITLE
quay: introduce a quay.io client library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,20 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quay"
+version = "0.0.0-dev"
+dependencies = [
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
 	"commons",
 	"graph-builder",
 	"policy-engine",
+	"quay",
 ]

--- a/dist/pr_check.sh
+++ b/dist/pr_check.sh
@@ -6,6 +6,7 @@ declare -A cargo_test_flags
 cargo_test_flags["cincinnati"]=""
 cargo_test_flags["graph-builder"]="--features test-net"
 cargo_test_flags["policy-engine"]=""
+cargo_test_flags["quay"]="--features test-net"
 
 declare -A executors
 executors["cargo"]="execute_native"

--- a/quay/Cargo.toml
+++ b/quay/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "quay"
+version = "0.0.0-dev"
+authors = ["Luca Bruno <luca.bruno@coreos.com>"]
+publish = false
+
+[dependencies]
+failure = "^0.1.5"
+futures = "^0.1.25"
+reqwest = "^0.9.8"
+serde = "^1.0.84"
+serde_derive = "^1.0.84"
+serde_json = "^1.0.34"
+
+[dev-dependencies]
+env_logger = "^0.6.0"
+tokio = "^0.1.14"
+
+[features]
+test-net = []
+test-net-private = []

--- a/quay/src/lib.rs
+++ b/quay/src/lib.rs
@@ -1,0 +1,11 @@
+//! Asynchronous client for quay.io v1 API.
+
+extern crate failure;
+extern crate futures;
+extern crate reqwest;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+pub mod v1;

--- a/quay/src/v1/manifest.rs
+++ b/quay/src/v1/manifest.rs
@@ -1,0 +1,48 @@
+//! Manifest API.
+
+use super::Client;
+use failure::Error;
+use futures::future;
+use futures::prelude::*;
+use reqwest::Method;
+
+/// API result with all labels.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Labels {
+    pub(crate) labels: Vec<Label>,
+}
+
+/// Tag label.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Label {
+    /// Label key.
+    pub key: String,
+    /// Label value.
+    pub value: String,
+    /// Label media-type.
+    pub media_type: String,
+    /// Label identifier.
+    pub id: String,
+    /// Label Source.
+    pub source_type: String,
+}
+
+impl Client {
+    pub fn get_labels<S: AsRef<str>>(
+        &self,
+        repository: S,
+        manifest_ref: S,
+    ) -> impl Future<Item = Vec<Label>, Error = Error> {
+        let endpoint = format!(
+            "repository/{}/manifest/{}/labels",
+            repository.as_ref(),
+            manifest_ref.as_ref()
+        );
+        let req = self.new_request(Method::GET, &endpoint);
+        future::result(req)
+            .and_then(|req| req.send().from_err())
+            .and_then(|resp| resp.error_for_status().map_err(Error::from))
+            .and_then(|mut resp| resp.json::<Labels>().from_err())
+            .map(|json| json.labels)
+    }
+}

--- a/quay/src/v1/manifest.rs
+++ b/quay/src/v1/manifest.rs
@@ -7,6 +7,30 @@ use futures::prelude::*;
 use reqwest::Method;
 
 /// API result with all labels.
+///
+/// The quay.io documentation doesn't specify the result type.
+/// It was inspected manually like so:
+/// ```console
+/// $ curl --get https://quay.io/api/v1/repository/redhat/openshift-cincinnati-test-labels-public-manual/manifest/sha256:b35233e5d354ca2c1cdf9f71f2cdfa807d030f2b307ce7c5e88d86f20e6b65a0/labels | jq .
+/// {
+///   "labels": [
+///     {
+///       "value": "0.0.1",
+///       "media_type": "text/plain",
+///       "id": "03e8f6db-4669-42d8-a4ec-2d2d2785b0b7",
+///       "key": "com.openshift.upgrades.graph.edge-previous-add",
+///       "source_type": "api"
+///     },
+///     {
+///       "value": "0.0.0",
+///       "media_type": "text/plain",
+///       "id": "b5e17080-08ce-4a98-a397-6869a0e16dbe",
+///       "key": "com.openshift.upgrades.graph.edge-previous-add",
+///       "source_type": "api"
+///     }
+///   ]
+/// }
+/// ```
 #[derive(Debug, Deserialize)]
 pub(crate) struct Labels {
     pub(crate) labels: Vec<Label>,
@@ -27,11 +51,19 @@ pub struct Label {
     pub source_type: String,
 }
 
+impl Into<(String, String)> for Label {
+    fn into(self) -> (String, String) {
+        (self.key, self.value)
+    }
+}
+
 impl Client {
+    /// Fetch manifestref labels
     pub fn get_labels<S: AsRef<str>>(
         &self,
         repository: S,
         manifest_ref: S,
+        filter: Option<S>,
     ) -> impl Future<Item = Vec<Label>, Error = Error> {
         let endpoint = format!(
             "repository/{}/manifest/{}/labels",
@@ -40,6 +72,13 @@ impl Client {
         );
         let req = self.new_request(Method::GET, &endpoint);
         future::result(req)
+            .map(|req| {
+                if let Some(filter) = filter {
+                    req.query(&[("filter", filter.as_ref())])
+                } else {
+                    req
+                }
+            })
             .and_then(|req| req.send().from_err())
             .and_then(|resp| resp.error_for_status().map_err(Error::from))
             .and_then(|mut resp| resp.json::<Labels>().from_err())

--- a/quay/src/v1/mod.rs
+++ b/quay/src/v1/mod.rs
@@ -1,0 +1,106 @@
+use failure::Fallible;
+use reqwest::{self, async};
+
+mod manifest;
+
+mod tag;
+pub use self::tag::Tag;
+
+static DEFAULT_API_BASE: &str = "https://quay.io/api/v1/";
+
+/// Client to make outgoing API requests to a quay instance.
+#[derive(Clone, Debug)]
+pub struct Client {
+    /// Base URL for API endpoint.
+    api_base: reqwest::Url,
+    /// Asynchronous reqwest client.
+    hclient: async::Client,
+    /// Authentication token.
+    token: Option<String>,
+}
+
+impl Client {
+    /// Return a client builder with default options.
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    /// Return a request builder with base URL and parameters set.
+    pub(crate) fn new_request<S: AsRef<str>>(
+        &self,
+        method: reqwest::Method,
+        url_suffix: S,
+    ) -> Fallible<async::RequestBuilder> {
+        let url = self.api_base.clone().join(url_suffix.as_ref())?;
+        let builder = {
+            let plain = self.hclient.request(method, url);
+            match self.token {
+                None => plain,
+                Some(ref token) => {
+                    let bearer_token = format!("Bearer {}", token);
+                    plain.header("Authorization", bearer_token)
+                }
+            }
+        };
+        Ok(builder)
+    }
+}
+
+/// Client to make outgoing API requests to a quay instance.
+#[derive(Clone, Debug)]
+pub struct ClientBuilder {
+    api_base: Option<String>,
+    hclient: Option<async::Client>,
+    token: Option<String>,
+}
+
+impl ClientBuilder {
+    /// Set (or reset) the HTTP client to use.
+    pub fn http_client(self, hclient: Option<async::Client>) -> Self {
+        let mut builder = self;
+        builder.hclient = hclient;
+        builder
+    }
+
+    /// Set (or reset) the access token to use.
+    pub fn access_token(self, token: Option<String>) -> Self {
+        let mut builder = self;
+        builder.token = token;
+        builder
+    }
+
+    /// Set (or reset) the base API endpoint URL to use.
+    pub fn api_base(self, api_base: Option<String>) -> Self {
+        let mut builder = self;
+        builder.api_base = api_base;
+        builder
+    }
+
+    /// Build a client with specified parameters.
+    pub fn build(self) -> Fallible<Client> {
+        let hclient = match self.hclient {
+            Some(client) => client,
+            None => async::ClientBuilder::new().build()?,
+        };
+        let api_base = match self.api_base {
+            Some(ref base) => reqwest::Url::parse(base)?,
+            None => reqwest::Url::parse(DEFAULT_API_BASE)?,
+        };
+        let quay_client = Client {
+            api_base,
+            hclient,
+            token: self.token,
+        };
+        Ok(quay_client)
+    }
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self {
+            api_base: Some(DEFAULT_API_BASE.to_string()),
+            hclient: None,
+            token: None,
+        }
+    }
+}

--- a/quay/src/v1/tag.rs
+++ b/quay/src/v1/tag.rs
@@ -1,4 +1,4 @@
-//! Manifest API.
+//! Tag API.
 
 use super::Client;
 use failure::Error;
@@ -13,7 +13,7 @@ pub(crate) struct PaginatedTags {
     pub(crate) has_additional: bool,
     /// Pagination index.
     pub(crate) page: u32,
-    /// Set of tags in current page.
+    /// List of tags in current page.
     pub(crate) tags: Vec<Tag>,
 }
 
@@ -30,11 +30,14 @@ pub struct Tag {
 
 impl Client {
     /// Fetch tags in a repository, in a streaming way.
-    pub fn stream_tags<S: AsRef<str>>(
+    pub fn stream_tags<S>(
         &self,
         repository: S,
         only_active_tags: bool,
-    ) -> impl Stream<Item = Tag, Error = Error> {
+    ) -> impl Stream<Item = Tag, Error = Error>
+    where
+        S: AsRef<str>,
+    {
         // TODO(lucab): implement pagination, filtering, and other advanced options.
         let endpoint = format!("repository/{}/tag", repository.as_ref());
         let actives_only = format!("{}", only_active_tags);

--- a/quay/src/v1/tag.rs
+++ b/quay/src/v1/tag.rs
@@ -1,0 +1,51 @@
+//! Manifest API.
+
+use super::Client;
+use failure::Error;
+use futures::prelude::*;
+use futures::{future, stream};
+use reqwest::Method;
+
+/// API result with paginated repository tags.
+#[derive(Debug, Deserialize)]
+pub(crate) struct PaginatedTags {
+    /// Pagination flag.
+    pub(crate) has_additional: bool,
+    /// Pagination index.
+    pub(crate) page: u32,
+    /// Set of tags in current page.
+    pub(crate) tags: Vec<Tag>,
+}
+
+/// Repository tag.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Tag {
+    /// Manifest digest, in `type:digest` format.
+    pub manifest_digest: Option<String>,
+    /// Tag name.
+    pub name: String,
+    /// Whether this tag version is an history revert.
+    pub reversion: bool,
+}
+
+impl Client {
+    /// Fetch tags in a repository, in a streaming way.
+    pub fn stream_tags<S: AsRef<str>>(
+        &self,
+        repository: S,
+        only_active_tags: bool,
+    ) -> impl Stream<Item = Tag, Error = Error> {
+        // TODO(lucab): implement pagination, filtering, and other advanced options.
+        let endpoint = format!("repository/{}/tag", repository.as_ref());
+        let actives_only = format!("{}", only_active_tags);
+
+        let req = self.new_request(Method::GET, endpoint);
+        future::result(req)
+            .map(|req| req.query(&[("onlyActiveTags", actives_only)]))
+            .and_then(|req| req.send().from_err())
+            .and_then(|resp| resp.error_for_status().map_err(Error::from))
+            .and_then(|mut resp| resp.json::<PaginatedTags>().from_err())
+            .map(|page| stream::iter_ok(page.tags))
+            .flatten_stream()
+    }
+}

--- a/quay/tests/mod.rs
+++ b/quay/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "test-net")]
+mod net;

--- a/quay/tests/net/mod.rs
+++ b/quay/tests/net/mod.rs
@@ -29,8 +29,8 @@ fn test_public_stream_active_tags() {
 #[test]
 fn test_public_get_labels() {
     let mut rt = common_init();
-    let repo = "redhat/openshift-cincinnati-test-public-manual";
-    let tag_name = "0.0.0";
+    let repo = "redhat/openshift-cincinnati-test-labels-public-manual";
+    let tag_name = "0.0.1";
 
     let client = quay::v1::Client::builder().build().unwrap();
     let fetch_tags = client.stream_tags(repo, true).collect();
@@ -46,7 +46,20 @@ fn test_public_get_labels() {
     assert_eq!(tag.name, tag_name);
 
     let digest = tag.manifest_digest.clone().unwrap();
-    let fetch_labels = client.get_labels(repo.to_string(), digest);
+    let fetch_labels = client.get_labels(
+        repo.to_string(),
+        digest,
+        Some("com.openshift.upgrades.graph".to_string()),
+    );
     let labels = rt.block_on(fetch_labels).unwrap();
-    assert_eq!(labels, vec![]);
+    assert_eq!(
+        labels
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<(String, String)>>(),
+        vec![(
+            "com.openshift.upgrades.graph.previous.remove".to_string(),
+            "0.0.0".to_string()
+        )]
+    );
 }

--- a/quay/tests/net/mod.rs
+++ b/quay/tests/net/mod.rs
@@ -1,0 +1,52 @@
+extern crate futures;
+extern crate tokio;
+
+use self::futures::prelude::*;
+use self::tokio::runtime::Runtime;
+
+#[cfg(feature = "test-net-private")]
+mod private;
+
+fn common_init() -> Runtime {
+    let _ = env_logger::try_init_from_env(env_logger::Env::default());
+    Runtime::new().unwrap()
+}
+
+#[test]
+fn test_public_stream_active_tags() {
+    let mut rt = common_init();
+    let repo = "redhat/openshift-cincinnati-test-public-manual";
+    let expected = vec!["0.0.1", "0.0.0"];
+
+    let client = quay::v1::Client::builder().build().unwrap();
+    let fetch_tags = client.stream_tags(repo, true).collect();
+    let tags = rt.block_on(fetch_tags).unwrap();
+
+    let tag_names: Vec<String> = tags.into_iter().map(|tag| tag.name).collect();
+    assert_eq!(tag_names, expected);
+}
+
+#[test]
+fn test_public_get_labels() {
+    let mut rt = common_init();
+    let repo = "redhat/openshift-cincinnati-test-public-manual";
+    let tag_name = "0.0.0";
+
+    let client = quay::v1::Client::builder().build().unwrap();
+    let fetch_tags = client.stream_tags(repo, true).collect();
+    let tags = rt.block_on(fetch_tags).unwrap();
+
+    let filtered_tags: Vec<quay::v1::Tag> = tags
+        .into_iter()
+        .filter(|tag| tag.name == tag_name)
+        .collect();
+    assert_eq!(filtered_tags.len(), 1);
+
+    let tag = &filtered_tags[0];
+    assert_eq!(tag.name, tag_name);
+
+    let digest = tag.manifest_digest.clone().unwrap();
+    let fetch_labels = client.get_labels(repo.to_string(), digest);
+    let labels = rt.block_on(fetch_labels).unwrap();
+    assert_eq!(labels, vec![]);
+}

--- a/quay/tests/net/private.rs
+++ b/quay/tests/net/private.rs
@@ -65,7 +65,7 @@ fn test_get_labels() {
     assert_eq!(tag.name, tag_name);
 
     let digest = tag.manifest_digest.clone().unwrap();
-    let fetch_labels = client.get_labels(repo.to_string(), digest);
+    let fetch_labels = client.get_labels(repo.to_string(), digest, None);
     let labels = rt.block_on(fetch_labels).unwrap();
     assert_eq!(labels, vec![]);
 }

--- a/quay/tests/net/private.rs
+++ b/quay/tests/net/private.rs
@@ -1,0 +1,71 @@
+extern crate futures;
+extern crate tokio;
+
+use self::futures::prelude::*;
+use self::tokio::runtime::Runtime;
+
+fn common_init() -> (Runtime, Option<String>) {
+    let _ = env_logger::try_init_from_env(env_logger::Env::default());
+    let runtime = Runtime::new().unwrap();
+    let token = std::env::var("CINCINNATI_TEST_QUAY_API_TOKEN")
+        .expect("CINCINNATI_TEST_QUAY_API_TOKEN missing");
+    (runtime, Some(token))
+}
+
+#[test]
+fn test_wrong_auth() {
+    let (mut rt, _) = common_init();
+    let repo = "redhat/openshift-cincinnati-test-private-manual";
+
+    let client = quay::v1::Client::builder()
+        .access_token(Some("CLEARLY_WRONG".to_string()))
+        .build()
+        .unwrap();
+    let fetch_tags = client.stream_tags(repo, true).collect();
+    rt.block_on(fetch_tags).unwrap_err();
+}
+
+#[test]
+fn test_stream_active_tags() {
+    let (mut rt, token) = common_init();
+    let repo = "redhat/openshift-cincinnati-test-private-manual";
+    let expected = vec!["0.0.1", "0.0.0"];
+
+    let client = quay::v1::Client::builder()
+        .access_token(token)
+        .build()
+        .unwrap();
+    let fetch_tags = client.stream_tags(repo, true).collect();
+    let tags = rt.block_on(fetch_tags).unwrap();
+
+    let tag_names: Vec<String> = tags.into_iter().map(|tag| tag.name).collect();
+    assert_eq!(tag_names, expected);
+}
+
+#[test]
+fn test_get_labels() {
+    let (mut rt, token) = common_init();
+    let repo = "redhat/openshift-cincinnati-test-private-manual";
+    let tag_name = "0.0.0";
+
+    let client = quay::v1::Client::builder()
+        .access_token(token)
+        .build()
+        .unwrap();
+    let fetch_tags = client.stream_tags(repo, true).collect();
+    let tags = rt.block_on(fetch_tags).unwrap();
+
+    let filtered_tags: Vec<quay::v1::Tag> = tags
+        .into_iter()
+        .filter(|tag| tag.name == tag_name)
+        .collect();
+    assert_eq!(filtered_tags.len(), 1);
+
+    let tag = &filtered_tags[0];
+    assert_eq!(tag.name, tag_name);
+
+    let digest = tag.manifest_digest.clone().unwrap();
+    let fetch_labels = client.get_labels(repo.to_string(), digest);
+    let labels = rt.block_on(fetch_labels).unwrap();
+    assert_eq!(labels, vec![]);
+}


### PR DESCRIPTION
This introduces an asynchronous quay.io client, based on reqwest.
Its feature set is currently limited to fetching tags and labels.