### PR TITLE
ci: add EPEL repo for yamllint

### DIFF
--- a/dist/openshift-release/Dockerfile.builder
+++ b/dist/openshift-release/Dockerfile.builder
@@ -1,5 +1,8 @@
 FROM centos:7 as builder
 
+# base: EPEL repo for extra tools
+RUN yum -y install epel-release
+
 # build: system utilities and libraries
 RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install openssl-devel


### PR DESCRIPTION
This adds the EPEL repo, as yamllint is not in the base Centos 7 one.

/cc @steveeJ 