### PR TITLE
Revert "*: rename payload -> image"

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -54,7 +54,7 @@ impl Release {
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct ConcreteRelease {
     pub version: String,
-    pub image: String,
+    pub payload: String,
     pub metadata: HashMap<String, String>,
 }
 
@@ -332,17 +332,17 @@ mod tests {
         let mut graph = Graph::default();
         let v1 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
             version: String::from("1.0.0"),
-            image: String::from("image/1.0.0"),
+            payload: String::from("image/1.0.0"),
             metadata: HashMap::new(),
         }));
         let v2 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
             version: String::from("2.0.0"),
-            image: String::from("image/2.0.0"),
+            payload: String::from("image/2.0.0"),
             metadata: HashMap::new(),
         }));
         let v3 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
             version: String::from("3.0.0"),
-            image: String::from("image/3.0.0"),
+            payload: String::from("image/3.0.0"),
             metadata: HashMap::new(),
         }));
         graph.dag.add_edge(v1, v2, Empty {}).unwrap();
@@ -355,12 +355,12 @@ mod tests {
     #[test]
     fn serialize_graph() {
         let graph = generate_graph();
-        assert_eq!(serde_json::to_string(&graph).unwrap(), r#"{"nodes":[{"version":"1.0.0","image":"image/1.0.0","metadata":{}},{"version":"2.0.0","image":"image/2.0.0","metadata":{}},{"version":"3.0.0","image":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#);
+        assert_eq!(serde_json::to_string(&graph).unwrap(), r#"{"nodes":[{"version":"1.0.0","payload":"image/1.0.0","metadata":{}},{"version":"2.0.0","payload":"image/2.0.0","metadata":{}},{"version":"3.0.0","payload":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#);
     }
 
     #[test]
     fn deserialize_graph() {
-        let json = r#"{"nodes":[{"version":"1.0.0","image":"image/1.0.0","metadata":{}},{"version":"2.0.0","image":"image/2.0.0","metadata":{}},{"version":"3.0.0","image":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#;
+        let json = r#"{"nodes":[{"version":"1.0.0","payload":"image/1.0.0","metadata":{}},{"version":"2.0.0","payload":"image/2.0.0","metadata":{}},{"version":"3.0.0","payload":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#;
 
         let de: Graph = serde_json::from_str(json).unwrap();
         assert_eq!(de.releases_count(), 3);
@@ -375,12 +375,12 @@ mod tests {
             let mut graph = Graph::default();
             let v1 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
                 version: String::from("1.0.0"),
-                image: String::from("image/1.0.0"),
+                payload: String::from("image/1.0.0"),
                 metadata: HashMap::new(),
             }));
             let v2 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
                 version: String::from("2.0.0"),
-                image: String::from("image/2.0.0"),
+                payload: String::from("image/2.0.0"),
                 metadata: HashMap::new(),
             }));
             graph.dag.add_edge(v1, v2, Empty {}).unwrap();
@@ -391,12 +391,12 @@ mod tests {
             let mut graph = Graph::default();
             let v3 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
                 version: String::from("3.0.0"),
-                image: String::from("image/3.0.0"),
+                payload: String::from("image/3.0.0"),
                 metadata: HashMap::new(),
             }));
             let v2 = graph.dag.add_node(Release::Concrete(ConcreteRelease {
                 version: String::from("2.0.0"),
-                image: String::from("image/2.0.0"),
+                payload: String::from("image/2.0.0"),
                 metadata: HashMap::new(),
             }));
             graph.dag.add_edge(v2, v3, Empty {}).unwrap();
