### PR TITLE
add ghp-updater.sh script for generate doc pages to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 **/*.rs.bk
 **/*.swp
 .idea
+
+docs/release

--- a/dist/commons.sh
+++ b/dist/commons.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 IMAGE_BUILD="${IMAGE_BUILD:-local/cincinnati-build:latest}"
-PROJECT_PARENT_DIR="${ABSOLUTE_PATH:?need ABSOLUTE_PATH set}/../"
+PROJECT_PARENT_DIR="${ABSOLUTE_PATH:?need ABSOLUTE_PATH set}/.."
 GIT_REV="$(git rev-parse --short=7 HEAD)"
 BUILD_VOLUME_CARGO_GIT="build_cargo_git_${GIT_REV}"
 BUILD_VOLUME_CARGO_REGISTRY="build_cargo_registry_${GIT_REV}"

--- a/dist/ghp_updater.sh
+++ b/dist/ghp_updater.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${ABSOLUTE_PATH}/commons.sh"
+DOC_OUTPUT_DIR="${PROJECT_PARENT_DIR}/docs"
+GH_REPO="shiywang/cincinnati"
+FULL_REPO="git@github.com:${GH_REPO}.git"
+
+
+if [[ -z "${CINCINNATI_GITHUB_PUSH_TOKEN_PATH}" ]]; then
+	echo 'No CINCINNATI_GITHUB_PUSH_TOKEN_PATH found, do not push to the remote repo'
+else
+	ssh-add ${CINCINNATI_GITHUB_PUSH_TOKEN_PATH}
+	cargo doc --no-deps --all --all-features --target-dir=${DOC_OUTPUT_DIR} --release
+	echo '<meta http-equiv=refresh content=0;url=doc/cincinnati/index.html>' > ${DOC_OUTPUT_DIR}/index.html
+	# commit and push changes
+	git add -A
+	git commit -m "GH-Pages update by openshift-merge-robot"
+	git push origin master
+fi


### PR DESCRIPTION

**1. about our index.html**
I take (project rust-random) https://github.com/rust-random/rand/blob/master/.travis.yml#L158-L161 and
https://github.com/huonw/travis-cargo/blob/master/travis_cargo.py#L145 
as a reference for generate our `index.html` 

`maybe we could use docstrings in the top-level crate for this?` since I do not quite understand the alternative way you suggested @steveeJ 

**2. about using travis or prow to push to gh-pages branch** 
if I added `ghp-updater.sh` to origin/release prow job, Does that ci-boot has permission to push to gh-pages by default ?