### PR TITLE
dist/cincinnati: fix status port variable

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -132,7 +132,7 @@ objects:
                 "--service.path_prefix", "${PE_PATH_PREFIX}",
                 "--service.port", "${PE_PORT}",
                 "--status.address", "$(PE_METRICS_ADDRESS)",
-                "--status.port", "${PE_METRICS_PORT}",
+                "--status.port", "${PE_STATUS_PORT}",
                 "--upstream.cincinnati.url", "$(UPSTREAM)",
               ]
               ports:


### PR DESCRIPTION
This fixes a mismatch on the template parameter name (as seen failing in staging).

/cc @steveeJ @aditya-konarde