### PR TITLE
update README.md remove file doesnt exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The *dist/* directory contains various CI/CD related files.
 For details please see [github.com/openshift/release/(...)/openshift-cincinnati-master.yaml][1].
 
 #### App-SRE
-* Uses *dist/build/Dockerfile* as a build container
+* Uses *dist/openshift-release/Dockerfile.builder* as a build container
 * Runs `dist/build_deploy.sh` for successful merges to the *master* branch and pushes the result to the staging environment *(URL is not yet publicly available)*
 
 [1]: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml


### PR DESCRIPTION
`dist/build/Dockerfile` is no longer exist, so we might intent to use `dist/openshift-release/Dockerfile.builder` ?