### PR TITLE
cincinnati/plugins/edge_add_remove: graceful and consistent handling of all inconsistent label constellations

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -35,7 +35,7 @@ pub mod plugins;
 
 use daggy::petgraph::visit::{IntoNodeReferences, NodeRef};
 use daggy::{Dag, Walker};
-use failure::Error;
+use failure::{Error, Fallible};
 use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::collections::HashMap;
@@ -193,6 +193,13 @@ impl Graph {
             .node_references()
             .find(|nr| nr.weight().version() == version)
             .map(|nr| ReleaseId(nr.id()))
+    }
+
+    /// Returns a Release for the given &ReleaseId
+    pub fn find_by_releaseid(&self, id: &ReleaseId) -> Fallible<&Release> {
+        self.dag
+            .node_weight(id.0)
+            .ok_or_else(move || format_err!("could not find Release with id: {:?}", id))
     }
 
     /// Removes the directed edge between the given releases.

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -145,6 +145,25 @@ impl<'a> Iterator for PreviousReleases<'a> {
 #[derive(Debug, Clone)]
 pub struct Empty;
 
+/// Errors that can be returned by the methods in this library
+pub mod errors {
+    /// Edge already exists
+    #[derive(Debug, Fail, Eq, PartialEq)]
+    #[fail(display = "edge from {:?} to {:?} already exists", from, to)]
+    pub struct EdgeAlreadyExists {
+        pub(crate) from: String,
+        pub(crate) to: String,
+    }
+
+    /// Edge doesn't exist
+    #[derive(Debug, Fail, Eq, PartialEq)]
+    #[fail(display = "edge from '{:?}' to '{:?}' doesn't exist", from, to)]
+    pub struct EdgeDoesntExist {
+        pub(crate) from: String,
+        pub(crate) to: String,
+    }
+}
+
 impl Graph {
     /// Add a release to the graph.
     ///
@@ -174,6 +193,13 @@ impl Graph {
     ///
     /// Fails with the `WoulcCycle` error if the new edge would lead to a cycle.
     pub fn add_edge(&mut self, from: &ReleaseId, to: &ReleaseId) -> Result<(), Error> {
+        if self.dag.find_edge(from.0, to.0).is_some() {
+            return Err(Error::from(errors::EdgeAlreadyExists {
+                from: self.find_by_releaseid(from)?.version().to_string(),
+                to: self.find_by_releaseid(to)?.version().to_string(),
+            }));
+        }
+
         self.dag
             .add_edge(from.0, to.0, Empty {})
             .map(|_| ())
@@ -210,7 +236,10 @@ impl Graph {
                 .map(|_| ())
                 .ok_or_else(|| format_err!("could not remove edge '{:?}'", edge))
         } else {
-            bail!("could not find edge from '{:?}' to '{:?}'", from, to);
+            Err(Error::from(errors::EdgeDoesntExist {
+                from: self.find_by_releaseid(from)?.version().to_string(),
+                to: self.find_by_releaseid(to)?.version().to_string(),
+            }))
         }
     }
 

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -176,6 +176,7 @@ impl EdgeAddRemovePlugin {
 mod tests {
     use super::*;
     use crate as cincinnati;
+    use commons::testing::init_logger;
     use std::collections::HashMap;
 
     static KEY_PREFIX: &str = "test_key";
@@ -447,6 +448,8 @@ mod tests {
         ) => {
             #[test]
             fn $name() -> Fallible<()> {
+                let _ = init_logger();
+
                 let input_metadata: HashMap<usize, HashMap<String, String>> = $input_metadata
                     .iter()
                     .map(|(n, metadata)| {

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -609,4 +609,11 @@ mod tests {
         input_edges: Some(vec![(0, 1)]),
         expected_edges: Some(vec![(0, 1)]),
     );
+
+    label_processing_order_test!(
+        name: gracefully_handle_nonexistent_edge_removal,
+        input_metadata: vec![(0, vec![("next.remove", "2.0.0"),],), (1, vec![])],
+        input_edges: Some(vec![]),
+        expected_edges: Some(vec![]),
+    );
 }

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -46,7 +46,11 @@ impl PluginSettings for EdgeAddRemovePlugin {
 /// The labels are grouped and processed in two separate passes in the following order:
 ///
 /// 1. *.add
+///     1. previous
+///     2. next
 /// 2. *.remove
+///     1. previous
+///     2. next
 ///
 /// This ordering has implications on the result of semantical contradictions, so that the `*.remove` labels take precedence over `*.add`.
 impl EdgeAddRemovePlugin {

--- a/commons/src/testing.rs
+++ b/commons/src/testing.rs
@@ -3,9 +3,15 @@
 use failure::Fallible;
 use tokio::runtime::current_thread::Runtime;
 
+/// Initialize logging.
+pub fn init_logger() -> Fallible<()> {
+    env_logger::try_init_from_env(env_logger::Env::default())?;
+    Ok(())
+}
+
 /// Initialize a tokio runtime for tests, with logging.
 pub fn init_runtime() -> Fallible<Runtime> {
-    let _ = env_logger::try_init_from_env(env_logger::Env::default());
+    let _ = init_logger();
     Runtime::new().map_err(failure::Error::from)
 }
 


### PR DESCRIPTION
Introduces consistency in gracefully handle all expected inconsistent label constellations for edge addition and removal.

Please see the commit messages for more details.