### PR TITLE
graph-builder: instrument and expose graph metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,7 @@ dependencies = [
 name = "graph-builder"
 version = "0.1.0"
 dependencies = [
+ "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
  "commons 0.1.0",
@@ -669,7 +670,9 @@ dependencies = [
  "flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quay 0.0.0-dev",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -7,11 +7,15 @@ authors = ["Alex Crawford <crawford@redhat.com>"]
 actix-web = "^0.7.8"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
+dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "a10c1aba444ce5c07e113c81160eb67c9711e327" }
 env_logger = "^0.6.0"
-itertools = "^0.7.8"
 failure = "^0.1.1"
 flate2 = "^1.0.1"
+futures = "0.1"
+itertools = "^0.7.8"
 log = "^0.4.3"
+quay = { path = "../quay" }
+regex = "^1.1.0"
 reqwest = "^0.9.0"
 semver = { version = "^0.9.0", features = [ "serde" ] }
 serde = "^1.0.70"
@@ -20,12 +24,7 @@ serde_json = "^1.0.22"
 structopt = "^0.2.10"
 tar = "^0.4.16"
 tokio = "0.1"
-dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "a10c1aba444ce5c07e113c81160eb67c9711e327" }
-futures = "0.1"
-quay = { path = "../quay" }
 url = "^1.7.2"
-regex = "^1.1.0"
-
 
 [features]
 test-net = []

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
 
 [dependencies]
+actix = "^0.7.6"
 actix-web = "^0.7.8"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
@@ -13,7 +14,9 @@ failure = "^0.1.1"
 flate2 = "^1.0.1"
 futures = "0.1"
 itertools = "^0.7.8"
+lazy_static = "^1.2.0"
 log = "^0.4.3"
+prometheus = "^0.4.2"
 quay = { path = "../quay" }
 regex = "^1.1.0"
 reqwest = "^0.9.0"

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -9,6 +9,8 @@ extern crate flate2;
 extern crate futures;
 extern crate itertools;
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate prometheus;

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -1,27 +1,27 @@
+extern crate actix_web;
 extern crate cincinnati;
 extern crate commons;
 extern crate dkregistry;
 extern crate env_logger;
+#[macro_use]
+extern crate failure;
 extern crate flate2;
 extern crate futures;
 extern crate itertools;
+#[macro_use]
+extern crate log;
+extern crate quay;
+extern crate regex;
 extern crate reqwest;
 extern crate semver;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate actix_web;
 extern crate serde_json;
-extern crate tar;
-extern crate tokio;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate log;
 #[macro_use]
 extern crate structopt;
-extern crate quay;
-extern crate regex;
+extern crate tar;
+extern crate tokio;
 
 pub mod config;
 pub mod graph;

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -10,6 +10,8 @@ extern crate futures;
 extern crate itertools;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate prometheus;
 extern crate quay;
 extern crate regex;
 extern crate reqwest;
@@ -25,5 +27,6 @@ extern crate tokio;
 
 pub mod config;
 pub mod graph;
+pub mod metrics;
 pub mod registry;
 pub mod release;

--- a/graph-builder/src/metrics.rs
+++ b/graph-builder/src/metrics.rs
@@ -1,0 +1,21 @@
+//! Metrics service.
+
+use actix_web::{HttpRequest, HttpResponse};
+use futures::future;
+use futures::prelude::*;
+use prometheus;
+
+/// Serve metrics requests (Prometheus textual format).
+pub fn serve(_req: HttpRequest<()>) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
+    use prometheus::Encoder;
+
+    let resp = future::ok(prometheus::gather())
+        .and_then(|metrics| {
+            let tenc = prometheus::TextEncoder::new();
+            let mut buf = vec![];
+            tenc.encode(&metrics, &mut buf).and(Ok(buf))
+        })
+        .from_err()
+        .map(|content| HttpResponse::Ok().body(content));
+    Box::new(resp)
+}


### PR DESCRIPTION
This adds a status service to serve graph-builder `/metrics` endpoint.
It is initially hardcoded to bind to `0.0.0.0:9080` (pending configuration rework).
It also adds initial instrumentation to record basic metrics about incoming
requests, total and failed scrapes, fetched releases, and nodes recorded in the
processed DAG.

Ref: https://jira.coreos.com/browse/CORS-1015
/cc @steveeJ 