### PR TITLE
policy-engine: add docstrings and enable missing_docs lint

### DIFF
--- a/policy-engine/src/config/cli.rs
+++ b/policy-engine/src/config/cli.rs
@@ -15,16 +15,19 @@ pub struct CliOptions {
     #[structopt(short = "c")]
     pub config_path: Option<String>,
 
+    // Status service options
     #[structopt(flatten)]
     pub service: options::ServiceOptions,
 
+    // Main service options
     #[structopt(flatten)]
     pub status: options::StatusOptions,
 
-    /// Fetcher method.
+    /// Upstream method
     #[structopt(long = "upstream.method")]
     pub upstream_method: Option<String>,
 
+    // Cincinnati upstream options
     #[structopt(flatten)]
     pub upstream_cincinnati: options::UpCincinnatiOptions,
 }

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -26,6 +26,7 @@ pub struct FileOptions {
 }
 
 impl FileOptions {
+    /// Parse a TOML configuration from path.
     pub fn read_filepath<P>(cfg_path: P) -> Fallible<Self>
     where
         P: AsRef<path::Path>,

--- a/policy-engine/src/config/options.rs
+++ b/policy-engine/src/config/options.rs
@@ -79,6 +79,7 @@ impl MergeOptions<Option<UpCincinnatiOptions>> for AppSettings {
     }
 }
 
+/// Parse a URI from a string.
 pub fn uri_from_str<S>(input: S) -> failure::Fallible<hyper::Uri>
 where
     S: AsRef<str>,
@@ -87,6 +88,7 @@ where
     Ok(uri)
 }
 
+/// Deserialize a URI from a string value.
 pub fn de_uri<'de, D>(deserializer: D) -> Result<Option<hyper::Uri>, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -1,5 +1,7 @@
 //! Cincinnati backend: policy-engine server.
 
+#![deny(missing_docs)]
+
 extern crate actix;
 extern crate actix_web;
 extern crate cincinnati;


### PR DESCRIPTION
This adds all missing docstrings and enable a lint to catch missing
ones in the future.

Ref: https://github.com/openshift/cincinnati/pull/92#discussion_r279714192
/cc @steveeJ 