### PR TITLE
extract graph-fetcher code from the policy-engine into an internal plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,9 @@ dependencies = [
 name = "cincinnati"
 version = "0.1.0"
 dependencies = [
+ "actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "commons 0.1.0",
+ "custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -491,16 +493,20 @@ dependencies = [
  "futures-locks 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockito 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quay 0.0.0-dev",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twoway 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -657,6 +663,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "custom_debug_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1599,6 +1615,7 @@ dependencies = [
  "actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
  "commons 0.1.0",
+ "custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2887,6 +2904,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "51764d3d7ee61d1ac25cc99b2cd8cdd9aabffb1b9e8fb17e41dcc5b21a278119"
 "checksum daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2099ef075418d7b252af69583c831cde749af9423c2a212dea8895e8ea78841"
 "checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -22,9 +22,16 @@ env_logger = "^0.6.0"
 lazy_static = "^1.2.0"
 regex = "^1.1.0"
 smart-default = "^0.5.2"
+reqwest = "^0.9.19"
+actix-web = "^1.0.2"
+serde_json = "^1.0.22"
+prometheus = "^0.7.0"
+custom_debug_derive = "^0.1.7"
 
 [dev-dependencies]
 serde_json = "1.0.22"
+mockito = "^0.20.0"
+twoway = "^0.2"
 
 [build-dependencies]
 protoc-rust = "2.8"

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -29,7 +29,12 @@ extern crate lazy_static;
 extern crate regex;
 #[macro_use]
 extern crate smart_default;
+extern crate actix_web;
 extern crate futures;
+extern crate prometheus;
+extern crate serde_json;
+#[macro_use]
+extern crate custom_debug_derive;
 pub extern crate futures_locks;
 
 #[cfg(test)]

--- a/cincinnati/src/plugins/catalog.rs
+++ b/cincinnati/src/plugins/catalog.rs
@@ -4,6 +4,7 @@
 //! referenced by name. It is used for configuration purposes.
 
 use super::internal::channel_filter::ChannelFilterPlugin;
+use super::internal::cincinnati_graph_fetch::CincinnatiGraphFetchPlugin;
 use super::internal::edge_add_remove::EdgeAddRemovePlugin;
 use super::internal::metadata_fetch_quay::QuayMetadataFetchPlugin;
 use super::internal::node_remove::NodeRemovePlugin;
@@ -17,7 +18,7 @@ static CONFIG_PLUGIN_NAME_KEY: &str = "name";
 /// Settings for a plugin.
 pub trait PluginSettings: Debug + Send {
     /// Build the corresponding plugin for this configuration.
-    fn build_plugin(&self) -> Fallible<BoxedPlugin>;
+    fn build_plugin(&self, registry: Option<&prometheus::Registry>) -> Fallible<BoxedPlugin>;
 }
 
 /// Validate configuration for a plugin and fill in defaults.
@@ -34,8 +35,25 @@ pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<dyn PluginSettings>>
         EdgeAddRemovePlugin::PLUGIN_NAME => EdgeAddRemovePlugin::deserialize_config(cfg),
         NodeRemovePlugin::PLUGIN_NAME => NodeRemovePlugin::deserialize_config(cfg),
         QuayMetadataFetchPlugin::PLUGIN_NAME => QuayMetadataFetchPlugin::deserialize_config(cfg),
+        CincinnatiGraphFetchPlugin::PLUGIN_NAME => {
+            CincinnatiGraphFetchPlugin::deserialize_config(cfg)
+        }
         x => bail!("unknown plugin '{}'", x),
     }
+}
+
+/// Bulid a vector of plugins from PluginSettings
+pub fn build_plugins(
+    policies: &[Box<dyn PluginSettings>],
+    registry: Option<&prometheus::Registry>,
+) -> Fallible<Vec<BoxedPlugin>> {
+    let mut plugins = Vec::with_capacity(policies.len());
+    for conf in policies {
+        let plugin = conf.build_plugin(registry)?;
+        plugins.push(plugin);
+    }
+
+    Ok(plugins)
 }
 
 #[cfg(test)]
