### PR TITLE
commons: list missing parameters in error message

### DIFF
--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -55,9 +55,11 @@ pub fn ensure_query_params(
         .map(|(k, _)| k)
         .collect();
 
-    // Make sure all mandatory parameters are present.
-    if !required_params.is_subset(&query_keys) {
-        return Err(GraphError::MissingParams);
+    // Make sure no mandatory parameters are missing.
+    let mut missing: Vec<String> = required_params.difference(&query_keys).cloned().collect();
+    if !missing.is_empty() {
+        missing.sort();
+        return Err(GraphError::MissingParams(missing));
     }
 
     Ok(())
@@ -122,5 +124,4 @@ mod tests {
         ensure_query_params(&simple, "").unwrap_err();
         ensure_query_params(&simple, "c=d").unwrap_err();
     }
-
 }

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -164,6 +164,9 @@ mod tests {
         let graph_call = graph::index(http_req);
         let resp = rt.block_on(graph_call).unwrap_err();
 
-        assert_eq!(resp, graph::GraphError::MissingParams);
+        assert_eq!(
+            resp,
+            graph::GraphError::MissingParams(vec!["id".to_string()])
+        );
     }
 }


### PR DESCRIPTION
This tells the client which parameters are missing in a request.

Ref: https://jira.coreos.com/browse/CIN-10
/cc @steveeJ 