### PR TITLE
Create a metric to track duration of upstream scrapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quay 0.0.0-dev",
@@ -553,7 +553,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,7 +1012,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)",
  "quay 0.0.0-dev",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1630,7 +1630,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openapiv3 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "prometheus"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93#6a02b0d2943f8fffce672e236e22c6f925184d93"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3015,7 +3015,7 @@ dependencies = [
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
-"checksum prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
+"checksum prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)" = "<none>"
 "checksum protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8aefcec9f142b524d98fc81d07827743be89dd6586a1ba6ab21fa66a500b3fa5"
 "checksum protobuf-codegen 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31539be8028d6b9e8e1b3b7c74e2fa3555302e27b2cc20dbaee6ffba648f75e2"
 "checksum protoc 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d60e39b07eb4039379829c55c11eba3fd8bd72b265b9ece8cc623b106908c08d"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1"
 futures-locks = "0.3.3"
 lazy_static = "^1.2.0"
 log = "^0.4.3"
-prometheus = "^0.7.0"
+prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a02b0d2943f8fffce672e236e22c6f925184d93"}
 protobuf = "2.0"
 quay = { path = "../quay" }
 regex = "^1.1.0"

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -10,7 +10,7 @@ env_logger = "^0.6.0"
 failure = "^0.1.5"
 lazy_static = "^1.2.0"
 log = "^0.4.6"
-prometheus = "^0.7.0"
+prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a02b0d2943f8fffce672e236e22c6f925184d93"}
 serde = "^1.0.70"
 serde_json = "^1.0.34"
 tokio = "^0.1"

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.1"
 itertools = "^0.7.8"
 lazy_static = "^1.2.0"
 log = "^0.4.3"
-prometheus = "^0.7.0"
+prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a02b0d2943f8fffce672e236e22c6f925184d93"}
 quay = { path = "../quay" }
 regex = "^1.1.0"
 reqwest = "^0.9.0"

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -16,7 +16,7 @@ hyper = "^0.12.6"
 lazy_static = "^1.2.0"
 log = "^0.4.3"
 openapiv3 = "0.1"
-prometheus = "^0.7.0"
+prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a02b0d2943f8fffce672e236e22c6f925184d93"}
 semver = "^0.9.0"
 serde = "^1.0.70"
 serde_derive = "^1.0.70"


### PR DESCRIPTION
Add a new histogram metric which measures duration of upstream scrapes. Initial scrape is not being included, saved into `initial_upstream_scrape_duration` instead.

Scrape duration is being recorded in `releases` validation (ignored if releases fetch failed). On first success `initial_upstream_scrape_duration` gauge is being later, in the following cycles duration is recorded in `graph_upstream_scrapes_duration` histogram.

`prometheus` crate is being built from git for now in order to be able to discard `HistogramTimer`, as its not included in tagged release yet

Ref: https://jira.coreos.com/browse/CIN-65

```
$ curl --verbose --header 'Accept:application/json' http://localhost:9080/metrics
...
# HELP cincinnati_gb_graph_initial_upstream_scrape_duration Duration of initial upstream scrape
# TYPE cincinnati_gb_graph_initial_upstream_scrape_duration gauge
cincinnati_gb_graph_initial_upstream_scrape_duration 7.338227124
...
# HELP cincinnati_gb_graph_upstream_scrapes_duration Upstream scrape duration in seconds
# TYPE cincinnati_gb_graph_upstream_scrapes_duration histogram
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="1"} 0
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="2"} 0
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="3"} 0
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="4"} 0
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="5"} 0
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="6"} 4
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="7"} 4
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="8"} 4
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="9"} 4
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="10"} 4
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="11"} 4
cincinnati_gb_graph_upstream_scrapes_duration_bucket{le="+Inf"} 4
cincinnati_gb_graph_upstream_scrapes_duration_sum 22.200288569
cincinnati_gb_graph_upstream_scrapes_duration_count 4
...
```

TODO:
* [x] a setting to adjust buckets?
  Hardcoded 1.0-11.0 buckets