### PR TITLE
policy-engine: add TOML configuration for policy plugins 

### DIFF
--- a/cincinnati/src/plugins/catalog.rs
+++ b/cincinnati/src/plugins/catalog.rs
@@ -7,7 +7,7 @@ use super::internal::channel_filter::ChannelFilterPlugin;
 use super::internal::edge_add_remove::EdgeAddRemovePlugin;
 use super::internal::metadata_fetch_quay::QuayMetadataFetchPlugin;
 use super::internal::node_remove::NodeRemovePlugin;
-use super::{Plugin, PluginIO};
+use crate::plugins::BoxedPlugin;
 use failure::Fallible;
 use std::fmt::Debug;
 
@@ -17,7 +17,7 @@ static CONFIG_PLUGIN_NAME_KEY: &str = "name";
 /// Settings for a plugin.
 pub trait PluginSettings: Debug + Send {
     /// Build the corresponding plugin for this configuration.
-    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>>;
+    fn build_plugin(&self) -> Fallible<BoxedPlugin>;
 }
 
 /// Validate configuration for a plugin and fill in defaults.

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -3,7 +3,7 @@
 //! and the value must match the regex specified at CHANNEL_VALIDATION_REGEX_STR
 
 use crate::plugins::{
-    InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
+    BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
 };
 use failure::Fallible;
 
@@ -21,7 +21,7 @@ pub struct ChannelFilterPlugin {
 }
 
 impl PluginSettings for ChannelFilterPlugin {
-    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>> {
+    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
         Ok(Box::new(InternalPluginWrapper(self.clone())))
     }
 }

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -2,7 +2,7 @@
 
 use crate as cincinnati;
 use crate::plugins::{
-    InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
+    BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
 };
 use crate::ReleaseId;
 use failure::Fallible;
@@ -33,7 +33,7 @@ impl InternalPlugin for EdgeAddRemovePlugin {
 }
 
 impl PluginSettings for EdgeAddRemovePlugin {
-    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>> {
+    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
         Ok(Box::new(InternalPluginWrapper(self.clone())))
     }
 }

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -10,7 +10,7 @@ extern crate tokio;
 
 use self::futures::future::Future;
 use crate::plugins::{
-    InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
+    BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
 };
 use crate::ReleaseId;
 use failure::{Fallible, ResultExt};
@@ -50,7 +50,7 @@ pub struct QuayMetadataFetchPlugin {
 }
 
 impl PluginSettings for QuayMetadataSettings {
-    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>> {
+    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
         let cfg = self.clone();
         let plugin = QuayMetadataFetchPlugin::try_new(
             cfg.repository,

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -1,7 +1,7 @@
 //! This plugin removes releases according to its metadata
 
 use crate::plugins::{
-    InternalIO, InternalPlugin, InternalPluginWrapper, Plugin, PluginIO, PluginSettings,
+    BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
 };
 use failure::Fallible;
 
@@ -15,7 +15,7 @@ pub struct NodeRemovePlugin {
 }
 
 impl PluginSettings for NodeRemovePlugin {
-    fn build_plugin(&self) -> Fallible<Box<Plugin<PluginIO>>> {
+    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
         Ok(Box::new(InternalPluginWrapper(self.clone())))
     }
 }

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -17,6 +17,18 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use try_from::{TryFrom, TryInto};
 
+/// Type for storing policy plugins in applications.
+pub type BoxedPlugin = Box<Plugin<PluginIO> + Sync + Send>;
+
+// NOTE(lucab): this abuses `Debug`, because `PartialEq` is not object-safe and
+// thus cannot be required on the underlying trait. It is a crude hack, but
+// only meant to be used by test assertions.
+impl PartialEq<BoxedPlugin> for BoxedPlugin {
+    fn eq(&self, other: &Self) -> bool {
+        format!("{:?}", self) == format!("{:?}", other)
+    }
+}
+
 /// Enum for the two IO variants used by InternalPlugin and ExternalPlugin respectively
 #[derive(Debug)]
 pub enum PluginIO {

--- a/commons/src/config.rs
+++ b/commons/src/config.rs
@@ -13,12 +13,12 @@ macro_rules! assign_if_some {
     }};
 }
 
-/// Merge configuration options into runtime settings.
+/// Try to merge configuration options into runtime settings.
 ///
-/// This consumes a generic configuration object, merging its options
+/// This consumes a generic configuration object, trying to merge its options
 /// into runtime settings. It only overlays populated values from config,
 /// leaving unset ones preserved as-is from existing settings.
 pub trait MergeOptions<T> {
     /// MergeOptions values from `options` into current settings.
-    fn merge(&mut self, options: T);
+    fn try_merge(&mut self, options: T) -> failure::Fallible<()>;
 }

--- a/graph-builder/src/config/file.rs
+++ b/graph-builder/src/config/file.rs
@@ -48,13 +48,14 @@ impl FileOptions {
 }
 
 impl MergeOptions<Option<FileOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<FileOptions>) {
+    fn try_merge(&mut self, opts: Option<FileOptions>) -> Fallible<()>{
         if let Some(file) = opts {
             assign_if_some!(self.verbosity, file.verbosity);
-            self.merge(file.service);
-            self.merge(file.status);
-            self.merge(file.upstream);
+            self.try_merge(file.service)?;
+            self.try_merge(file.status)?;
+            self.try_merge(file.upstream)?;
         }
+        Ok(())
     }
 }
 
@@ -69,10 +70,11 @@ pub struct UpstreamOptions {
 }
 
 impl MergeOptions<Option<UpstreamOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<UpstreamOptions>) {
+    fn try_merge(&mut self, opts: Option<UpstreamOptions>) -> Fallible<()> {
         if let Some(upstream) = opts {
-            self.merge(upstream.registry);
+            self.try_merge(upstream.registry)?;
         }
+        Ok(())
     }
 }
 
