### PR TITLE
policy-engine: add basic tests for graph endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -19,3 +19,6 @@ semver = "^0.9.0"
 serde_json = "^1.0.22"
 structopt = "^0.2.10"
 openapiv3 = "0.1"
+
+[dev-dependencies]
+tokio = "^0.1"

--- a/policy-engine/src/config.rs
+++ b/policy-engine/src/config.rs
@@ -5,6 +5,9 @@ use hyper::Uri;
 use std::collections::HashSet;
 use std::net::IpAddr;
 
+/// Default URL to upstream graph provider.
+pub(crate) static DEFAULT_UPSTREAM_URL: &str = "http://localhost:8080/v1/graph";
+
 #[derive(Debug, StructOpt)]
 pub struct Options {
     /// Verbosity level
@@ -12,7 +15,7 @@ pub struct Options {
     pub verbosity: u64,
 
     /// URL for the upstream graph builder or policy engine
-    #[structopt(long = "upstream", default_value = "http://localhost:8080/v1/graph")]
+    #[structopt(long = "upstream", raw(default_value = "DEFAULT_UPSTREAM_URL"))]
     pub upstream: Uri,
 
     /// Address on which the server will listen

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -86,3 +86,13 @@ pub struct AppState {
     pub upstream: hyper::Uri,
     pub path_prefix: String,
 }
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            mandatory_params: HashSet::new(),
+            upstream: hyper::Uri::from_static(config::DEFAULT_UPSTREAM_URL),
+            path_prefix: String::new(),
+        }
+    }
+}


### PR DESCRIPTION
This adds initial test infrastructure and some (very basic) negative tests for policy-engine graph endpoint.

/cc @steveeJ 