### PR TITLE
commons: add custom errors with JSON responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,9 @@ dependencies = [
 name = "commons"
 version = "0.1.0"
 dependencies = [
+ "actix-web 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 authors = ["Stefan Junker <mail@stefanjunker.de>"]
 
 [dependencies]
+actix-web = "^0.7.8"
 failure = "^0.1.5"
+serde_json = "^1.0.34"
 url = "^1.7.2"

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -1,0 +1,66 @@
+use actix_web::http;
+use actix_web::HttpResponse;
+
+#[derive(Debug, Fail, Eq, PartialEq)]
+pub enum GraphError {
+    #[fail(display = "failed to deserialize JSON: {}", _0)]
+    FailedJsonIn(String),
+    #[fail(display = "failed to serialize JSON: {}", _0)]
+    FailedJsonOut(String),
+    #[fail(display = "failed to fetch upstream graph: {}", _0)]
+    FailedUpstreamFetch(String),
+    #[fail(display = "failed to assemble upstream request")]
+    FailedUpstreamRequest,
+    #[fail(display = "invalid Content-Type requested")]
+    InvalidContentType,
+    #[fail(display = "mandatory client parameters missing")]
+    MissingParams,
+}
+
+impl actix_web::error::ResponseError for GraphError {
+    fn error_response(&self) -> HttpResponse {
+        self.as_json_error()
+    }
+}
+
+impl GraphError {
+    // Return the HTTP JSON error response.
+    pub fn as_json_error(&self) -> HttpResponse {
+        let code = self.as_status_code();
+        let json_body = json!({
+            "kind": self.as_kind(),
+            "value": self.as_value(),
+        });
+        HttpResponse::build(code).json(json_body)
+    }
+
+    // Return the HTTP status code for the error.
+    fn as_status_code(&self) -> http::StatusCode {
+        match *self {
+            GraphError::FailedJsonIn(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+            GraphError::FailedJsonOut(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+            GraphError::FailedUpstreamFetch(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+            GraphError::FailedUpstreamRequest => http::StatusCode::INTERNAL_SERVER_ERROR,
+            GraphError::InvalidContentType => http::StatusCode::NOT_ACCEPTABLE,
+            GraphError::MissingParams => http::StatusCode::BAD_REQUEST,
+        }
+    }
+
+    // Return the kind for the error.
+    fn as_kind(&self) -> String {
+        let kind = match *self {
+            GraphError::FailedJsonIn(_) => "failed_json_in",
+            GraphError::FailedJsonOut(_) => "failed_json_out",
+            GraphError::FailedUpstreamFetch(_) => "failed_upstream_fetch",
+            GraphError::FailedUpstreamRequest => "failed_upstream_request",
+            GraphError::InvalidContentType => "invalid_content_type",
+            GraphError::MissingParams => "missing_params",
+        };
+        kind.to_string()
+    }
+
+    // Return the value for the error.
+    fn as_value(&self) -> String {
+        format!("{}", self)
+    }
+}

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -26,16 +26,16 @@ impl actix_web::error::ResponseError for GraphError {
 impl GraphError {
     // Return the HTTP JSON error response.
     pub fn as_json_error(&self) -> HttpResponse {
-        let code = self.as_status_code();
+        let code = self.status_code();
         let json_body = json!({
-            "kind": self.as_kind(),
-            "value": self.as_value(),
+            "kind": self.kind(),
+            "value": self.value(),
         });
         HttpResponse::build(code).json(json_body)
     }
 
     // Return the HTTP status code for the error.
-    fn as_status_code(&self) -> http::StatusCode {
+    fn status_code(&self) -> http::StatusCode {
         match *self {
             GraphError::FailedJsonIn(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
             GraphError::FailedJsonOut(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -47,7 +47,7 @@ impl GraphError {
     }
 
     // Return the kind for the error.
-    fn as_kind(&self) -> String {
+    fn kind(&self) -> String {
         let kind = match *self {
             GraphError::FailedJsonIn(_) => "failed_json_in",
             GraphError::FailedJsonOut(_) => "failed_json_out",
@@ -60,7 +60,7 @@ impl GraphError {
     }
 
     // Return the value for the error.
-    fn as_value(&self) -> String {
+    fn value(&self) -> String {
         format!("{}", self)
     }
 }

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -56,7 +56,7 @@ pub fn ensure_query_params(
     Ok(())
 }
 
-/// Make sure client requested the relevant content type.
+/// Make sure client requested a valid content type.
 pub fn ensure_content_type(
     headers: &actix_web::http::HeaderMap,
     content_type: &'static str,

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -1,8 +1,14 @@
+extern crate actix_web;
 #[macro_use]
 extern crate failure;
+#[macro_use]
+extern crate serde_json;
 extern crate url;
 
-use failure::Fallible;
+mod errors;
+pub use errors::GraphError;
+
+use actix_web::http::header;
 use std::collections::HashSet;
 use url::form_urlencoded;
 
@@ -27,9 +33,12 @@ pub fn parse_params_set(params: &str) -> HashSet<String> {
 }
 
 /// Make sure `query` string contains all `params` keys.
-pub fn ensure_query_params(params: &HashSet<String>, query: &str) -> Fallible<()> {
+pub fn ensure_query_params(
+    required_params: &HashSet<String>,
+    query: &str,
+) -> Result<(), GraphError> {
     // No mandatory parameters, always fine.
-    if params.is_empty() {
+    if required_params.is_empty() {
         return Ok(());
     }
 
@@ -40,12 +49,29 @@ pub fn ensure_query_params(params: &HashSet<String>, query: &str) -> Fallible<()
         .collect();
 
     // Make sure all mandatory parameters are present.
-    ensure!(
-        params.is_subset(&query_keys),
-        "mandatory parameters missing"
-    );
+    if !required_params.is_subset(&query_keys) {
+        return Err(GraphError::MissingParams);
+    }
 
     Ok(())
+}
+
+/// Make sure client requested the relevant content type.
+pub fn ensure_content_type(
+    headers: &actix_web::http::HeaderMap,
+    content_type: &'static str,
+) -> Result<(), GraphError> {
+    let content_json = header::HeaderValue::from_static(content_type);
+
+    if !headers
+        .get(header::ACCEPT)
+        .map(|accept| accept == content_json)
+        .unwrap_or(false)
+    {
+        Err(GraphError::InvalidContentType)
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/docs/design/cincinnati.md
+++ b/docs/design/cincinnati.md
@@ -143,6 +143,15 @@ The response to the `/v1/graph` endpoint is a JSON representation of the release
 
 The transitions between releases are represented as an array in the top-level `edges` array. Each of these arrays has two entries: the index of the starting node, and the index of the ending node. Both are non-negative integers, ranging from 0 to `len(nodes)-1`.
 
+### Errors ###
+
+Errors on the `/v1/graph` endpoint are returned to the client as JSON objects, with a 4xx or 5xx HTTP status code.
+Error values carry a type identifier and a textual description, according to the folloowing schema:
+
+|  Key   | Optional | Description                                                  |
+|:------:|:--------:|:-------------------------------------------------------------|
+| kind   | required | error type identifier, as a non-empty JSON string            |
+| value  | required | human-friendly error description, as a non-empty JSON string |
 
 #### Example ####
 

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -25,8 +25,38 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Bad client request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "Invalid Content-Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    },
                     "default": {
-                        "description": "Graph error",
+                        "description": "Generic graph error",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -26,11 +26,11 @@
                         }
                     },
                     "default": {
-                        "description": "unexpected error",
+                        "description": "Graph error",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/GraphError"
                                 }
                             }
                         }
@@ -82,17 +82,16 @@
                     "format": "int32"
                 }
             },
-            "Error": {
+            "GraphError": {
                 "required": [
-                    "code",
-                    "message"
+                    "kind",
+                    "value"
                 ],
                 "properties": {
-                    "code": {
-                        "type": "integer",
-                        "format": "int32"
+                    "kind": {
+                        "type": "string"
                     },
-                    "message": {
+                    "value": {
                         "type": "string"
                     }
                 }


### PR DESCRIPTION
This adds a custom `GraphError` error used by both graph-builder and policy-engine "graph" endpoints.
It provides a kind+value JSON serialization so that informative errors can be returned to clients.

Fixes: https://jira.coreos.com/browse/CORS-913
/cc @steveeJ 