### PR TITLE
Fix long status port names

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -58,7 +58,7 @@ objects:
           ports:
           - name: graph-builder
             containerPort: ${{GB_PORT}}
-          - name: status-graph-builder
+          - name: status-gb
             containerPort: 9080
           livenessProbe:
             httpGet:
@@ -111,7 +111,7 @@ objects:
           ports:
           - name: policy-engine 
             containerPort: ${{PE_PORT}}
-          - name: status-policy-engine
+          - name: status-pe
             containerPort: 9081
           livenessProbe:
             httpGet:
@@ -154,7 +154,7 @@ objects:
         protocol: TCP
         port: ${{GB_PORT}}
         targetPort: ${{GB_PORT}}
-      - name: status-graph-builder
+      - name: status-gb
         protocol: TCP
         port: 9080
         targetPort: 9080
@@ -172,7 +172,7 @@ objects:
         protocol: TCP
         port: 80
         targetPort: ${{PE_PORT}}
-      - name: status-policy-engine
+      - name: status-pe
         protocol: TCP
         port: 9081
         targetPort: 9081


### PR DESCRIPTION
There's a 15 characters limit on the port names.

This commit shortens the port names to fix the deployment from failing

status-policy-engine -> status-pe
status-graph-builder -> status-gb