### PR TITLE
commons: rename error metrics

### DIFF
--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -5,7 +5,7 @@ use prometheus::{IntCounterVec, Opts, Registry};
 
 lazy_static! {
     static ref V1_GRAPH_ERRORS: IntCounterVec = IntCounterVec::new(
-        Opts::new("v1_graph_errors_total", "Errors on /v1/graph"),
+        Opts::new("v1_graph_response_errors_total", "Error responses on /v1/graph"),
         &["kind"]
     )
     .unwrap();


### PR DESCRIPTION
This renames the error counter in order to make more explicit that
it counts non-positive HTTP responses.

/cc @steveeJ @aditya-konarde 