### PR TITLE
graph-builder: expose readiness status

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -81,11 +81,8 @@ objects:
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/graph
-              port: ${{GB_PORT}}
-              httpHeaders:
-              - name: Accept
-                value: application/json
+              path: /readiness
+              port: ${{GB_STATUS_PORT}}
             initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(), Error> {
             .middleware(Logger::default())
             .route("/liveness", Method::GET, status::serve_liveness)
             .route("/metrics", Method::GET, status::serve_metrics)
+            .route("/readiness", Method::GET, status::serve_readiness)
     })
     .bind(status_addr)?
     .start();


### PR DESCRIPTION
This exposes a `/readiness` endpoint on the status service, to signal when
the JSON graph has been cached on startup.

Ref: https://jira.coreos.com/browse/CIN-12
/cc @steveeJ 