@@ -105,7 +107,7 @@ mod tests {
         let toml_input = "status.port = 2222";
         let file_opts: FileOptions = toml::from_str(toml_input).unwrap();
 
-        settings.merge(Some(file_opts));
+        settings.try_merge(Some(file_opts)).unwrap();
         assert_eq!(settings.status_port, 2222);
     }
 

--- a/graph-builder/src/config/options.rs
+++ b/graph-builder/src/config/options.rs
@@ -2,6 +2,7 @@
 
 use super::AppSettings;
 use commons::{parse_params_set, parse_path_prefix, MergeOptions};
+use failure::Fallible;
 use std::collections::HashSet;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -77,7 +78,7 @@ pub struct DockerRegistryOptions {
 }
 
 impl MergeOptions<Option<ServiceOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<ServiceOptions>) {
+    fn try_merge(&mut self, opts: Option<ServiceOptions>) -> Fallible<()> {
         if let Some(service) = opts {
             assign_if_some!(self.address, service.address);
             assign_if_some!(self.port, service.port);
@@ -86,20 +87,22 @@ impl MergeOptions<Option<ServiceOptions>> for AppSettings {
                 self.mandatory_client_parameters.extend(params);
             }
         }
+        Ok(())
     }
 }
 
 impl MergeOptions<Option<StatusOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<StatusOptions>) {
+    fn try_merge(&mut self, opts: Option<StatusOptions>) -> Fallible<()> {
         if let Some(status) = opts {
             assign_if_some!(self.status_address, status.address);
             assign_if_some!(self.status_port, status.port);
         }
+        Ok(())
     }
 }
 
 impl MergeOptions<Option<DockerRegistryOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<DockerRegistryOptions>) {
+    fn try_merge(&mut self, opts: Option<DockerRegistryOptions>) -> Fallible<()> {
         if let Some(registry) = opts {
             assign_if_some!(self.pause_secs, registry.pause_secs);
             assign_if_some!(self.registry, registry.url);
@@ -107,6 +110,7 @@ impl MergeOptions<Option<DockerRegistryOptions>> for AppSettings {
             assign_if_some!(self.credentials_path, registry.credentials_path);
             assign_if_some!(self.manifestref_key, registry.manifestref_key);
         }
+        Ok(())
     }
 }
 

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -76,8 +76,8 @@ impl AppSettings {
 
         // Combine options into a single config.
         let mut cfg = defaults;
-        cfg.merge(cli_opts);
-        cfg.merge(file_opts);
+        cfg.try_merge(cli_opts)?;
+        cfg.try_merge(file_opts)?;
 
         // Validate and convert to settings.
         Self::try_validate(cfg)

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -49,13 +49,14 @@ impl FileOptions {
 }
 
 impl MergeOptions<Option<FileOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<FileOptions>) {
+    fn try_merge(&mut self, opts: Option<FileOptions>) -> failure::Fallible<()> {
         if let Some(file) = opts {
             assign_if_some!(self.verbosity, file.verbosity);
-            self.merge(file.service);
-            self.merge(file.status);
-            self.merge(file.upstream);
+            self.try_merge(file.service)?;
+            self.try_merge(file.status)?;
+            self.try_merge(file.upstream)?;
         }
+        Ok(())
     }
 }
 
@@ -70,10 +71,11 @@ pub struct UpstreamOptions {
 }
 
 impl MergeOptions<Option<UpstreamOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<UpstreamOptions>) {
+    fn try_merge(&mut self, opts: Option<UpstreamOptions>) -> Fallible<()> {
         if let Some(upstream) = opts {
-            self.merge(upstream.cincinnati);
+            self.try_merge(upstream.cincinnati)?;
         }
+        Ok(())
     }
 }
 
