### PR TITLE
graph-builder: fetch quay labels conditionally

### DIFF
--- a/graph-builder/src/config.rs
+++ b/graph-builder/src/config.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use commons::{parse_params_set, parse_path_prefix};
+use metadata::DEFAULT_QUAY_LABEL_FILTER;
+use quay::v1::DEFAULT_API_BASE;
 use std::collections::HashSet;
 use std::net::IpAddr;
 use std::num::ParseIntError;
@@ -70,10 +72,22 @@ pub struct Options {
     )]
     pub mandatory_client_parameters: HashSet<String>,
 
+    /// Whether to disable the fetching and processing metadata from the quay API
+    #[structopt(long = "disable-quay-api-metadata")]
+    pub disable_quay_api_metadata: bool,
+
+    /// Base URL to the quay API host
+    #[structopt(
+        long = "quay-api-base",
+        long_help = "API base URL",
+        raw(default_value = "DEFAULT_API_BASE")
+    )]
+    pub quay_api_base: String,
+
     /// Filter for receiving quay labels
     #[structopt(
         long = "quay-label-filter",
-        default_value = "com.openshift.upgrades.graph"
+        raw(default_value = "DEFAULT_QUAY_LABEL_FILTER")
     )]
     pub quay_label_filter: String,
 

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -25,5 +25,6 @@ extern crate regex;
 
 pub mod config;
 pub mod graph;
+pub mod metadata;
 pub mod registry;
 pub mod release;

--- a/graph-builder/src/metadata.rs
+++ b/graph-builder/src/metadata.rs
@@ -1,0 +1,102 @@
+//! This module implements the fetching of dynamic metadata
+
+use failure::{Error, Fallible};
+use futures::future::Future;
+use quay;
+use registry;
+use std::path::PathBuf;
+
+pub static DEFAULT_QUAY_LABEL_FILTER: &str = "com.openshift.upgrades.graph";
+pub static MANIFESTREF_KEY: &str = "com.openshift.upgrades.graph.release.manifestref";
+
+pub trait AsyncMetadataFetcher<T, U, E> {
+    fn fetch_metadata(&self, fetch_args: U) -> Box<Future<Item = T, Error = E>>;
+}
+
+/// Convenience type for a metadata entry
+type MetadataEntry = (String, String);
+
+/// Convenience type for fetch_args()'s metadata_fetcher argument
+pub type MetadataFetcher = Box<AsyncMetadataFetcher<Vec<MetadataEntry>, String, Error>>;
+
+pub struct QuayMetadataFetcher {
+    client: quay::v1::Client,
+    label_filter: String,
+    repo: String,
+}
+impl AsyncMetadataFetcher<Vec<MetadataEntry>, String, Error> for QuayMetadataFetcher {
+    fn fetch_metadata(
+        &self,
+        manifestref: String,
+    ) -> Box<Future<Item = Vec<MetadataEntry>, Error = Error>> {
+        Box::new(
+            self.client
+                .get_labels(
+                    self.repo.clone(),
+                    manifestref,
+                    Some(self.label_filter.clone()),
+                )
+                .map(|labels| labels.into_iter().map(Into::into).collect()),
+        )
+    }
+}
+
+impl QuayMetadataFetcher {
+    pub fn try_new(
+        label_filter: String,
+        api_token_path: Option<&PathBuf>,
+        api_base: String,
+        repo: String,
+    ) -> Fallible<Box<Self>> {
+        let api_token =
+            quay::read_credentials(api_token_path).expect("could not read quay API credentials");
+
+        let client: quay::v1::Client = quay::v1::Client::builder()
+            .access_token(api_token.map(|s| s.to_string()))
+            .api_base(Some(api_base.to_string()))
+            .build()?;
+
+        Ok(Box::new(QuayMetadataFetcher {
+            client,
+            label_filter,
+            repo,
+        }))
+    }
+}
+
+/// Asynchronously fetches and populates the dynamic metadata for the given releases
+///
+/// This method is all or nothing and fails in these cases:
+/// * a Release doesn't contain the manifestref in its metadata
+/// * the dynamic metadata can't be fetched for a manifestref
+pub fn fetch_and_populate_dynamic_metadata<'a>(
+    metadata_fetcher: &'a MetadataFetcher,
+    releases: Vec<registry::Release>,
+) -> impl Future<Item = Vec<registry::Release>, Error = Error> + 'a {
+    let populated_releases = releases.into_iter().map(move |mut release| {
+        futures::future::ok(release.metadata.metadata.remove(MANIFESTREF_KEY))
+            .and_then(move |manifestref_value| match manifestref_value {
+                Some(manifestref) => Ok((release, manifestref)),
+                None => Err(format_err!(
+                    "metadata of release '{}' doesn't contain the manifestref",
+                    release.source
+                )),
+            })
+            .and_then(move |(mut release, manifestref)| {
+                metadata_fetcher
+                    .fetch_metadata(manifestref.to_string())
+                    .and_then(|dynamic_metadata| {
+                        release.metadata.metadata = release
+                            .metadata
+                            .metadata
+                            .into_iter()
+                            .chain(dynamic_metadata)
+                            .collect();
+
+                        Ok(release)
+                    })
+            })
+    });
+
+    futures::future::join_all(populated_releases)
+}

--- a/quay/src/v1/mod.rs
+++ b/quay/src/v1/mod.rs
@@ -6,7 +6,7 @@ mod manifest;
 mod tag;
 pub use self::tag::Tag;
 
-static DEFAULT_API_BASE: &str = "https://quay.io/api/v1/";
+pub static DEFAULT_API_BASE: &str = "https://quay.io/api/v1/";
 
 /// Client to make outgoing API requests to a quay instance.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Incomplete list of things done:

graph-builder: add metadata module
graph-builder: add CLI flag to disable quay labels
graph-builder: add CLI flag for quay API base
graph-builder/config: use appropriate constants as default values
graph-builder: fetch metadata in the main loop

I will split this into respective commits once we've iterated on these changes.

/cc @lucab 