### PR TITLE
policy-engine/graph: log served errors

### DIFF
--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -126,6 +126,15 @@ pub(crate) fn index(
         })
         .then(move |r| {
             timer.observe_duration();
+
+            if let Err(e) = &r {
+                error!(
+                    "Error serving request with parameters '{:?}': {}",
+                    req.query(),
+                    e
+                );
+            }
+
             r
         });
     Box::new(serve)


### PR DESCRIPTION
This might help debugging problematic requests until we have a better
way of tracing them.