### PR TITLE
graph-builder: use sha256 in payload if available

### DIFF
--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -249,6 +249,14 @@ pub fn fetch_releases(
         };
 
         if let Some(manifestref) = manifestref {
+            // Replace the tag specifier with the manifestref
+            release.source = {
+                let mut source_split: Vec<&str> = release.source.split(':').collect();
+                let _ = source_split.pop();
+
+                format!("{}@{}", source_split.join(":"), manifestref)
+            };
+
             // Attach the manifestref this release was found in for further processing
             release
                 .metadata


### PR DESCRIPTION
This reduces the work for the consumer which now gets the most accurate
pullspec directly instead of having to assemble it using the manifestref
in the metadata.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686589.

TODO: 
- [x] Extend tests