@@ -52,7 +70,7 @@ mod tests {
 
         let node_remove_default: toml::Value = toml::from_str("name = 'node-remove'").unwrap();
         let nr_settings = deserialize_config(node_remove_default).unwrap();
-        nr_settings.build_plugin().unwrap();
+        nr_settings.build_plugin(None).unwrap();
 
         let cfg = r#"
             name = "quay-metadata"
@@ -60,6 +78,6 @@ mod tests {
         "#;
         let quay_metadata_repo: toml::Value = toml::from_str(cfg).unwrap();
         let qm_settings = deserialize_config(quay_metadata_repo).unwrap();
-        qm_settings.build_plugin().unwrap();
+        qm_settings.build_plugin(None).unwrap();
     }
 }

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -2,8 +2,8 @@
 //! It reads the requested channel from the parameters value at key "channel",
 //! and the value must match the regex specified at CHANNEL_VALIDATION_REGEX_STR
 
-use crate::plugins::BoxedPlugin;
-use crate::plugins::{AsyncIO, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
+use prometheus::Registry;
+use crate::plugins::{BoxedPlugin, AsyncIO, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
 use failure::Fallible;
 use futures::Future;
 
@@ -21,13 +21,13 @@ pub struct ChannelFilterPlugin {
 }
 
 impl PluginSettings for ChannelFilterPlugin {
-    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
+    fn build_plugin(&self, _: Option<&Registry>) -> Fallible<BoxedPlugin> {
         Ok(new_plugin!(InternalPluginWrapper(self.clone())))
     }
 }
 
 impl ChannelFilterPlugin {
-    pub(crate) const PLUGIN_NAME: &'static str = "channel-filter";
+    pub const PLUGIN_NAME: &'static str = "channel-filter";
 
     /// Validate plugin configuration and fill in defaults.
     pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<dyn PluginSettings>> {

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -1,0 +1,335 @@
+//! Plugin which implements fetching a Cincinnati graph via HTTP from a `/v1/graph`-compliant endpoint.
+//!
+//! Instead of processing the input graph, ghis plugin fetches a graph from a
+//! remote endpoint, which makes it effectively discard any given input graph.
+
+use crate::plugins::{
+    AsyncIO, BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
+};
+use crate::CONTENT_TYPE;
+use commons::GraphError;
+use failure::Fallible;
+use futures::{future, Future, Stream};
+use prometheus::{Counter, Registry};
+use reqwest;
+use reqwest::header::{HeaderValue, ACCEPT};
+
+/// Default URL to upstream graph provider.
+pub static DEFAULT_UPSTREAM_URL: &str = "http://localhost:8080/v1/graph";
+
+/// Plugin settings.
+#[derive(Clone, CustomDebug, Deserialize, SmartDefault)]
+#[serde(default)]
+struct CincinnatiGraphFetchSettings {
+    #[default(DEFAULT_UPSTREAM_URL.to_string())]
+    upstream: String,
+}
+
+/// Graph fetcher for Cincinnati `/v1/graph` endpoints.
+#[derive(CustomDebug)]
+pub struct CincinnatiGraphFetchPlugin {
+    /// The upstream from which to fetch the graph
+    pub upstream: String,
+
+    /// The optional metric for counting upstream requests
+    #[debug(skip)]
+    pub http_upstream_reqs: Counter,
+
+    /// The optional metric for counting failed upstream requests
+    #[debug(skip)]
+    pub http_upstream_errors_total: Counter,
+}
+
+impl PluginSettings for CincinnatiGraphFetchSettings {
+    fn build_plugin(&self, registry: Option<&Registry>) -> Fallible<BoxedPlugin> {
+        let cfg = self.clone();
+        let plugin = CincinnatiGraphFetchPlugin::try_new(cfg.upstream, registry)?;
+        Ok(new_plugin!(InternalPluginWrapper(plugin)))
+    }
+}
+
+impl CincinnatiGraphFetchPlugin {
+    /// Plugin name, for configuration.
+    pub const PLUGIN_NAME: &'static str = "cincinnati-graph-fetch";
+
+    /// Validate plugin configuration and fill in defaults.
+    pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<dyn PluginSettings>> {
+        let settings: CincinnatiGraphFetchSettings = cfg.try_into()?;
+
+        ensure!(!settings.upstream.is_empty(), "empty upstream");
+
+        Ok(Box::new(settings))
+    }
+
+    fn try_new(
+        upstream: String,
+        prometheus_registry: Option<&prometheus::Registry>,
+    ) -> Fallible<Self> {
+        let http_upstream_reqs = Counter::new(
+            "http_upstream_requests_total",
+            "Total number of HTTP upstream requests",
+        )?;
+
+        let http_upstream_errors_total = Counter::new(
+            "http_upstream_errors_total",
+            "Total number of HTTP upstream unreachable errors",
+        )?;
+
+        if let Some(registry) = &prometheus_registry {
+            registry.register(Box::new(http_upstream_reqs.clone()))?;
+            registry.register(Box::new(http_upstream_errors_total.clone()))?;
+        };
+
+        Ok(Self {
+            upstream,
+            http_upstream_reqs,
+            http_upstream_errors_total,
+        })
+    }
+}
+
+impl InternalPlugin for CincinnatiGraphFetchPlugin {
+    fn run_internal(self: &Self, io: InternalIO) -> AsyncIO<InternalIO> {
+        let upstream = self.upstream.to_owned();
+        let http_upstream_errors_total = self.http_upstream_errors_total.clone();
+
+        trace!("getting graph from upstream at {}", upstream);
+        self.http_upstream_reqs.inc();
+
+        let future_graph = futures::future::result(
+            reqwest::r#async::ClientBuilder::new()
+                .build()
+                .map_err(|e| GraphError::FailedUpstreamRequest(e.to_string())),
+        )
+        .and_then(move |client| {
+            client
+                .get(&upstream)
+                .header(ACCEPT, HeaderValue::from_static(CONTENT_TYPE))
+                .send()
+                .map_err(|e| GraphError::FailedUpstreamFetch(e.to_string()))
+        })
+        .and_then(move |res| {
+            if res.status().is_success() {
+                future::ok(res)
+            } else {
+                future::err(GraphError::FailedUpstreamFetch(res.status().to_string()))
+            }
+        })
+        .and_then(move |res| {
+            res.into_body()
+                // TODO(steveeJ): find a way to make this fail in a test
+                .concat2()
+                .map_err(move |e| GraphError::FailedUpstreamFetch(e.to_string()))
+        })
+        .and_then(move |body| {
+            serde_json::from_slice(&body).map_err(|e| GraphError::FailedJsonIn(e.to_string()))
+        })
+        .map(|graph| InternalIO {
+            graph,
+            parameters: io.parameters,
+        })
+        .map_err(move |e| {
+            error!("error fetching graph: {}", e);
+            http_upstream_errors_total.inc();
+            failure::Error::from(e)
+        });
+
+        Box::new(future_graph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::generate_custom_graph;
+    use actix_web::test::TestRequest;
+    use commons::metrics::{self, RegistryWrapper};
+    use commons::testing::{self, init_runtime};
+    use failure::{bail, Fallible};
+    use futures::Future;
+    use prometheus::Registry;
+
+    macro_rules! fetch_upstream_success_test {
+        (
+            name: $name:ident,
+            mock_body: $mock_body:expr,
+            expected_graph: $expected_graph:expr,
+
+        ) => {
+            #[test]
+            fn $name() -> Fallible<()> {
+                let mut runtime = init_runtime()?;
+
+                // run mock graph-builder
+                let _m = mockito::mock("GET", "/")
+                    .with_status(200)
+                    .with_header("content-type", "application/json")
+                    .with_body($mock_body.to_string())
+                    .create();
+
+                let plugin = CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), None)?;
+                let http_upstream_reqs = plugin.http_upstream_reqs.clone();
+                let http_upstream_errors_total = plugin.http_upstream_errors_total.clone();
+
+                assert_eq!(0, http_upstream_reqs.clone().get() as u64);
+                assert_eq!(0, http_upstream_errors_total.clone().get() as u64);
+
+                let future_processed_graph = plugin
+                    .run_internal(InternalIO {
+                        graph: Default::default(),
+                        parameters: Default::default(),
+                    })
+                    .and_then(|final_io| Ok(final_io.graph));
+
+                let processed_graph = runtime
+                    .block_on(future_processed_graph)
+                    .expect("plugin run failed");
+
+                assert_eq!($expected_graph, processed_graph);
+
+                assert_eq!(1, http_upstream_reqs.get() as u64);
+                assert_eq!(0, http_upstream_errors_total.get() as u64);
+
+                Ok(())
+            }
+        };
+    }
+
+    fetch_upstream_success_test!(
+        name: fetch_success_empty_graph_fetch,
+        mock_body: &serde_json::to_string(&crate::Graph::default())?,
+        expected_graph: crate::Graph::default(),
+    );
+
+    fetch_upstream_success_test!(
+        name: fetch_success_simple_graph_fetch,
+        mock_body: &serde_json::to_string(&generate_custom_graph(
+            0,
+            3,
+            Default::default(),
+            Some(vec![(0, 1), (1, 2)]),
+        ))?,
+        expected_graph: generate_custom_graph(
+            0,
+            3,
+            Default::default(),
+            Some(vec![(0, 1), (1, 2)]),
+        ),
+    );
+
+    macro_rules! fetch_upstream_failure_test {
+        (
+            name: $name:ident,
+            upstream: $upstream:expr,
+            mock_status: $mock_status:expr,
+            mock_header: $mock_header:expr,
+            mock_body: $mock_body:expr,
+        ) => {
+            #[test]
+            fn $name() -> Fallible<()> {
+                let mut runtime = init_runtime()?;
+                // run mock graph-builder
+                let _m = mockito::mock("GET", "/")
+                    .with_status($mock_status)
+                    .with_header($mock_header.0, $mock_header.1)
+                    .with_body($mock_body.to_string())
+                    .create();
+
+                let plugin = CincinnatiGraphFetchPlugin::try_new($upstream.to_string(), None)?;
+                let http_upstream_reqs = plugin.http_upstream_reqs.clone();
+                let http_upstream_errors_total = plugin.http_upstream_errors_total.clone();
+
+                assert_eq!(0, http_upstream_reqs.clone().get() as u64);
+                assert_eq!(0, http_upstream_errors_total.clone().get() as u64);
+
+                let future_result = plugin
+                    .run_internal(InternalIO {
+                        graph: Default::default(),
+                        parameters: Default::default(),
+                    })
+                    .and_then(|final_io| Ok(final_io.graph));
+
+                assert!(runtime.block_on(future_result).is_err());
+
+                assert_eq!(1, http_upstream_reqs.get() as usize);
+                assert_eq!(1, http_upstream_errors_total.get() as usize);
+
+                Ok(())
+            }
+        };
+    }
+
+    fetch_upstream_failure_test!(
+        name: fetch_fail_invalid_url,
+        upstream: "invalid.url",
+        mock_status: 0,
+        mock_header: ("", ""),
+        mock_body: "",
+    );
+
+    fetch_upstream_failure_test!(
+        name: fetch_fail_unreachable_server_url,
+        upstream: "http://not.reachable.test",
+        mock_status: 0,
+        mock_header: ("", ""),
+        mock_body: "",
+    );
+
+    fetch_upstream_failure_test!(
+        name: fetch_fail_request_fails_with_404,
+        upstream: &mockito::server_url(),
+        mock_status: 404,
+        mock_header: ("content-type", "application/json"),
+        mock_body: "NOT_FOUND",
+    );
+
+    fetch_upstream_failure_test!(
+        name: fetch_fail_graph_deserialization,
+        upstream: &mockito::server_url(),
+        mock_status: 200,
+        mock_header: ("content-type", "application/json"),
+        mock_body: "{not a valid graph}",
+    );
+
+    #[test]
+    fn register_metrics() -> Fallible<()> {
+        let mut rt = testing::init_runtime()?;
+
+        let metrics_prefix = "test_service".to_string();
+        let registry: &'static Registry = Box::leak(Box::new(metrics::new_registry(Some(
+            metrics_prefix.clone(),
+        ))?));
+
+        let _ = CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), Some(registry))?;
+
+        let http_req = TestRequest::default()
+            .data(RegistryWrapper(registry))
+            .to_http_request();
+        let metrics_call = metrics::serve::<metrics::RegistryWrapper>(http_req);
+        let resp = rt.block_on(metrics_call)?;
+
+        assert_eq!(resp.status(), 200);
+        if let actix_web::body::ResponseBody::Body(body) = resp.body() {
+            if let actix_web::body::Body::Bytes(bytes) = body {
+                assert!(!bytes.is_empty());
+                println!("{:?}", std::str::from_utf8(bytes.as_ref()));
+                assert!(twoway::find_bytes(
+                    bytes.as_ref(),
+                    format!("{}_http_upstream_errors_total 0\n", &metrics_prefix).as_bytes()
+                )
+                .is_some());
+                assert!(twoway::find_bytes(
+                    bytes.as_ref(),
+                    format!("{}_http_upstream_requests_total 0\n", &metrics_prefix).as_bytes()
+                )
+                .is_some());
+            } else {
+                bail!("expected Body")
+            }
+        } else {
+            bail!("expected bytes in body")
+        };
+
+        Ok(())
+    }
+}

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -1,5 +1,6 @@
 //! This plugin adds and removes Edges from Nodes based on metadata labels.
 
