### PR TITLE
 cincinnati/plugins: add plugins catalog and configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +735,7 @@ dependencies = [
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "smart-default 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1257,7 +1258,7 @@ dependencies = [
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "smart-default 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1734,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "smart-default"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2596,7 +2597,7 @@ dependencies = [
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
-"checksum smart-default 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fae090012788f95156fc33f43631242480f311cca6bf7f600943eba14ae032ed"
+"checksum smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9dbd5f03d04e80355cbbe3ce5cf1f65c421eac575402e3d4d6e95d5a44edaa"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -20,6 +20,7 @@ try_from = "0.3.2"
 env_logger = "^0.6.0"
 lazy_static = "^1.2.0"
 regex = "^1.1.0"
+smart-default = "^0.5.2"
 
 [dev-dependencies]
 serde_json = "1.0.22"

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -22,11 +22,14 @@ extern crate commons;
 #[macro_use]
 extern crate log;
 extern crate protobuf;
+extern crate toml;
 extern crate try_from;
 extern crate url;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+#[macro_use]
+extern crate smart_default;
 
 pub mod plugins;
 

--- a/cincinnati/src/plugins/catalog.rs
+++ b/cincinnati/src/plugins/catalog.rs
@@ -1,0 +1,65 @@
+//! Plugins catalog.
+//!
+//! This catalog relies on a static list of all available plugins,
+//! referenced by name. It is used for configuration purposes.
+
+use super::internal::channel_filter::ChannelFilterPlugin;
+use super::internal::edge_add_remove::EdgeAddRemovePlugin;
+use super::internal::metadata_fetch_quay::QuayMetadataFetchPlugin;
+use super::internal::node_remove::NodeRemovePlugin;
+use super::{Plugin, PluginIO};
+use failure::Fallible;
+use std::fmt::Debug;
+
+/// Key used to look up plugin-type in a configuration entry.
+static CONFIG_PLUGIN_NAME_KEY: &str = "name";
+
+/// Settings for a plugin.
+pub trait PluginSettings: Debug + Send {
+    /// Build the corresponding plugin for this configuration.
+    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>>;
+}
+
+/// Validate configuration for a plugin and fill in defaults.
+pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<PluginSettings>> {
+    let name = cfg
+        .get(CONFIG_PLUGIN_NAME_KEY)
+        .ok_or_else(|| format_err!("missing plugin name"))?
+        .as_str()
+        .ok_or_else(|| format_err!("invalid plugin name value"))?
+        .to_string();
+
+    match name.as_str() {
+        ChannelFilterPlugin::PLUGIN_NAME => ChannelFilterPlugin::deserialize_config(cfg),
+        EdgeAddRemovePlugin::PLUGIN_NAME => EdgeAddRemovePlugin::deserialize_config(cfg),
+        NodeRemovePlugin::PLUGIN_NAME => NodeRemovePlugin::deserialize_config(cfg),
+        QuayMetadataFetchPlugin::PLUGIN_NAME => QuayMetadataFetchPlugin::deserialize_config(cfg),
+        x => bail!("unknown plugin '{}'", x),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_basic() {
+        let empty: toml::Value = toml::from_str("").unwrap();
+        deserialize_config(empty).unwrap_err();
+
+        let no_name: toml::Value = toml::from_str("foo = 'bar'").unwrap();
+        deserialize_config(no_name).unwrap_err();
+
+        let node_remove_default: toml::Value = toml::from_str("name = 'node-remove'").unwrap();
+        let nr_settings = deserialize_config(node_remove_default).unwrap();
+        nr_settings.build_plugin().unwrap();
+
+        let cfg = r#"
+            name = "quay-metadata"
+            repository = "mytest"
+        "#;
+        let quay_metadata_repo: toml::Value = toml::from_str(cfg).unwrap();
+        let qm_settings = deserialize_config(quay_metadata_repo).unwrap();
+        qm_settings.build_plugin().unwrap();
+    }
+}

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -2,10 +2,17 @@
 
 use crate as cincinnati;
 use failure::Fallible;
-use plugins::{InternalIO, InternalPlugin};
+use plugins::{
+    InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
+};
 use ReleaseId;
 
+static DEFAULT_KEY_FILTER: &str = "com.openshift.upgrades.graph";
+
+#[derive(Clone, Debug, Deserialize, SmartDefault)]
+#[serde(default)]
 pub struct EdgeAddRemovePlugin {
+    #[default(DEFAULT_KEY_FILTER.to_string())]
     pub key_prefix: String,
 }
 
@@ -21,10 +28,28 @@ impl InternalPlugin for EdgeAddRemovePlugin {
     }
 }
 
+impl PluginSettings for EdgeAddRemovePlugin {
+    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>> {
+        Ok(Box::new(InternalPluginWrapper(self.clone())))
+    }
+}
+
 /// Adds and removes next and previous releases to/from quay labels
 ///
 /// The labels are assumed to have the syntax `<prefix>.(previous|next).(remove|add)=(<Version>,)*<Version>`
 impl EdgeAddRemovePlugin {
+    /// Plugin name, for configuration.
+    pub(crate) const PLUGIN_NAME: &'static str = "edge-add-remove";
+
+    /// Validate plugin configuration and fill in defaults.
+    pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<PluginSettings>> {
+        let plugin: Self = cfg.try_into()?;
+
+        ensure!(!plugin.key_prefix.is_empty(), "empty prefix");
+
+        Ok(Box::new(plugin))
+    }
+
     /// Remove next and previous releases from quay labels
     ///
     /// The labels are assumed to have the syntax `<prefix>.(previous|next).remove=(<Version>,)*<Version>`

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -3,10 +3,13 @@
 
 #[macro_use]
 pub mod macros;
+
+mod catalog;
 pub mod external;
 pub mod interface;
 pub mod internal;
 
+pub use self::catalog::{deserialize_config, PluginSettings};
 use crate as cincinnati;
 use failure::{Error, Fallible, ResultExt};
 use plugins::interface::{PluginError, PluginExchange};


### PR DESCRIPTION
This adds a plugins catalog in order to be able to lookup plugins in
configuration entries. It also adds config deserialization for plugins,
from TOML values.

/cc @steveeJ 