@@ -415,18 +415,18 @@ mod tests {
     fn test_graph_eq_is_agnostic_to_node_and_edge_order() {
         let r1 = Release::Concrete(ConcreteRelease {
             version: String::from("1.0.0"),
-            image: String::from("image/1.0.0"),
+            payload: String::from("image/1.0.0"),
             metadata: HashMap::new(),
         });
         let r2 = Release::Concrete(ConcreteRelease {
             version: String::from("2.0.0"),
-            image: String::from("image/2.0.0"),
+            payload: String::from("image/2.0.0"),
             metadata: HashMap::new(),
         });
 
         let r3 = Release::Concrete(ConcreteRelease {
             version: String::from("3.0.0"),
-            image: String::from("image/3.0.0"),
+            payload: String::from("image/3.0.0"),
             metadata: HashMap::new(),
         });
 

--- a/docs/design/openshift.md
+++ b/docs/design/openshift.md
@@ -1,6 +1,6 @@
 # Cincinnati in OpenShift #
 
-OpenShift will make use of the [Cincinnati update scheme](cincinnati.md) to provide over-the-air updates to all clusters. Because Cincinnati is a generic scheme, OpenShift specifics will need to be defined. This document serves to document those specifics, which include: the Quay Graph Builder, OpenShift Policy Engine, update image format, and client update protocol.
+OpenShift will make use of the [Cincinnati update scheme](cincinnati.md) to provide over-the-air updates to all clusters. Because Cincinnati is a generic scheme, OpenShift specifics will need to be defined. This document serves to document those specifics, which include: the Quay Graph Builder, OpenShift Policy Engine, update payload format, and client update protocol.
 
 <figure align="center">
   <img src="figures/openshift-1.svg" alt="Figure 1: An overview of the relationships between the Cincinnati components within OpenShift" />
@@ -10,11 +10,11 @@ OpenShift will make use of the [Cincinnati update scheme](cincinnati.md) to prov
 
 ## Key Decisions ##
 
-* **Images declare transitions** - In order to ensure the integrity of updates, the declared transitions (a window into the overall DAG) should remain a part of the update image. Coupling the declaration of valid transitions allows the client to validate that the update was intended for the currently running release. This also makes the future maintenance of a project easier if the DAG can be committed alongside the code. This coupling is the result of the fact that the DAG is really just an easy-to-parse declaration of the intention of the implementation.
-* **Decouple image delivery** - By decoupling the image delivery mechanism from Cincinnati, it allows many different forms of image and their delivery to be supported. The Cincinnati server is able to provide metadata about images in a uniform manner but leaves the retrieval up to each of the clients.
-* **image availability declared in Quay** - Using Quay’s image labels to annotate images allows Quay to be treated as the sole source of truth for the Graph Builders.
-* **image digest and signature is self contained** - If the image contains its digest and signature, the cluster will be able to verify the authenticity of the image without any additional metadata. This is a requirement for offline installations since clusters in these environments won’t communicate with the root Policy Engines.
-* **Each graph API endpoint represents a single product** - All of the versions and channels in a graph are expected to refer to a related set of content, and all images can be assumed to be related.
+* **Payloads declare transitions** - In order to ensure the integrity of updates, the declared transitions (a window into the overall DAG) should remain a part of the update payload. Coupling the declaration of valid transitions allows the client to validate that the update was intended for the currently running release. This also makes the future maintenance of a project easier if the DAG can be committed alongside the code. This coupling is the result of the fact that the DAG is really just an easy-to-parse declaration of the intention of the implementation.
+* **Decouple payload delivery** - By decoupling the payload delivery mechanism from Cincinnati, it allows many different forms of payload and their delivery to be supported. The Cincinnati server is able to provide metadata about payloads in a uniform manner but leaves the retrieval up to each of the clients.
+* **Payload availability declared in Quay** - Using Quay’s image labels to annotate images allows Quay to be treated as the sole source of truth for the Graph Builders.
+* **Payload digest and signature is self contained** - If the payload contains its digest and signature, the cluster will be able to verify the authenticity of the payload without any additional metadata. This is a requirement for offline installations since clusters in these environments won’t communicate with the root Policy Engines.
+* **Each graph API endpoint represents a single product** - All of the versions and channels in a graph are expected to refer to a related set of content, and all payloads can be assumed to be related.
 
 
 ## Update Process ##
@@ -119,9 +119,9 @@ The response from the policy engine will conform to the [Cincinnati Graph API re
 
 ## Update Format ##
 
-### Update Image ###
+### Update Payload ###
 
-The Update Images served by Cincinnati to the Cluster Version Operator are formatted as a JSON document containing a reference to a container image. This document is versioned so that it may change over time. An example of this document is shown below:
+The Update Payloads served by Cincinnati to the Cluster Version Operator are formatted as a JSON document containing a reference to a container image. This document is versioned so that it may change over time. An example of this document is shown below:
 
 ```json
 {

--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -36,7 +36,7 @@ impl Into<cincinnati::Release> for Release {
     fn into(self) -> cincinnati::Release {
         cincinnati::Release::Concrete(cincinnati::ConcreteRelease {
             version: self.metadata.version.to_string(),
-            image: self.source,
+            payload: self.source,
             metadata: self.metadata.metadata,
         })
     }

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -60,14 +60,14 @@
             "Node": {
                 "required": [
                     "version",
-                    "image",
+                    "payload",
                     "metadata"
                 ],
                 "properties": {
                     "version": {
                         "type": "string"
                     },
-                    "image": {
+                    "payload": {
                         "type": "string"
                     },
                     "metadata": {


### PR DESCRIPTION
This reverts commit 5d226dab3ca1a45cea13b2b6753cb08f6f05cb0d.

After some discussion, we've decided that the term "payload" is more
appropriate here given that not all consumers of Cincinnati will specify
their updates as an image reference. The idea of expressing the payload
as an extendable structure was also discussed. We determined that this
structure would need to remain opaque to the Cincinnati stack (since
different consumers have different requirements) and would ultimately
complicate things too much at this stage in the project.