@@ -99,7 +101,7 @@ mod tests {
         let toml_input = "status.port = 2222";
         let file_opts: FileOptions = toml::from_str(toml_input).unwrap();
 
-        settings.merge(Some(file_opts));
+        settings.try_merge(Some(file_opts)).unwrap();
         assert_eq!(settings.status_port, 2222);
     }
 

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -18,6 +18,9 @@ pub struct FileOptions {
     /// Upstream options.
     pub upstream: Option<UpstreamOptions>,
 
+    /// Policy plugins options.
+    pub policy: Option<Vec<toml::Value>>,
+
     /// Web frontend options.
     pub service: Option<options::ServiceOptions>,
 
@@ -52,9 +55,22 @@ impl MergeOptions<Option<FileOptions>> for AppSettings {
     fn try_merge(&mut self, opts: Option<FileOptions>) -> failure::Fallible<()> {
         if let Some(file) = opts {
             assign_if_some!(self.verbosity, file.verbosity);
+            self.try_merge(file.policy)?;
             self.try_merge(file.service)?;
             self.try_merge(file.status)?;
             self.try_merge(file.upstream)?;
+        }
+        Ok(())
+    }
+}
+
+impl MergeOptions<Option<Vec<toml::Value>>> for AppSettings {
+    fn try_merge(&mut self, opts: Option<Vec<toml::Value>>) -> Fallible<()> {
+        if let Some(policies) = opts {
+            for conf in policies {
+                let plugin = cincinnati::plugins::deserialize_config(conf)?;
+                self.policies.push(plugin);
+            }
         }
         Ok(())
     }
@@ -81,7 +97,9 @@ impl MergeOptions<Option<UpstreamOptions>> for AppSettings {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::FileOptions;
+    use crate::config::AppSettings;
+    use commons::MergeOptions;
 
     #[test]
     fn toml_basic() {
@@ -143,5 +161,41 @@ mod tests {
         let ups = opts.upstream.unwrap().cincinnati.unwrap();
         let ups_url = ups.url.unwrap();
         assert_eq!(ups_url, input_url);
+    }
+
+    #[test]
+    fn toml_basic_policy() {
+        use cincinnati::plugins::internal::channel_filter::ChannelFilterPlugin;
+        use cincinnati::plugins::{BoxedPlugin, InternalPluginWrapper};
+
+        let expected: Vec<BoxedPlugin> =
+            vec![Box::new(InternalPluginWrapper(ChannelFilterPlugin {
+                key_prefix: String::from("io.openshift.upgrades.graph"),
+                key_suffix: String::from("release.channels"),
+            }))];
+        let mut settings = AppSettings::default();
+
+        let opts = {
+            use std::io::Write;
+
+            let sample_config = r#"
+                [[policy]]
+                name = "channel-filter"
+                key_prefix = "io.openshift.upgrades.graph"
+                key_suffix = "release.channels"
+            "#;
+
+            let mut config_file = tempfile::NamedTempFile::new().unwrap();
+            config_file
+                .write_fmt(format_args!("{}", sample_config))
+                .unwrap();
+            crate::config::FileOptions::read_filepath(config_file.path()).unwrap()
+        };
+        assert!(opts.policy.is_some());
+        settings.try_merge(Some(opts)).unwrap();
+        assert_eq!(settings.policies.len(), 1);
+
+        let policies = settings.policy_plugins().unwrap();
+        assert_eq!(policies, expected);
     }
 }

--- a/policy-engine/src/config/mod.rs
+++ b/policy-engine/src/config/mod.rs
@@ -11,5 +11,8 @@ mod file;
 mod options;
 mod settings;
 
+#[cfg(test)]
+pub(crate) use self::file::FileOptions;
+
 pub use self::settings::AppSettings;
 pub use self::settings::DEFAULT_UPSTREAM_URL;

--- a/policy-engine/src/config/options.rs
+++ b/policy-engine/src/config/options.rs
@@ -2,6 +2,7 @@
 
 use super::AppSettings;
 use commons::{parse_params_set, parse_path_prefix, MergeOptions};
+use failure::Fallible;
 use std::collections::HashSet;
 use std::net::IpAddr;
 
@@ -18,11 +19,12 @@ pub struct StatusOptions {
 }
 
 impl MergeOptions<Option<StatusOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<StatusOptions>) {
+    fn try_merge(&mut self, opts: Option<StatusOptions>) -> Fallible<()> {
         if let Some(status) = opts {
             assign_if_some!(self.status_address, status.address);
             assign_if_some!(self.status_port, status.port);
         }
+        Ok(())
     }
 }
 
@@ -50,7 +52,7 @@ pub struct ServiceOptions {
 }
 
 impl MergeOptions<Option<ServiceOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<ServiceOptions>) {
+    fn try_merge(&mut self, opts: Option<ServiceOptions>) -> Fallible<()> {
         if let Some(service) = opts {
             assign_if_some!(self.address, service.address);
             assign_if_some!(self.port, service.port);
@@ -59,6 +61,7 @@ impl MergeOptions<Option<ServiceOptions>> for AppSettings {
                 self.mandatory_client_parameters.extend(params);
             }
         }
+        Ok(())
     }
 }
 
@@ -72,10 +75,11 @@ pub struct UpCincinnatiOptions {
 }
 
 impl MergeOptions<Option<UpCincinnatiOptions>> for AppSettings {
-    fn merge(&mut self, opts: Option<UpCincinnatiOptions>) {
+    fn try_merge(&mut self, opts: Option<UpCincinnatiOptions>) -> Fallible<()> {
         if let Some(up) = opts {
             assign_if_some!(self.upstream, up.url);
         }
+        Ok(())
     }
 }
 

--- a/policy-engine/src/config/settings.rs
+++ b/policy-engine/src/config/settings.rs
@@ -1,6 +1,7 @@
 //! Application settings for policy-engine.
 
 use super::{cli, file};
+use cincinnati::plugins::{BoxedPlugin, PluginSettings};
 use failure::Fallible;
 use hyper::Uri;
 use std::collections::HashSet;
@@ -40,6 +41,9 @@ pub struct AppSettings {
     /// Endpoints namespace for the main service.
     pub path_prefix: String,
 
+    /// Policy plugins configuration.
+    pub policies: Vec<Box<PluginSettings>>,
+
     /// Required client parameters for the main service.
     pub mandatory_client_parameters: HashSet<String>,
 }
@@ -68,6 +72,22 @@ impl AppSettings {
         Self::try_validate(cfg)
     }
 
+    /// Validate and return policy plugins.
+    pub fn policy_plugins(&self) -> Fallible<Vec<BoxedPlugin>> {
+        let mut configured_plugins = Vec::with_capacity(self.policies.len());
+        for conf in &self.policies {
+            let plugin = conf.build_plugin()?;
+            configured_plugins.push(plugin);
+        }
+
+        // TODO(lucab): drop this as soon as all config-maps are in place (prod & staging).
+        if configured_plugins.is_empty() {
+            configured_plugins = default_openshift_plugins();
+        }
+
+        Ok(configured_plugins)
+    }
+
     /// Validate and build runtime settings.
     fn try_validate(self) -> Fallible<Self> {
         if self.address == self.status_address && self.port == self.status_port {
@@ -76,4 +96,16 @@ impl AppSettings {
 
         Ok(self)
     }
+}
+
+fn default_openshift_plugins() -> Vec<BoxedPlugin> {
+    // TODO(lucab): drop this as soon as all config-maps are in place (prod & staging).
+    use cincinnati::plugins::internal::channel_filter::ChannelFilterPlugin;
+    use cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_LABEL_FILTER;
+    use cincinnati::plugins::InternalPluginWrapper;
+
+    vec![Box::new(InternalPluginWrapper(ChannelFilterPlugin {
+        key_prefix: String::from(DEFAULT_QUAY_LABEL_FILTER),
+        key_suffix: String::from("release.channels"),
+    }))]
 }

--- a/policy-engine/src/config/settings.rs
+++ b/policy-engine/src/config/settings.rs
@@ -1,7 +1,6 @@
 //! Application settings for policy-engine.
 
 use super::{cli, file};
-use commons::MergeOptions;
 use failure::Fallible;
 use hyper::Uri;
 use std::collections::HashSet;
@@ -49,6 +48,8 @@ impl AppSettings {
     /// Lookup all optional configs, merge them with defaults, and
     /// transform into valid runtime settings.
     pub fn assemble() -> Fallible<Self> {
+        use commons::MergeOptions;
+
         let defaults = Self::default();
 
         // Source options.
@@ -60,8 +61,8 @@ impl AppSettings {
 
         // Combine options into a single config.
         let mut cfg = defaults;
-        cfg.merge(cli_opts);
-        cfg.merge(file_opts);
+        cfg.try_merge(cli_opts)?;
+        cfg.try_merge(file_opts)?;
 
         // Validate and convert to settings.
         Self::try_validate(cfg)

--- a/policy-engine/src/openapi.rs
+++ b/policy-engine/src/openapi.rs
@@ -159,6 +159,7 @@ mod tests {
         let data = actix_web::web::Data::new(AppState {
             mandatory_params: mandatory_params.clone(),
             path_prefix: path_prefix.clone(),
+            plugins: std::sync::Arc::new(vec![]),
             upstream: Default::default(),
         });
         let resource =


### PR DESCRIPTION
This adds logic and basic tests to source policy plugins settings
from TOML configuration file.

Ref: https://jira.coreos.com/browse/CIN-3