### PR TITLE
cincinnati/src/plugins/macros: make rustfmt 1.38 happy

### DIFF
--- a/cincinnati/src/plugins/macros.rs
+++ b/cincinnati/src/plugins/macros.rs
@@ -100,5 +100,4 @@ mod tests {
         let a: &String = get_multiple_values!(params, "a").unwrap();
         assert_eq!(&"a".to_string(), a);
     }
-
 }


### PR DESCRIPTION
See results in https://github.com/openshift/release/pull/4936 - rustfmt 1.38 is stricter than .37 or .36

/cc @steveeJ @wking @lucab 
