### PR TITLE
Use default port numbers, add specific app labels to services

### DIFF
--- a/dist/openshift/cincinnati.configmap.yaml
+++ b/dist/openshift/cincinnati.configmap.yaml
@@ -9,5 +9,5 @@ data:
   gb.repository: "steveej/cincinnati-test"
   gb.log.verbosity: "vvv"
   pe.address: "0.0.0.0"
-  pe.upstream: "http://cincinnati-graph-builder.cincinnati-staging.svc:8181/v1/graph"
+  pe.upstream: "http://cincinnati-graph-builder.cincinnati-staging.svc:8080/v1/graph"
   pe.log.verbosity: "vvv"

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -147,7 +147,7 @@ objects:
   metadata:
     name: cincinnati-graph-builder
     labels:
-      app: cincinnati
+      app: cincinnati-graph-builder
   spec:
     ports:
       - name: graph-builder
@@ -165,7 +165,7 @@ objects:
   metadata:
     name: cincinnati-policy-engine
     labels:
-      app: cincinnati
+      app: cincinnati-policy-engine
   spec:
     ports:
       - name: policy-engine 
@@ -192,10 +192,10 @@ parameters:
   displayName: Memory Limit
   description: Maximum amount of memory the container can use. Defaults 256Mi
 - name: GB_PORT
-  value: "8181"
+  value: "8080"
   displayName: Graph builder port
 - name: PE_PORT
-  value: "8080"
+  value: "8081"
   displayName: Policy enigine port
 - name: PE_PATH_PREFIX
   value: "/api/upgrades_info"


### PR DESCRIPTION
We initially got the status ports interchanged. The correct port mappings are:

status-graph-builder: 9081
status-policy-engine: 9080

Also adds a specific app label to the service, so that we can select
by that label in the servicemonitor.