### PR TITLE
graph-builder/metrics: track timestamp of last graph refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
  "commons 0.1.0",
  "dkregistry 0.3.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=eb6349f2b99cd3dbd681d18d692a8c69e2e7b339)",

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 actix = "^0.8.3"
 actix-web = "^1.0.2"
+chrono = "^0.4.7"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "eb6349f2b99cd3dbd681d18d692a8c69e2e7b339" }
-
 env_logger = "^0.6.0"
 failure = "^0.1.1"
 flate2 = "^1.0.1"


### PR DESCRIPTION
This instruments and tracks via metrics the timestamp of last
successful graph refresh.

Ref: https://jira.coreos.com/browse/CIN-60
/cc @steveeJ 