### PR TITLE
graph-builder: expose liveness status

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -74,11 +74,8 @@ objects:
             containerPort: ${{GB_STATUS_PORT}}
           livenessProbe:
             httpGet:
-              path: /v1/graph
-              port: ${{GB_PORT}}
-              httpHeaders:
-              - name: Accept
-                value: application/json
+              path: /liveness
+              port: ${{GB_STATUS_PORT}}
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 3

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -80,9 +80,9 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(mandatory_params: HashSet<String>) -> State {
+    pub fn new(json: Arc<RwLock<String>>, mandatory_params: HashSet<String>) -> State {
         State {
-            json: Arc::new(RwLock::new(String::new())),
+            json,
             mandatory_params,
         }
     }

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -32,6 +32,6 @@ extern crate toml;
 
 pub mod config;
 pub mod graph;
-pub mod metrics;
+pub mod status;
 pub mod registry;
 pub mod release;

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -32,6 +32,6 @@ extern crate toml;
 
 pub mod config;
 pub mod graph;
-pub mod status;
 pub mod registry;
 pub mod release;
+pub mod status;

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -24,6 +24,7 @@ use graph_builder::{config, graph, status};
 
 use actix_web::{http::Method, middleware::Logger, server, App};
 use failure::Error;
+use std::sync::{Arc, RwLock};
 use std::thread;
 
 fn main() -> Result<(), Error> {
@@ -36,20 +37,27 @@ fn main() -> Result<(), Error> {
         .init();
     debug!("application settings:\n{:#?}", &settings);
 
-    let state = graph::State::new(settings.mandatory_client_parameters.clone());
+    let json_graph = Arc::new(RwLock::new(String::new()));
+    let status_state = status::StatusState::new(json_graph.clone());
+    let app_state = graph::State::new(
+        json_graph.clone(),
+        settings.mandatory_client_parameters.clone(),
+    );
     let service_addr = (settings.address, settings.port);
     let status_addr = (settings.status_address, settings.status_port);
     let app_prefix = settings.path_prefix.clone();
 
     {
-        let state = state.clone();
+        let state = app_state.clone();
         thread::spawn(move || graph::run(&settings, &state));
     }
 
     // Status service.
-    server::new(|| {
-        App::new()
+    server::new(move || {
+        let state = status_state.clone();
+        App::with_state(state)
             .middleware(Logger::default())
+            .route("/liveness", Method::GET, status::serve_liveness)
             .route("/metrics", Method::GET, status::serve_metrics)
     })
     .bind(status_addr)?
@@ -58,7 +66,7 @@ fn main() -> Result<(), Error> {
     // Main service.
     server::new(move || {
         let app_prefix = app_prefix.clone();
-        let state = state.clone();
+        let state = app_state.clone();
         App::with_state(state)
             .middleware(Logger::default())
             .prefix(app_prefix)

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -20,7 +20,7 @@ extern crate graph_builder;
 extern crate log;
 extern crate structopt;
 
-use graph_builder::{config, graph, metrics};
+use graph_builder::{config, graph, status};
 
 use actix_web::{http::Method, middleware::Logger, server, App};
 use failure::Error;
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     server::new(|| {
         App::new()
             .middleware(Logger::default())
-            .route("/metrics", Method::GET, metrics::serve)
+            .route("/metrics", Method::GET, status::serve_metrics)
     })
     .bind(status_addr)?
     .start();

--- a/graph-builder/src/status.rs
+++ b/graph-builder/src/status.rs
@@ -1,12 +1,14 @@
-//! Metrics service.
+//! Status service.
 
 use actix_web::{HttpRequest, HttpResponse};
 use futures::future;
 use futures::prelude::*;
 use prometheus;
 
-/// Serve metrics requests (Prometheus textual format).
-pub fn serve(_req: HttpRequest<()>) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
+/// Expose metrics (Prometheus textual format).
+pub fn serve_metrics(
+    _req: HttpRequest<()>,
+) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
     use prometheus::Encoder;
 
     let resp = future::ok(prometheus::gather())

--- a/graph-builder/src/status.rs
+++ b/graph-builder/src/status.rs
@@ -4,10 +4,24 @@ use actix_web::{HttpRequest, HttpResponse};
 use futures::future;
 use futures::prelude::*;
 use prometheus;
+use std::sync::{Arc, RwLock};
+
+/// State for the status service.
+#[derive(Clone)]
+pub struct StatusState {
+    /// Cached graph.
+    json_graph: Arc<RwLock<String>>,
+}
+
+impl StatusState {
+    pub fn new(json_graph: Arc<RwLock<String>>) -> Self {
+        Self { json_graph }
+    }
+}
 
 /// Expose metrics (Prometheus textual format).
 pub fn serve_metrics(
-    _req: HttpRequest<()>,
+    _req: HttpRequest<StatusState>,
 ) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
     use prometheus::Encoder;
 
@@ -20,4 +34,29 @@ pub fn serve_metrics(
         .from_err()
         .map(|content| HttpResponse::Ok().body(content));
     Box::new(resp)
+}
+
+/// Expose liveness status.
+///
+/// Status:
+///  * Live (200 code): JSON graph is accessible (lock not poisoned).
+///  * Not Live (500 code): everything else.
+pub fn serve_liveness(
+    req: HttpRequest<StatusState>,
+) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
+    let live = req
+        .state()
+        .json_graph
+        .read()
+        .ok()
+        .map(|_| true)
+        .unwrap_or(false);
+
+    let resp = if live {
+        HttpResponse::Ok().finish()
+    } else {
+        HttpResponse::InternalServerError().finish()
+    };
+
+    Box::new(future::ok(resp))
 }


### PR DESCRIPTION
This exposes a `/liveness` endpoint on the status service, to check
that the JSON graph content can be served.

Ref: https://jira.coreos.com/browse/CIN-16
/cc @steveeJ 