### PR TITLE
channel_filter: return GraphErrors instead of FailedPluginExecution

### DIFF
--- a/cincinnati/src/plugins/macros.rs
+++ b/cincinnati/src/plugins/macros.rs
@@ -9,7 +9,7 @@ macro_rules! get_multiple_values {
                     if let Some(value) = $map.get($key) {
                         value
                     } else {
-                        bail!("could not find key '{}'", $key)
+                        bail!("{}", $key)
                     },
                 )
             };
@@ -25,7 +25,7 @@ macro_rules! get_multiple_values {
                             if let Some(value) = $map.get($key) {
                                 value
                             } else {
-                                bail!("could not find key '{}'", $key)
+                                bail!("{}", $key)
                             },
                         )*
                     )

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -57,7 +57,7 @@ pub enum GraphError {
     MissingParams(Vec<String>),
 
     /// Invalid client parameters.
-    #[fail(display = "invalid client parameters")]
+    #[fail(display = "invalid client parameters: {}", _0)]
     InvalidParams(String),
 }
 

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -219,12 +219,12 @@ mod tests {
             .create();
 
         match rt.block_on(graph_call) {
-            Err(graph::GraphError::FailedPluginExecution(ref msg))
+            Err(graph::GraphError::InvalidParams(ref msg))
                 if msg.contains("does not match regex") =>
             {
                 Ok(())
             }
-            res => Err(format!("expected FailedPluginExecution error, got: {:?}", res).into()),
+            res => Err(format!("expected InvalidParams error, got: {:?}", res).into()),
         }
     }
 
@@ -407,7 +407,7 @@ mod tests {
                 mandatory_params: &["channel"],
                 passed_params: &[("channel", "invalid:channel")],
                 plugin_config: &[plugin_config!(("name", ChannelFilterPlugin::PLUGIN_NAME))?],
-                expected_result: TestResult::Error(commons::GraphError::FailedPluginExecution(
+                expected_result: TestResult::Error(commons::GraphError::InvalidParams(
                     "channel 'invalid:channel'".to_string(),
                 )),
             },
@@ -416,7 +416,7 @@ mod tests {
                 mandatory_params: &["channel"],
                 passed_params: &[("channel", "invalid=channel")],
                 plugin_config: &[plugin_config!(("name", ChannelFilterPlugin::PLUGIN_NAME))?],
-                expected_result: TestResult::Error(commons::GraphError::FailedPluginExecution(
+                expected_result: TestResult::Error(commons::GraphError::InvalidParams(
                     "channel 'invalid=channel'".to_string(),
                 )),
             },


### PR DESCRIPTION
MissingParams error is returned if channel is not set, InvalidParams error - if channel does not match the regexp.

Ref: https://jira.coreos.com/browse/CIN-69

```
$ curl -s --header 'Accept:application/json' http://localhost:8081/v1/graph
{"kind":"missing_params","value":"mandatory client parameters missing: could not find key 'channel'"}
$ curl -s --header 'Accept:application/json' http://localhost:8081/v1/graph\?channel\=invalid:channel
{"kind":"invalid_params","value":"invalid client parameters: channel 'invalid:channel' does not match regex '^[0-9a-z\\-\\.]+$'"}
```