### PR TITLE
graph-builder: do not cache empty graph on failed scrapes

### DIFF
--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -169,7 +169,7 @@ pub fn run<'a>(opts: &'a config::Options, state: &State) -> ! {
                 UPSTREAM_ERRORS.inc();
                 err.iter_chain()
                     .for_each(|cause| error!("failed to fetch all release metadata: {}", cause));
-                vec![]
+                continue;
             }
         };
         GRAPH_UPSTREAM_RAW_RELEASES.set(releases.len() as i64);


### PR DESCRIPTION
This fixes a logic mistake in the scraper, where a temporary failure in
release fetching will result in caching an empty graph.

/cc @steveeJ 