### PR TITLE
cincinnati/src/plugins/internal/channel_filter: Expose all channels

### DIFF
--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -80,12 +80,7 @@ impl InternalPlugin for ChannelFilterPlugin {
                                 .metadata
                                 .get_mut(&format!("{}.{}", key_prefix, key_suffix))
                                 .map_or(true, |values| {
-                                    if values.split(',').any(|value| value.trim() == channel) {
-                                        *values = channel.clone();
-                                        false
-                                    } else {
-                                        true
-                                    }
+                                    !values.split(',').any(|value| value.trim() == channel)
                                 }),
                             // remove if it's not a ConcreteRelease
                             _ => true,
@@ -257,7 +252,7 @@ mod tests {
                             0,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("a"),
+                                String::from("a, c"),
                             )]
                             .iter()
                             .cloned()
@@ -267,7 +262,7 @@ mod tests {
                             1,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("a"),
+                                String::from("a, c"),
                             )]
                             .iter()
                             .cloned()
@@ -303,7 +298,7 @@ mod tests {
                             2,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("b"),
+                                String::from("b, c"),
                             )]
                             .iter()
                             .cloned()
@@ -313,7 +308,7 @@ mod tests {
                             3,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("b"),
+                                String::from("b, c"),
                             )]
                             .iter()
                             .cloned()
@@ -349,7 +344,7 @@ mod tests {
                             0,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("c"),
+                                String::from("a, c"),
                             )]
                             .iter()
                             .cloned()
@@ -359,7 +354,7 @@ mod tests {
                             1,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("c"),
+                                String::from("a, c"),
                             )]
                             .iter()
                             .cloned()
@@ -369,7 +364,7 @@ mod tests {
                             2,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("c"),
+                                String::from("b, c"),
                             )]
                             .iter()
                             .cloned()
@@ -379,7 +374,7 @@ mod tests {
                             3,
                             [(
                                 format!("{}.{}", &key_prefix, &key_suffix),
-                                String::from("c"),
+                                String::from("b, c"),
                             )]
                             .iter()
                             .cloned()


### PR DESCRIPTION
This filter landed in cfa652e251 (#79), with filtering the metadata as an explicit goal:

> If a release belongs to several channels the other channel names are removed from the result.

But the channel-switching procedure is:

1. Upgrade to a release that belongs to both your current channel (e.g. `prerelease-4.1`) and the target channel (e.g. `stable-4.1`).
2. Change your channel.
3. Upgrade in the new channel.

This commit leaves the channel metadata alone, so now the channel filter is only removing releases that don't belong to the channel and is no longer adjusting metadata for releases that do belong to the channel.  The open list won't work with secret channels, but we don't have any short-/mid-term plans for secret channels, and we have very short-term plans for 4.1->4.2 edges.  Tooling like the web console's channel-picker can use the new approach to retrieve available channels for the current release, instead of hard-coding a list of channel choices that really has nothing to do with the current release (e.g. openshift/console#1498).