### PR TITLE
cincinnati/src/plugins/internal/edge_add_remove: Mention labels in leading comment

### DIFF
--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -1,4 +1,4 @@
-//! This plugin adds and removes Edges from Nodes accordingly
+//! This plugin adds and removes Edges from Nodes based on metadata labels.
 
 use crate as cincinnati;
 use crate::plugins::{


### PR DESCRIPTION
Many plugins might add or remove edges.  What's special about this one is that it acts on labels, instead of all the other input you might want to use to make edge decisions.