### PR TITLE
graph-builder: test cyclic metadata

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -38,6 +38,8 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::collections::HashMap;
 use std::{collections, fmt};
 
+pub use daggy::WouldCycle;
+
 pub const CONTENT_TYPE: &str = "application/json";
 const EXPECT_NODE_WEIGHT: &str = "all exisitng nodes to have a weight (release)";
 
@@ -94,7 +96,7 @@ impl<'a> Iterator for NextReleases<'a> {
 }
 
 #[derive(Debug, Clone)]
-struct Empty;
+pub struct Empty;
 
 impl Graph {
     pub fn add_release<R>(&mut self, release: R) -> Result<ReleaseId, Error>

--- a/graph-builder/tests/images/test-cyclic-public-manual-0.0.0
+++ b/graph-builder/tests/images/test-cyclic-public-manual-0.0.0
@@ -1,0 +1,1 @@
+test-private-manual-0.0.0

--- a/graph-builder/tests/images/test-cyclic-public-manual-0.0.1
+++ b/graph-builder/tests/images/test-cyclic-public-manual-0.0.1
@@ -1,0 +1,1 @@
+test-private-manual-0.0.1

--- a/graph-builder/tests/images/test-cyclic-public-manual-0.0.2/Dockerfile
+++ b/graph-builder/tests/images/test-cyclic-public-manual-0.0.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY release-metadata release-manifests/release-metadata

--- a/graph-builder/tests/images/test-cyclic-public-manual-0.0.2/release-metadata
+++ b/graph-builder/tests/images/test-cyclic-public-manual-0.0.2/release-metadata
@@ -1,6 +1,5 @@
 {
 	"kind": "cincinnati-metadata-v0",
-	"schema": 1,
 	"version": "0.0.2",
 	"previous": ["0.0.1"],
 	"next": ["0.0.1"],

--- a/graph-builder/tests/images/test-cyclic-public-manual-0.0.2/release-metadata
+++ b/graph-builder/tests/images/test-cyclic-public-manual-0.0.2/release-metadata
@@ -1,0 +1,10 @@
+{
+	"kind": "cincinnati-metadata-v0",
+	"schema": 1,
+	"version": "0.0.2",
+	"previous": ["0.0.1"],
+	"next": ["0.0.1"],
+	"metadata": {
+		"kind": "test"
+	}
+}

--- a/graph-builder/tests/images/test-private-manual-0.0.1/release-metadata
+++ b/graph-builder/tests/images/test-private-manual-0.0.1/release-metadata
@@ -1,6 +1,5 @@
 {
 	"kind": "cincinnati-metadata-v0",
-	"schema": 1,
 	"version": "0.0.1",
 	"previous": ["0.0.0"],
 	"metadata": {

--- a/graph-builder/tests/mod.rs
+++ b/graph-builder/tests/mod.rs
@@ -1,2 +1,5 @@
+#[macro_use]
+extern crate failure;
+
 #[cfg(feature = "test-net")]
 mod net;

--- a/graph-builder/tests/net/quay_io/mod.rs
+++ b/graph-builder/tests/net/quay_io/mod.rs
@@ -10,6 +10,9 @@ use self::graph_builder::release::{Metadata, MetadataKind::V0};
 use self::semver::Version;
 use failure::Fallible;
 use net::quay_io::cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_MANIFESTREF_KEY as MANIFESTREF_KEY;
+use net::quay_io::cincinnati::Empty;
+use net::quay_io::cincinnati::WouldCycle;
+use net::quay_io::graph_builder::graph::create_graph;
 use net::quay_io::graph_builder::registry::Registry;
 use std::collections::HashMap;
 
@@ -324,4 +327,37 @@ fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
     .iter()
     .map(|url| registry::Registry::try_from_str(url).unwrap())
     .for_each(test);
+}
+
+#[test]
+fn fetch_release_with_cyclic_metadata_fails() -> Fallible<()> {
+    init_logger();
+
+    let registry = Registry::try_from_str("quay.io").unwrap();
+    let repo = "redhat/openshift-cincinnati-test-cyclic-public-manual";
+
+    let mut cache = HashMap::new();
+    let (username, password) = (None, None);
+
+    let releases = fetch_releases(
+        &registry,
+        &repo,
+        username,
+        password,
+        &mut cache,
+        MANIFESTREF_KEY,
+    )
+    .expect("fetch_releases failed: ");
+
+    match create_graph(releases) {
+        Ok(_) => bail!("create_graph succeeded despite cyclic metadata"),
+        Err(err) => {
+            ensure!(
+                err.downcast_ref::<WouldCycle<Empty>>().is_some(),
+                "error {:#?} has wrong type",
+                err,
+            );
+            Ok(())
+        }
+    }
 }

--- a/graph-builder/tests/net/quay_io/mod.rs
+++ b/graph-builder/tests/net/quay_io/mod.rs
@@ -8,6 +8,7 @@ extern crate url;
 use self::graph_builder::registry::{self, fetch_releases, Release};
 use self::graph_builder::release::{Metadata, MetadataKind::V0};
 use self::semver::Version;
+use failure::Fallible;
 use net::quay_io::cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_MANIFESTREF_KEY as MANIFESTREF_KEY;
 use net::quay_io::graph_builder::registry::Registry;
 use std::collections::HashMap;


### PR DESCRIPTION
This test is expected to fail with the according to the Cincinnati specification and implementation, which make use of a directed acyclic graph.