### PR TITLE
dist/pr_check: add missing `commons` crate

### DIFF
--- a/dist/pr_check.sh
+++ b/dist/pr_check.sh
@@ -4,6 +4,7 @@ set -ex
 
 declare -A cargo_test_flags
 cargo_test_flags["cincinnati"]=""
+cargo_test_flags["commons"]=""
 cargo_test_flags["graph-builder"]="--features test-net"
 cargo_test_flags["policy-engine"]=""
 cargo_test_flags["quay"]="--features test-net"


### PR DESCRIPTION
This makes `pr_check` test runner aware of `commons` crate.