### PR TITLE
cincinnati: fix and switch to Rust edition 2018

### DIFF
--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cincinnati"
 version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
+edition = "2018"
 
 [dependencies]
 daggy = { version = "^0.6.0", features = [ "serde-1" ] }

--- a/cincinnati/src/plugins/catalog.rs
+++ b/cincinnati/src/plugins/catalog.rs
@@ -7,8 +7,8 @@ use super::internal::channel_filter::ChannelFilterPlugin;
 use super::internal::edge_add_remove::EdgeAddRemovePlugin;
 use super::internal::metadata_fetch_quay::QuayMetadataFetchPlugin;
 use super::internal::node_remove::NodeRemovePlugin;
+use crate::plugins::BoxedPlugin;
 use failure::Fallible;
-use plugins::BoxedPlugin;
 use std::fmt::Debug;
 
 /// Key used to look up plugin-type in a configuration entry.

--- a/cincinnati/src/plugins/external/web.rs
+++ b/cincinnati/src/plugins/external/web.rs
@@ -16,11 +16,11 @@ pub struct _WebPluginClient {
 #[cfg(test)]
 mod tests {
     use crate as cincinnati;
+    use crate::plugins::AsyncIO;
     use crate::plugins::{interface, ExternalIO, ExternalPlugin, InternalIO, PluginResult};
     use crate::tests::generate_graph;
     use commons::testing::init_runtime;
     use failure::Fallible;
-    use plugins::AsyncIO;
     use std::convert::TryInto;
 
     struct DummyWebClient {

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -2,10 +2,10 @@
 //! It reads the requested channel from the parameters value at key "channel",
 //! and the value must match the regex specified at CHANNEL_VALIDATION_REGEX_STR
 
+use crate::plugins::BoxedPlugin;
 use crate::plugins::{AsyncIO, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
 use failure::Fallible;
 use futures::Future;
-use plugins::BoxedPlugin;
 
 static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 static DEFAULT_CHANNEL_KEY: &str = "release.channels";

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -1,10 +1,10 @@
 //! This plugin adds and removes Edges from Nodes based on metadata labels.
 
 use crate as cincinnati;
+use crate::plugins::BoxedPlugin;
 use crate::plugins::{AsyncIO, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
 use crate::ReleaseId;
 use failure::Fallible;
-use plugins::BoxedPlugin;
 
 static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 pub static DEFAULT_REMOVE_ALL_EDGES_VALUE: &str = "*";

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -8,12 +8,12 @@ extern crate futures;
 extern crate quay;
 extern crate tokio;
 
+use crate::plugins::AsyncIO;
+use crate::plugins::BoxedPlugin;
 use crate::plugins::{InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings};
 use crate::ReleaseId;
 use failure::{Error, Fallible, ResultExt};
 use futures::future::Future;
-use plugins::AsyncIO;
-use plugins::BoxedPlugin;
 use std::path::PathBuf;
 
 pub static DEFAULT_QUAY_LABEL_FILTER: &str = "io.openshift.upgrades.graph";


### PR DESCRIPTION
This runs a `cargo fix --edition` on `cincinnati` crate and then switches it to Rust edition 2018.

/cc @steveej