### PR TITLE
cincinnati: add maplit, simplify testcase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "futures-locks 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1286,6 +1287,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
@@ -2971,6 +2977,7 @@ dependencies = [
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -5,32 +5,32 @@ authors = ["Alex Crawford <crawford@redhat.com>"]
 edition = "2018"
 
 [dependencies]
-daggy = { version = "^0.6.0", features = [ "serde-1" ] }
-failure = "^0.1.1"
-serde = "1.0.70"
-serde_derive = "1.0.70"
+actix-web = "^1.0.2"
 commons = { path = "../commons" }
-quay = { path = "../quay" }
-protobuf = "2.0"
-url = "^1.7.2"
-log = "^0.4.3"
+custom_debug_derive = "^0.1.7"
+daggy = { version = "^0.6.0", features = [ "serde-1" ] }
+env_logger = "^0.6.0"
+failure = "^0.1.1"
 futures = "0.1"
 futures-locks = "0.3.3"
+lazy_static = "^1.2.0"
+log = "^0.4.3"
+prometheus = "^0.7.0"
+protobuf = "2.0"
+quay = { path = "../quay" }
+regex = "^1.1.0"
+reqwest = "^0.9.19"
+serde = "1.0.70"
+serde_derive = "1.0.70"
+serde_json = "^1.0.22"
+smart-default = "^0.5.2"
 tokio = "0.1"
 toml = "^0.4.10"
-env_logger = "^0.6.0"
-lazy_static = "^1.2.0"
-regex = "^1.1.0"
-smart-default = "^0.5.2"
-reqwest = "^0.9.19"
-actix-web = "^1.0.2"
-serde_json = "^1.0.22"
-prometheus = "^0.7.0"
-custom_debug_derive = "^0.1.7"
+url = "^1.7.2"
 
 [dev-dependencies]
-serde_json = "1.0.22"
 mockito = "^0.20.0"
+serde_json = "1.0.22"
 twoway = "^0.2"
 
 [build-dependencies]

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -29,6 +29,7 @@ toml = "^0.4.10"
 url = "^1.7.2"
 
 [dev-dependencies]
+maplit = "^1.0.2"
 mockito = "^0.20.0"
 serde_json = "1.0.22"
 twoway = "^0.2"

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -1,10 +1,10 @@
 //! This plugin removes releases according to its metadata
 
-use prometheus::Registry;
 use crate::plugins::{
     AsyncIO, BoxedPlugin, InternalIO, InternalPlugin, InternalPluginWrapper, PluginSettings,
 };
 use failure::Fallible;
+use prometheus::Registry;
 
 static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 
@@ -73,7 +73,10 @@ mod tests {
     use crate as cincinnati;
     use commons::testing::init_runtime;
     use failure::ResultExt;
+    use maplit::hashmap;
     use std::collections::HashMap;
+
+    type MetadataMap = HashMap<usize, HashMap<String, String>>;
 
     #[test]
     fn ensure_release_remove() -> Fallible<()> {
@@ -83,39 +86,18 @@ mod tests {
         let key_suffix = "release.remove".to_string();
 
         let input_graph: cincinnati::Graph = {
-            let metadata: HashMap<usize, HashMap<String, String>> = [
-                (
-                    0,
-                    [(
-                        format!("{}.{}", key_prefix, key_suffix),
-                        String::from("true"),
-                    )]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                ),
-                (1, HashMap::new()),
-                (
-                    2,
-                    [(
-                        format!("{}.{}", key_prefix, key_suffix),
-                        String::from("true"),
-                    )]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                ),
-            ]
-            .iter()
-            .cloned()
-            .collect();
-
+            let metadata: MetadataMap = hashmap! {
+                0 => hashmap!{ format!("{}.{}", key_prefix, key_suffix) => String::from("true") },
+                1 => hashmap!{},
+                2 => hashmap!{ format!("{}.{}", key_prefix, key_suffix) => String::from("true") },
+            };
             crate::tests::generate_custom_graph(0, metadata.len(), metadata, None)
         };
 
         let expected_graph: cincinnati::Graph = {
-            let metadata: HashMap<usize, HashMap<String, String>> =
-                [(1, HashMap::new())].iter().cloned().collect();
+            let metadata: MetadataMap = hashmap! {
+                1 => hashmap!{},
+            };
 
             crate::tests::generate_custom_graph(1, metadata.len(), metadata, None)
         };


### PR DESCRIPTION
This adds `maplit` as a dev-dependency, and starts simplifying testcases.

/cc @steveej