### PR TITLE
cincinnati: namespace all metrics according to application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,9 @@ version = "0.1.0"
 dependencies = [
  "actix-web 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -6,7 +6,9 @@ authors = ["Stefan Junker <mail@stefanjunker.de>"]
 [dependencies]
 actix-web = "^0.7.8"
 failure = "^0.1.5"
+lazy_static = "^1.2.0"
 log = "^0.4.6"
+prometheus = "^0.6.0"
 serde = "^1.0.70"
 serde_json = "^1.0.34"
 url = "^1.7.2"

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -7,6 +7,9 @@ extern crate actix_web;
 extern crate failure;
 extern crate serde;
 #[macro_use]
+extern crate lazy_static;
+extern crate prometheus;
+#[macro_use]
 extern crate serde_json;
 extern crate url;
 
@@ -16,7 +19,7 @@ pub use config::MergeOptions;
 pub mod de;
 
 mod errors;
-pub use errors::GraphError;
+pub use errors::{register_metrics, GraphError};
 
 use actix_web::http::header;
 use std::collections::HashSet;

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -54,6 +54,7 @@ lazy_static! {
 
 /// Register relevant metrics to a prometheus registry.
 pub fn register_metrics(registry: &prometheus::Registry) -> Fallible<()> {
+    commons::register_metrics(&registry)?;
     registry.register(Box::new(GRAPH_FINAL_RELEASES.clone()))?;
     registry.register(Box::new(GRAPH_UPSTREAM_RAW_RELEASES.clone()))?;
     registry.register(Box::new(UPSTREAM_ERRORS.clone()))?;

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -16,8 +16,8 @@ use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use cincinnati::{plugins, AbstractRelease, Graph, Release, CONTENT_TYPE};
 use commons::GraphError;
 use config;
-use failure::Error;
-use prometheus::{Counter, IntGauge};
+use failure::{Error, Fallible};
+use prometheus::{self, Counter, IntGauge};
 use registry::{self, Registry};
 use serde_json;
 use std::collections::{HashMap, HashSet};
@@ -25,33 +25,44 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 
 lazy_static! {
-    static ref GRAPH_FINAL_RELEASES: IntGauge = register_int_gauge!(
-        "cincinnati_gb_graph_final_releases",
+    static ref GRAPH_FINAL_RELEASES: IntGauge = IntGauge::new(
+        "graph_final_releases",
         "Number of releases in the final graph, after processing"
     )
     .unwrap();
-    static ref GRAPH_UPSTREAM_RAW_RELEASES: IntGauge = register_int_gauge!(
-        "cincinnati_gb_graph_upstream_raw_releases",
+    static ref GRAPH_UPSTREAM_RAW_RELEASES: IntGauge = IntGauge::new(
+        "graph_upstream_raw_releases",
         "Number of releases fetched from upstream, before processing"
     )
     .unwrap();
-    static ref UPSTREAM_SCRAPES: Counter = register_counter!(
-        "cincinnati_gb_graph_upstream_scrapes_total",
-        "Total number of upstream scrapes"
-    )
-    .unwrap();
-    static ref UPSTREAM_ERRORS: Counter = register_counter!(
-        "cincinnati_gb_graph_upstream_errors_total",
+    static ref UPSTREAM_ERRORS: Counter = Counter::new(
+        "graph_upstream_errors_total",
         "Total number of upstream scraping errors"
     )
     .unwrap();
-    static ref V1_GRAPH_INCOMING_REQS: Counter = register_counter!(
-        "cincinnati_gb_v1_graph_incoming_requests_total",
+    static ref UPSTREAM_SCRAPES: Counter = Counter::new(
+        "graph_upstream_scrapes_total",
+        "Total number of upstream scrapes"
+    )
+    .unwrap();
+    static ref V1_GRAPH_INCOMING_REQS: Counter = Counter::new(
+        "v1_graph_incoming_requests_total",
         "Total number of incoming HTTP client request to /v1/graph"
     )
     .unwrap();
 }
 
+/// Register relevant metrics to a prometheus registry.
+pub fn register_metrics(registry: &prometheus::Registry) -> Fallible<()> {
+    registry.register(Box::new(GRAPH_FINAL_RELEASES.clone()))?;
+    registry.register(Box::new(GRAPH_UPSTREAM_RAW_RELEASES.clone()))?;
+    registry.register(Box::new(UPSTREAM_ERRORS.clone()))?;
+    registry.register(Box::new(UPSTREAM_SCRAPES.clone()))?;
+    registry.register(Box::new(V1_GRAPH_INCOMING_REQS.clone()))?;
+    Ok(())
+}
+
+/// Serve Cincinnati graph requests.
 pub fn index(req: HttpRequest<State>) -> Result<HttpResponse, GraphError> {
     V1_GRAPH_INCOMING_REQS.inc();
 

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -13,7 +13,6 @@ extern crate itertools;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate prometheus;
 extern crate quay;
 extern crate regex;

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> Result<(), Error> {
     }
 
     // Status service.
+    graph::register_metrics(&status::PROM_REGISTRY)?;
     server::new(move || {
         let state = status_state.clone();
         App::with_state(state)

--- a/graph-builder/src/status.rs
+++ b/graph-builder/src/status.rs
@@ -6,6 +6,16 @@ use futures::prelude::*;
 use prometheus;
 use std::sync::{Arc, RwLock};
 
+/// Common prefix for graph-builder metrics.
+static GB_METRICS_PREFIX: &str = "cincinnati_gb";
+
+lazy_static! {
+    /// Metrics registry.
+    pub static ref PROM_REGISTRY: prometheus::Registry =
+        prometheus::Registry::new_custom(Some(GB_METRICS_PREFIX.to_string()), None)
+            .expect("could not create metrics registry");
+}
+
 /// State for the status service.
 #[derive(Clone)]
 pub struct StatusState {
@@ -49,7 +59,7 @@ pub fn serve_metrics(
 ) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
     use prometheus::Encoder;
 
-    let resp = future::ok(prometheus::gather())
+    let resp = future::ok(PROM_REGISTRY.gather())
         .and_then(|metrics| {
             let tenc = prometheus::TextEncoder::new();
             let mut buf = vec![];

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -7,56 +7,67 @@ use cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_LABEL_FILTE
 use cincinnati::plugins::InternalPluginWrapper;
 use cincinnati::{plugins, Graph, CONTENT_TYPE};
 use commons::{self, GraphError};
+use failure::Fallible;
 use futures::{future, Future, Stream};
 use hyper::{Body, Client, Request};
-use prometheus::{Counter, Histogram};
+use prometheus::{Counter, Histogram, HistogramOpts, Registry};
 use serde_json;
 use AppState;
 
 lazy_static! {
-    static ref HTTP_GRAPH_REQS: Counter = register_counter!(
-        "http_graph_requests_total",
-        "Total number of HTTP /v1/graph requests."
-    )
-    .unwrap();
-    static ref HTTP_GRAPH_BAD_REQS: Counter = register_counter!(
-        "http_graph_bad_requests_total",
-        "Total number of bad HTTP /v1/graph requests."
-    )
-    .unwrap();
-    static ref HTTP_UPSTREAM_REQS: Counter = register_counter!(
+    static ref HTTP_UPSTREAM_REQS: Counter = Counter::new(
         "http_upstream_requests_total",
-        "Total number of HTTP upstream requests."
+        "Total number of HTTP upstream requests"
     )
     .unwrap();
-    static ref HTTP_UPSTREAM_UNREACHABLE: Counter = register_counter!(
+    static ref HTTP_UPSTREAM_UNREACHABLE: Counter = Counter::new(
         "http_upstream_errors_total",
-        "Total number of HTTP upstream unreachable errors."
+        "Total number of HTTP upstream unreachable errors"
     )
     .unwrap();
-    static ref HTTP_SERVE_HIST: Histogram = register_histogram!(
-        "http_graph_serve_duration_seconds",
-        "HTTP graph serving latency in seconds."
+    static ref V1_GRAPH_INCOMING_REQS: Counter = Counter::new(
+        "v1_graph_incoming_requests_total",
+        "Total number of incoming HTTP client request to /v1/graph"
     )
     .unwrap();
+    static ref V1_GRAPH_BAD_REQS: Counter = Counter::new(
+        "v1_graph_incoming_bad_requests_total",
+        "Total number of incoming bad HTTP client request to /v1/graph"
+    )
+    .unwrap();
+    static ref V1_GRAPH_SERVE_HIST: Histogram = Histogram::with_opts(HistogramOpts::new(
+        "v1_graph_serve_duration_seconds",
+        "HTTP graph serving latency in seconds"
+    ))
+    .unwrap();
+}
+
+/// Register relevant metrics to a prometheus registry.
+pub(crate) fn register_metrics(registry: &Registry) -> Fallible<()> {
+    registry.register(Box::new(V1_GRAPH_INCOMING_REQS.clone()))?;
+    registry.register(Box::new(V1_GRAPH_BAD_REQS.clone()))?;
+    registry.register(Box::new(HTTP_UPSTREAM_REQS.clone()))?;
+    registry.register(Box::new(HTTP_UPSTREAM_UNREACHABLE.clone()))?;
+    registry.register(Box::new(V1_GRAPH_SERVE_HIST.clone()))?;
+    Ok(())
 }
 
 /// Serve Cincinnati graph requests.
 pub(crate) fn index(
     req: HttpRequest<AppState>,
 ) -> Box<Future<Item = HttpResponse, Error = GraphError>> {
-    HTTP_GRAPH_REQS.inc();
+    V1_GRAPH_INCOMING_REQS.inc();
 
     // Check that the client can accept JSON media type.
     if let Err(e) = commons::ensure_content_type(req.headers(), CONTENT_TYPE) {
-        HTTP_GRAPH_BAD_REQS.inc();
+        V1_GRAPH_BAD_REQS.inc();
         return Box::new(future::err(e));
     }
 
     // Check for required client parameters.
     let mandatory_params = &req.state().mandatory_params;
     if let Err(e) = commons::ensure_query_params(mandatory_params, req.query_string()) {
-        HTTP_GRAPH_BAD_REQS.inc();
+        V1_GRAPH_BAD_REQS.inc();
         return Box::new(future::err(e));
     }
 
@@ -81,7 +92,7 @@ pub(crate) fn index(
     };
 
     HTTP_UPSTREAM_REQS.inc();
-    let timer = HTTP_SERVE_HIST.start_timer();
+    let timer = V1_GRAPH_SERVE_HIST.start_timer();
     let serve = Client::new()
         .request(ups_req)
         .map_err(|e| GraphError::FailedUpstreamFetch(e.to_string()))

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -16,7 +16,6 @@ extern crate hyper;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate prometheus;
 extern crate semver;
 extern crate serde;
@@ -50,6 +49,7 @@ fn main() -> Result<(), Error> {
     debug!("application settings:\n{:#?}", &settings);
 
     // Metrics service.
+    graph::register_metrics(&metrics::PROM_REGISTRY)?;
     server::new(|| {
         App::new()
             .middleware(Logger::default())

--- a/policy-engine/src/metrics.rs
+++ b/policy-engine/src/metrics.rs
@@ -5,13 +5,23 @@ use futures::future;
 use futures::prelude::*;
 use prometheus;
 
+/// Common prefix for policy-engine metrics.
+static PE_METRICS_PREFIX: &str = "cincinnati_pe";
+
+lazy_static! {
+    /// Metrics registry.
+    pub(crate) static ref PROM_REGISTRY: prometheus::Registry =
+        prometheus::Registry::new_custom(Some(PE_METRICS_PREFIX.to_string()), None)
+            .expect("could not create metrics registry");
+}
+
 /// Serve metrics requests (Prometheus textual format).
 pub(crate) fn serve(
     _req: HttpRequest<()>,
 ) -> Box<Future<Item = HttpResponse, Error = failure::Error>> {
     use prometheus::Encoder;
 
-    let resp = future::ok(prometheus::gather())
+    let resp = future::ok(PROM_REGISTRY.gather())
         .and_then(|metrics| {
             let tenc = prometheus::TextEncoder::new();
             let mut buf = vec![];


### PR DESCRIPTION
This reworks metrics registration, introducing per-application namespaced registries.
In turn, this unlocks moving error counting into common library logic and introducing error-kind partitioning via labels.

/cc @steveeJ 
Ref: https://jira.coreos.com/browse/CIN-24