### PR TITLE
policy-engine && graph-builder: fix and switch to 2018 edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
 **/*.swp
+.idea

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -525,7 +525,7 @@ impl From<Graph> for plugins::interface::Graph {
     fn from(graph: Graph) -> Self {
         use daggy::petgraph::visit::IntoNeighborsDirected;
         use daggy::petgraph::Direction;
-        use Release::{Abstract, Concrete};
+        use crate::Release::{Abstract, Concrete};
 
         let mut nodes_converted: Vec<plugins::interface::Graph_Node> =
             std::vec::Vec::with_capacity(graph.dag.node_count());

--- a/cincinnati/src/plugins/external/web.rs
+++ b/cincinnati/src/plugins/external/web.rs
@@ -16,8 +16,8 @@ pub struct _WebPluginClient {
 mod tests {
     use crate as cincinnati;
     use failure::Fallible;
-    use plugins::{interface, ExternalIO, ExternalPlugin, InternalIO, PluginResult};
-    use tests::generate_graph;
+    use crate::plugins::{interface, ExternalIO, ExternalPlugin, InternalIO, PluginResult};
+    use crate::tests::generate_graph;
     use try_from::TryInto;
 
     struct DummyWebClient {

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -3,7 +3,7 @@
 //! and the value must match the regex specified at CHANNEL_VALIDATION_REGEX_STR
 
 use failure::Fallible;
-use plugins::{
+use crate::plugins::{
     InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
 };
 

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -2,10 +2,10 @@
 
 use crate as cincinnati;
 use failure::Fallible;
-use plugins::{
+use crate::plugins::{
     InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
 };
-use ReleaseId;
+use crate::ReleaseId;
 
 static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -10,11 +10,11 @@ extern crate tokio;
 
 use self::futures::future::Future;
 use failure::{Fallible, ResultExt};
-use plugins::{
+use crate::plugins::{
     InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
 };
 use std::path::PathBuf;
-use ReleaseId;
+use crate::ReleaseId;
 
 pub static DEFAULT_QUAY_LABEL_FILTER: &str = "io.openshift.upgrades.graph";
 pub static DEFAULT_QUAY_MANIFESTREF_KEY: &str = "io.openshift.upgrades.graph.release.manifestref";

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -1,7 +1,7 @@
 //! This plugin removes releases according to its metadata
 
 use failure::Fallible;
-use plugins::{
+use crate::plugins::{
     InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
 };
 

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -12,7 +12,7 @@ pub mod internal;
 pub use self::catalog::{deserialize_config, PluginSettings};
 use crate as cincinnati;
 use failure::{Error, Fallible, ResultExt};
-use plugins::interface::{PluginError, PluginExchange};
+use crate::plugins::interface::{PluginError, PluginExchange};
 use std::collections::HashMap;
 use try_from::{TryFrom, TryInto};
 
@@ -61,7 +61,7 @@ where
 
 /// Trait to be implemented by internal plugins with their native IO type
 pub trait InternalPlugin {
-    fn run_internal(&self, InternalIO) -> Fallible<InternalIO>;
+    fn run_internal(&self, input: InternalIO) -> Fallible<InternalIO>;
 }
 
 /// Trait to be implemented by external plugins with its native IO type
@@ -69,7 +69,7 @@ pub trait InternalPlugin {
 /// There's a gotcha in that this type can't be used to access the information
 /// directly as it's merely bytes.
 pub trait ExternalPlugin {
-    fn run_external(&self, ExternalIO) -> Fallible<ExternalIO>;
+    fn run_external(&self, input: ExternalIO) -> Fallible<ExternalIO>;
 }
 
 /// Dummy converter to satisfy the Trait
@@ -321,8 +321,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use plugins::Plugin;
-    use tests::generate_graph;
+    use crate::plugins::Plugin;
+    use crate::tests::generate_graph;
 
     #[test]
     fn convert_externalio_pluginresult() {

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -14,12 +14,12 @@ extern crate serde_json;
 extern crate url;
 
 mod config;
-pub use config::MergeOptions;
+pub use crate::config::MergeOptions;
 
 pub mod de;
 
 mod errors;
-pub use errors::{register_metrics, GraphError};
+pub use crate::errors::{register_metrics, GraphError};
 
 use actix_web::http::header;
 use std::collections::HashSet;

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -2,6 +2,7 @@
 name = "graph-builder"
 version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
+edition = "2018"
 
 [dependencies]
 actix = "^0.7.6"

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -15,11 +15,11 @@
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use cincinnati::{plugins, AbstractRelease, Graph, Release, CONTENT_TYPE};
 use commons::GraphError;
-use config;
+use crate::config;
 use failure::{Error, Fallible};
 use prometheus::{self, Counter, IntGauge};
 pub use parking_lot::RwLock;
-use registry::{self, Registry};
+use crate::registry::{self, Registry};
 use serde_json;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -16,7 +16,7 @@ use cincinnati;
 use failure::{Error, Fallible, ResultExt};
 use flate2::read::GzDecoder;
 use futures::prelude::*;
-use release::Metadata;
+use crate::release::Metadata;
 use serde_json;
 use std::collections::HashMap;
 use std::fs::File;

--- a/graph-builder/src/status.rs
+++ b/graph-builder/src/status.rs
@@ -3,7 +3,7 @@
 use actix_web::{HttpRequest, HttpResponse};
 use futures::future;
 use futures::prelude::*;
-use graph::State;
+use crate::graph::State;
 use prometheus;
 
 /// Common prefix for graph-builder metrics.

--- a/graph-builder/tests/net/quay_io/mod.rs
+++ b/graph-builder/tests/net/quay_io/mod.rs
@@ -9,11 +9,11 @@ use self::graph_builder::registry::{self, fetch_releases, Release};
 use self::graph_builder::release::{Metadata, MetadataKind::V0};
 use self::semver::Version;
 use failure::Fallible;
-use net::quay_io::cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_MANIFESTREF_KEY as MANIFESTREF_KEY;
-use net::quay_io::cincinnati::Empty;
-use net::quay_io::cincinnati::WouldCycle;
-use net::quay_io::graph_builder::graph::create_graph;
-use net::quay_io::graph_builder::registry::Registry;
+use self::cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_MANIFESTREF_KEY as MANIFESTREF_KEY;
+use self::cincinnati::Empty;
+use self::cincinnati::WouldCycle;
+use self::graph_builder::graph::create_graph;
+use self::graph_builder::registry::Registry;
 use std::collections::HashMap;
 
 #[cfg(feature = "test-net-private")]

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "policy-engine"
 version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
+edition = "2018"
 
 [dependencies]
 actix = "^0.7.6"

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -12,7 +12,7 @@ use futures::{future, Future, Stream};
 use hyper::{Body, Client, Request};
 use prometheus::{Counter, Histogram, HistogramOpts, Registry};
 use serde_json;
-use AppState;
+use crate::AppState;
 
 lazy_static! {
     static ref HTTP_UPSTREAM_REQS: Counter = Counter::new(

--- a/policy-engine/src/openapi.rs
+++ b/policy-engine/src/openapi.rs
@@ -1,7 +1,7 @@
 use actix_web::{HttpRequest, HttpResponse};
 use openapiv3::{OpenAPI, ReferenceOr};
 use std::collections::HashSet;
-use AppState;
+use crate::AppState;
 
 /// Template for policy-engine OpenAPIv3 document.
 const SPEC: &str = include_str!("openapiv3.json");

--- a/quay/src/v1/mod.rs
+++ b/quay/src/v1/mod.rs
@@ -1,5 +1,5 @@
 use failure::Fallible;
-use reqwest::{self, async};
+use reqwest;
 
 mod manifest;
 
@@ -14,7 +14,7 @@ pub struct Client {
     /// Base URL for API endpoint.
     api_base: reqwest::Url,
     /// Asynchronous reqwest client.
-    hclient: async::Client,
+    hclient: reqwest::async::Client,
     /// Authentication token.
     token: Option<String>,
 }
@@ -30,7 +30,7 @@ impl Client {
         &self,
         method: reqwest::Method,
         url_suffix: S,
-    ) -> Fallible<async::RequestBuilder> {
+    ) -> Fallible<reqwest::async::RequestBuilder> {
         let url = self.api_base.clone().join(url_suffix.as_ref())?;
         let builder = {
             let plain = self.hclient.request(method, url);
@@ -50,13 +50,13 @@ impl Client {
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
     api_base: Option<String>,
-    hclient: Option<async::Client>,
+    hclient: Option<reqwest::async::Client>,
     token: Option<String>,
 }
 
 impl ClientBuilder {
     /// Set (or reset) the HTTP client to use.
-    pub fn http_client(self, hclient: Option<async::Client>) -> Self {
+    pub fn http_client(self, hclient: Option<reqwest::async::Client>) -> Self {
         let mut builder = self;
         builder.hclient = hclient;
         builder
@@ -80,7 +80,7 @@ impl ClientBuilder {
     pub fn build(self) -> Fallible<Client> {
         let hclient = match self.hclient {
             Some(client) => client,
-            None => async::ClientBuilder::new().build()?,
+            None => reqwest::async::ClientBuilder::new().build()?,
         };
         let api_base = match self.api_base {
             Some(ref base) => reqwest::Url::parse(base)?,


### PR DESCRIPTION
https://jira.coreos.com/browse/CIN-32
https://jira.coreos.com/browse/CIN-33

What've been doing just basically follow this doc: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html