+use prometheus::Registry;
 use crate as cincinnati;
 use crate::plugins::BoxedPlugin;
 use crate::plugins::{AsyncIO, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
@@ -37,7 +38,7 @@ impl InternalPlugin for EdgeAddRemovePlugin {
 }
 
 impl PluginSettings for EdgeAddRemovePlugin {
-    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
+    fn build_plugin(&self, _: Option<&Registry>) -> Fallible<BoxedPlugin> {
         Ok(new_plugin!(InternalPluginWrapper(self.clone())))
     }
 }

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -8,9 +8,8 @@ extern crate futures;
 extern crate quay;
 extern crate tokio;
 
-use crate::plugins::AsyncIO;
-use crate::plugins::BoxedPlugin;
-use crate::plugins::{InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
+use prometheus::Registry;
+use crate::plugins::{AsyncIO, BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
 use crate::ReleaseId;
 use failure::{Error, Fallible, ResultExt};
 use futures::future::Future;
@@ -50,7 +49,7 @@ pub struct QuayMetadataFetchPlugin {
 }
 
 impl PluginSettings for QuayMetadataSettings {
-    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
+    fn build_plugin(&self, _: Option<&Registry>) -> Fallible<BoxedPlugin> {
         let cfg = self.clone();
         let plugin = QuayMetadataFetchPlugin::try_new(
             cfg.repository,

--- a/cincinnati/src/plugins/internal/mod.rs
+++ b/cincinnati/src/plugins/internal/mod.rs
@@ -1,6 +1,7 @@
 //! This module implements the internal plugins
 
 pub mod channel_filter;
+pub mod cincinnati_graph_fetch;
 pub mod edge_add_remove;
 pub mod metadata_fetch_quay;
 pub mod node_remove;

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -1,5 +1,6 @@
 //! This plugin removes releases according to its metadata
 
+use prometheus::Registry;
 use crate::plugins::{
     AsyncIO, BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
 };
@@ -15,7 +16,7 @@ pub struct NodeRemovePlugin {
 }
 
 impl PluginSettings for NodeRemovePlugin {
-    fn build_plugin(&self) -> Fallible<BoxedPlugin> {
+    fn build_plugin(&self, _: Option<&Registry>) -> Fallible<BoxedPlugin> {
         Ok(new_plugin!(InternalPluginWrapper(self.clone())))
     }
 }

--- a/cincinnati/src/plugins/macros.rs
+++ b/cincinnati/src/plugins/macros.rs
@@ -48,6 +48,17 @@ macro_rules! new_plugins {
     ($($x:expr),*) => { vec![$(new_plugin!($x)),*] };
 }
 
+#[macro_export]
+macro_rules! plugin_config {
+    ($( $tuple:expr ),*) => {
+        cincinnati::plugins::deserialize_config(toml::value::Value::Table(toml::value::Table::from_iter(
+            [ $(($tuple)),* ]
+            .iter()
+            .map(|(k, v)| (k.to_string(), toml::value::Value::String(v.to_string()))),
+        )))
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -9,7 +9,7 @@ pub mod external;
 pub mod interface;
 pub mod internal;
 
-pub use self::catalog::{deserialize_config, PluginSettings};
+pub use self::catalog::{build_plugins, deserialize_config, PluginSettings};
 use crate as cincinnati;
 use crate::plugins::interface::{PluginError, PluginExchange};
 use failure::{Error, Fallible, ResultExt};
@@ -24,8 +24,10 @@ pub mod prelude {
     pub use super::BoxedPlugin;
     pub use super::ExternalPluginWrapper;
     pub use super::InternalPluginWrapper;
+    pub use super::{build_plugins, deserialize_config, PluginSettings};
     pub use crate::{new_plugin, new_plugins};
     pub use futures_locks;
+    pub use std::iter::FromIterator;
 }
 
 /// Convenience type to wrap other types in a Future

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -46,7 +46,7 @@ pub enum GraphError {
 
     /// Error while reaching upstream.
     #[fail(display = "failed to assemble upstream request")]
-    FailedUpstreamRequest,
+    FailedUpstreamRequest(String),
 
     /// Requested invalid mediatype.
     #[fail(display = "invalid Content-Type requested")]
@@ -87,7 +87,7 @@ impl GraphError {
             GraphError::FailedJsonOut(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
             GraphError::FailedUpstreamFetch(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
             GraphError::FailedPluginExecution(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
-            GraphError::FailedUpstreamRequest => http::StatusCode::INTERNAL_SERVER_ERROR,
+            GraphError::FailedUpstreamRequest(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
             GraphError::InvalidContentType => http::StatusCode::NOT_ACCEPTABLE,
             GraphError::MissingParams(_) => http::StatusCode::BAD_REQUEST,
             GraphError::InvalidParams(_) => http::StatusCode::BAD_REQUEST,
@@ -101,7 +101,7 @@ impl GraphError {
             GraphError::FailedJsonOut(_) => "failed_json_out",
             GraphError::FailedUpstreamFetch(_) => "failed_upstream_fetch",
             GraphError::FailedPluginExecution(_) => "failed_plugin_execution",
-            GraphError::FailedUpstreamRequest => "failed_upstream_request",
+            GraphError::FailedUpstreamRequest(_) => "failed_upstream_request",
             GraphError::InvalidContentType => "invalid_content_type",
             GraphError::MissingParams(_) => "missing_params",
             GraphError::InvalidParams(_) => "invalid_params",

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -26,6 +26,7 @@ structopt = "^0.2.10"
 toml = "^0.4.10"
 url = "1.7.2"
 tempfile = "^3.1.0"
+custom_debug_derive = "^0.1.7"
 
 [dev-dependencies]
 tokio = "^0.1"

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -194,7 +194,7 @@ mod tests {
         settings.try_merge(Some(opts)).unwrap();
         assert_eq!(settings.policies.len(), 1);
 
-        let policies = settings.policy_plugins().unwrap();
+        let policies = settings.policy_plugins(None).unwrap();
         assert_eq!(policies, expected);
     }
 }

--- a/policy-engine/src/openapi.rs
+++ b/policy-engine/src/openapi.rs
@@ -160,7 +160,6 @@ mod tests {
             mandatory_params: mandatory_params.clone(),
             path_prefix: path_prefix.clone(),
             plugins: Box::leak(Box::new([])),
-            upstream: Default::default(),
         });
         let resource =
             actix_web::web::resource(service_uri).route(actix_web::web::get().to(super::index));


### PR DESCRIPTION
Depends on
- [x] #133 
- [x] #141.

TODO:
- [x] Discuss the metrics approach for internal plugins
- [x] Push `CustomDebug` as far down as possible
- [x] Rename the `http_upstream_unreachable` to `http_upstream_errors`
- [x] Ensure there are no leftover panics (unwraps/expects)
- [x] Elevate the `GraphError`s from plugins a level up to make them appear as native errors to the requester.
