### PR TITLE
hack/graph: Drop URI argument from the example

### DIFF
--- a/hack/graph.sh
+++ b/hack/graph.sh
@@ -2,11 +2,11 @@
 #
 # Usage:
 #
-#   cat cincinnati.json | graph.sh [URI] >graph.dot
+#   cat cincinnati.json | graph.sh >graph.dot
 #
 # For example:
 #
-#   curl -sH 'Accept:application/json' 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=prerelease-4.1' | graph.sh https://cincinnati.example.org/your/graph | dot -Tsvg >graph.svg
+#   curl -sH 'Accept:application/json' 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=prerelease-4.1' | graph.sh | dot -Tsvg >graph.svg
 set -e
 
 JQ_SCRIPT="$(cat <<EOF


### PR DESCRIPTION
I'd forgotten to remove these while rerolling 7ec4253c3f (#108) to read the graph from stdin.