### PR TITLE
add app-sre as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,5 +3,6 @@
 
 approvers:
   - cincinnati-approvers
+  - app-sre
 reviewers:
   - cincinnati-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,4 +7,15 @@ aliases:
     - lucab
     - wking
     - vrutkovs
+  app-sre:
+    - aditya-konarde
+    - jfchevrette
+    - jmelis
+    - jakedt
+    - jzelinskie
+    - maorfr
+    - mmclanerh
+    - pbergene
+    - skryzhny
+    - tparikh
   cincinnati-reviewers:


### PR DESCRIPTION
done as part of https://jira.coreos.com/browse/APPSRE-481

we do not plan to use these powers, but only in case of emergency.