### PR TITLE
*: Move from com.openshift.upgrades to io.openshift.upgrades

### DIFF
--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -7,7 +7,7 @@ use plugins::{
     InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
 };
 
-static DEFAULT_KEY_FILTER: &str = "com.openshift.upgrades.graph";
+static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 static DEFAULT_CHANNEL_KEY: &str = "release.channels";
 
 #[derive(Clone, Debug, Deserialize, SmartDefault)]

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -7,7 +7,7 @@ use plugins::{
 };
 use ReleaseId;
 
-static DEFAULT_KEY_FILTER: &str = "com.openshift.upgrades.graph";
+static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 
 #[derive(Clone, Debug, Deserialize, SmartDefault)]
 #[serde(default)]

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -16,8 +16,8 @@ use plugins::{
 use std::path::PathBuf;
 use ReleaseId;
 
-pub static DEFAULT_QUAY_LABEL_FILTER: &str = "com.openshift.upgrades.graph";
-pub static DEFAULT_QUAY_MANIFESTREF_KEY: &str = "com.openshift.upgrades.graph.release.manifestref";
+pub static DEFAULT_QUAY_LABEL_FILTER: &str = "io.openshift.upgrades.graph";
+pub static DEFAULT_QUAY_MANIFESTREF_KEY: &str = "io.openshift.upgrades.graph.release.manifestref";
 pub static DEFAULT_QUAY_REPOSITORY: &str = "openshift";
 
 /// Plugin settings.

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -5,7 +5,7 @@ use plugins::{
     InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
 };
 
-static DEFAULT_KEY_FILTER: &str = "com.openshift.upgrades.graph";
+static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 
 #[derive(Clone, Debug, Deserialize, SmartDefault)]
 #[serde(default)]

--- a/docs/user/graph-builder-configuration.md
+++ b/docs/user/graph-builder-configuration.md
@@ -19,7 +19,7 @@ TOML configuration currently supports the following sections and options:
    - `method` (string): upstream provider selector. Allowed values: "registry". Default: "registry".
    - `registry` (section): configuration for Docker-v2 registry provider.
      - `credentials_path` (string): path to file containing registry credentials, in "dockercfg" format. Default: unset.
-     - `manifestref_key` (string): metadata key where to record the manifest-reference. Default: "com.openshift.upgrades.graph.release.manifestref".
+     - `manifestref_key` (string): metadata key where to record the manifest-reference. Default: "io.openshift.upgrades.graph.release.manifestref".
      - `pause_secs` (unsigned integer): pause between repository scrapes, in seconds. Default: 30.
      - `repository` (string): target image in the registry. Default: "openshift".
      - `url` (string): URL for the registry. Default: "http://localhost:5000". 

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -21,7 +21,7 @@ pub struct AppSettings {
     pub mandatory_client_parameters: HashSet<String>,
 
     /// Metadata key where to record the manifest-reference.
-    #[default("com.openshift.upgrades.graph.release.manifestref")]
+    #[default("io.openshift.upgrades.graph.release.manifestref")]
     pub manifestref_key: String,
 
     /// Endpoints namespace for the main service.

--- a/graph-builder/tests/net/quay_io/mod.rs
+++ b/graph-builder/tests/net/quay_io/mod.rs
@@ -205,7 +205,7 @@ fn expected_releases_labels_test_annoated(registry: &Registry, repo: &str) -> Ve
             [
                 (String::from("kind"), String::from("test")),
                 (
-                    String::from("com.openshift.upgrades.graph.previous.remove"),
+                    String::from("io.openshift.upgrades.graph.previous.remove"),
                     String::from("0.0.0"),
                 ),
             ]
@@ -216,7 +216,7 @@ fn expected_releases_labels_test_annoated(registry: &Registry, repo: &str) -> Ve
         (
             2,
             [(
-                String::from("com.openshift.upgrades.graph.release.remove"),
+                String::from("io.openshift.upgrades.graph.release.remove"),
                 String::from("true"),
             )]
             .iter()
@@ -226,7 +226,7 @@ fn expected_releases_labels_test_annoated(registry: &Registry, repo: &str) -> Ve
         (
             3,
             [(
-                String::from("com.openshift.upgrades.graph.previous.add"),
+                String::from("io.openshift.upgrades.graph.previous.add"),
                 String::from("0.0.1,0.0.0"),
             )]
             .iter()

--- a/quay/src/v1/manifest.rs
+++ b/quay/src/v1/manifest.rs
@@ -18,14 +18,14 @@ use reqwest::Method;
 ///       "value": "0.0.1",
 ///       "media_type": "text/plain",
 ///       "id": "03e8f6db-4669-42d8-a4ec-2d2d2785b0b7",
-///       "key": "com.openshift.upgrades.graph.edge-previous-add",
+///       "key": "io.openshift.upgrades.graph.edge-previous-add",
 ///       "source_type": "api"
 ///     },
 ///     {
 ///       "value": "0.0.0",
 ///       "media_type": "text/plain",
 ///       "id": "b5e17080-08ce-4a98-a397-6869a0e16dbe",
-///       "key": "com.openshift.upgrades.graph.edge-previous-add",
+///       "key": "io.openshift.upgrades.graph.edge-previous-add",
 ///       "source_type": "api"
 ///     }
 ///   ]

--- a/quay/tests/net/mod.rs
+++ b/quay/tests/net/mod.rs
@@ -49,7 +49,7 @@ fn test_public_get_labels() {
     let fetch_labels = client.get_labels(
         repo.to_string(),
         digest,
-        Some("com.openshift.upgrades.graph".to_string()),
+        Some("io.openshift.upgrades.graph".to_string()),
     );
     let labels = rt.block_on(fetch_labels).unwrap();
     assert_eq!(
@@ -58,7 +58,7 @@ fn test_public_get_labels() {
             .map(Into::into)
             .collect::<Vec<(String, String)>>(),
         vec![(
-            "com.openshift.upgrades.graph.previous.remove".to_string(),
+            "io.openshift.upgrades.graph.previous.remove".to_string(),
             "0.0.0".to_string()
         )]
     );


### PR DESCRIPTION
Generated with:

```console
$ sed -i 's/com\.openshift\.upgrades/io.openshift.upgrades/g' $(git grep -l 'com\.openshift\.upgrades')
```

There are currently no known consumers of this metadata, so move to the right namespace before we grow some.  The cluster-version operator is the only in-cluster graph consumer, and it isn't using anything under this namespace:

```console
cluster-version-operator$ git describe
v1.0.0-24-g33079c7
cluster-version-operator$ git grep 'com\.openshift\.upgrades'
...no hits...
```

CC @smarterclayton