### PR TITLE
OWNERS_ALIASES: prevent unnecessary notifications

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,9 +2,7 @@
 
 aliases:
   cincinnati-approvers:
-    - aaronlevy
     - crawford
-    - smarterclayton
     - steveeJ
     - lucab
   cincinnati-reviewers:


### PR DESCRIPTION
This prevents people who are not actually expected to review PRs on a
regular bases from constantly being requested for review.

This complements https://github.com/openshift/release/pull/2927. 

/cc @aaronlevy @crawford @smarterclayton (please acknowledge)