### PR TITLE
cincinnati/plugins: require and derive Debug on plugins

### DIFF
--- a/cincinnati/src/plugins/external/web.rs
+++ b/cincinnati/src/plugins/external/web.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use url::Url;
 
 /// Struct for implementing the client side of a web plugin
+#[derive(Debug)]
 pub struct _WebPluginClient {
     pub url: Url,
     pub timeout: std::time::Duration,
@@ -22,6 +23,12 @@ mod tests {
 
     struct DummyWebClient {
         callback: Box<Fn(interface::PluginExchange) -> PluginResult>,
+    }
+
+    impl std::fmt::Debug for DummyWebClient {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "DummyWebClient")
+        }
     }
 
     impl ExternalPlugin for DummyWebClient {

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -41,6 +41,7 @@ struct QuayMetadataSettings {
 }
 
 /// Metadata fetcher for quay.io API.
+#[derive(Debug)]
 pub struct QuayMetadataFetchPlugin {
     client: quay::v1::Client,
     repo: String,

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -14,9 +14,11 @@ use crate as cincinnati;
 use crate::plugins::interface::{PluginError, PluginExchange};
 use failure::{Error, Fallible, ResultExt};
 use std::collections::HashMap;
+use std::fmt::Debug;
 use try_from::{TryFrom, TryInto};
 
 /// Enum for the two IO variants used by InternalPlugin and ExternalPlugin respectively
+#[derive(Debug)]
 pub enum PluginIO {
     InternalIO(InternalIO),
     ExternalIO(ExternalIO),
@@ -54,13 +56,17 @@ pub struct ExternalIO {
 /// Trait which fronts InternalPlugin and ExternalPlugin, allowing their trait objects to live in the same collection
 pub trait Plugin<T>
 where
+    Self: Debug,
     T: TryInto<PluginIO> + TryFrom<PluginIO>,
 {
     fn run(&self, t: T) -> Fallible<T>;
 }
 
 /// Trait to be implemented by internal plugins with their native IO type
-pub trait InternalPlugin {
+pub trait InternalPlugin
+where
+    Self: Debug,
+{
     fn run_internal(&self, input: InternalIO) -> Fallible<InternalIO>;
 }
 
@@ -68,7 +74,10 @@ pub trait InternalPlugin {
 ///
 /// There's a gotcha in that this type can't be used to access the information
 /// directly as it's merely bytes.
-pub trait ExternalPlugin {
+pub trait ExternalPlugin
+where
+    Self: Debug,
+{
     fn run_external(&self, input: ExternalIO) -> Fallible<ExternalIO>;
 }
 
@@ -262,9 +271,11 @@ impl TryFrom<PluginIO> for ExternalIO {
 }
 
 /// Wrapper struct for a universal implementation of Plugin<PluginIO> for all InternalPlugin implementors
+#[derive(Debug)]
 pub struct InternalPluginWrapper<T>(pub T);
 
 /// Wrapper struct for a universal implementation of Plugin<PluginIO> for all ExternalPlugin implementors
+#[derive(Debug)]
 pub struct ExternalPluginWrapper<T>(pub T);
 
 /// This implementation allows the process function to run ipmlementors of
@@ -359,6 +370,7 @@ mod tests {
         assert_eq!(input_internal, output_internal);
     }
 
+    #[derive(Debug)]
     struct TestInternalPlugin {}
     impl InternalPlugin for TestInternalPlugin {
         fn run_internal(&self, io: InternalIO) -> Fallible<InternalIO> {
@@ -366,6 +378,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
     struct TestExternalPlugin {}
     impl ExternalPlugin for TestExternalPlugin {
         fn run_external(&self, io: ExternalIO) -> Fallible<ExternalIO> {


### PR DESCRIPTION
This enforces a top-level Debug bound on Plugin, and adds all relevant
derive annotations.
The goal of this is to ease embedding and composing plugins into
other owning structures.

/cc @steveeJ 