### PR TITLE
Policy engine: Publish Prometheus metrics on all interfaces inside Pod

### DIFF
--- a/dist/openshift/cincinnati.configmap.yaml
+++ b/dist/openshift/cincinnati.configmap.yaml
@@ -9,5 +9,6 @@ data:
   gb.repository: "steveej/cincinnati-test"
   gb.log.verbosity: "vvv"
   pe.address: "0.0.0.0"
+  pe.metrics.address: "0.0.0.0"
   pe.upstream: "http://cincinnati-graph-builder.cincinnati-staging.svc:8080/v1/graph"
   pe.log.verbosity: "vvv"

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -96,6 +96,11 @@ objects:
                 configMapKeyRef:
                     key: pe.address
                     name: cincinnati
+            - name: PE_METRICS_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                    key: pe.metrics.address
+                    name: cincinnati
             - name: UPSTREAM
               valueFrom:
                 configMapKeyRef:
@@ -107,7 +112,7 @@ objects:
                   key: pe.log.verbosity
                   name: cincinnati
           command: ["/usr/bin/policy-engine"]
-          args: ["-$(PE_LOG_VERBOSITY)", "--address", "$(ADDRESS)", "--port", "${PE_PORT}", "--upstream", "$(UPSTREAM)", "--path-prefix", "${PE_PATH_PREFIX}"]
+          args: ["-$(PE_LOG_VERBOSITY)", "--address", "$(ADDRESS)", "--port", "${PE_PORT}", "--upstream", "$(UPSTREAM)", "--path-prefix", "${PE_PATH_PREFIX}", "--metrics_address", "$(PE_METRICS_ADDRESS)"]
           ports:
           - name: policy-engine 
             containerPort: ${{PE_PORT}}


### PR DESCRIPTION
Add pe.metrics.address field to cincinnati configmap
For policy engine container CMD, add argument to use metrics address from Configmap

This is required so that the prometheus endpoint is available outside the pod. 