### PR TITLE
quay: tweak read credentials logic

### DIFF
--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -106,14 +106,16 @@ impl QuayMetadataFetchPlugin {
         repo: String,
         label_filter: String,
         manifestref_key: String,
-        api_token_path: Option<&PathBuf>,
+        api_token_path: Option<PathBuf>,
         api_base: String,
     ) -> Fallible<Self> {
-        let api_token =
-            quay::read_credentials(api_token_path).expect("could not read quay API credentials");
+        let api_token = api_token_path
+            .map(|path| quay::read_credentials(path))
+            .transpose()
+            .context("could not read quay API credentials")?;
 
         let client: quay::v1::Client = quay::v1::Client::builder()
-            .access_token(api_token.map(|s| s.to_string()))
+            .access_token(api_token)
             .api_base(Some(api_base.to_string()))
             .build()?;
 

--- a/quay/src/lib.rs
+++ b/quay/src/lib.rs
@@ -13,29 +13,27 @@ use failure::Fallible;
 use failure::ResultExt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::Path;
 
 pub mod v1;
 
-pub fn read_credentials(credentials_path: Option<&PathBuf>) -> Fallible<Option<String>> {
-    match &credentials_path {
-        Some(pathbuf) => {
-            let file =
-                File::open(pathbuf).context(format!("could not open '{}'", &pathbuf.display()))?;
+pub fn read_credentials<P>(path: P) -> Fallible<String>
+where
+    P: AsRef<Path>,
+{
+    let filepath = path.as_ref();
+    let file = File::open(filepath).context(format!("could not open '{}'", filepath.display()))?;
 
-            let first_line = BufReader::new(file)
-                .lines()
-                .nth(0)
-                .ok_or_else(|| format_err!("empty credentials."))?;
+    let first_line = BufReader::new(file)
+        .lines()
+        .nth(0)
+        .ok_or_else(|| format_err!("empty credentials."))?;
 
-            let token = first_line?.trim_end().to_string();
+    let token = first_line?.trim_end().to_string();
 
-            if token.is_empty() {
-                bail!("found an empty first line in '{}'", &pathbuf.display())
-            }
-
-            Ok(Some(token))
-        }
-        None => Ok(None),
+    if token.is_empty() {
+        bail!("found an empty first line in '{}'", filepath.display())
     }
+
+    Ok(token)
 }


### PR DESCRIPTION
This updates the logic for reading credentials, getting rid of Option
handling and using generic path references instead.

/cc @steveeJ 