### PR TITLE
Add prow_rustfmt helper to run rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ The *dist/* directory contains various CI/CD related files.
 #### Openshift Dev
 * Uses *dist/Dockerfile.build/Dockerfile* as the build container image
 * Run the following scripts on PR
-    * `dist/cargo_test.sh`
     * `dist/prow_yaml_lint.sh`
+    * `dist/prow_rustfmt.sh`
+    * `dist/cargo_test.sh`
 
 For details please see [github.com/openshift/release/(...)/openshift-cincinnati-master.yaml][1].
 

--- a/dist/prow_rustfmt.sh
+++ b/dist/prow_rustfmt.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install and run cargofmt. Input: rust version. Defaults to current default if unset
+CARGO="cargo"
+test -z ${1} || TOOLCHAIN_ARG="--toolchain ${1}"
+test -z ${1} || CARGO="rustup run ${1} cargo"
+rustup component add rustfmt ${TOOLCHAIN_ARG}
+${CARGO} fmt --all -- --check


### PR DESCRIPTION
Adds a handy script to install rustfmt for selected rust version (latest if unset). See https://github.com/openshift/release/pull/4936#issuecomment-537394744

/cc @lucab @steveeJ 