### PR TITLE
hack/graph: Port graph.sh for 🍎

### DIFF
--- a/hack/graph.sh
+++ b/hack/graph.sh
@@ -9,26 +9,25 @@
 #   curl -sH 'Accept:application/json' 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=prerelease-4.1' | graph.sh | dot -Tsvg >graph.svg
 set -e
 
-JQ_SCRIPT="$(cat <<EOF
-  "digraph Upgrades {\n  labelloc=t;\n  rankdir=BT;" as \$header |
+JQ_SCRIPT='"digraph Upgrades {\n  labelloc=t;\n  rankdir=BT;" as $header |
   (
     [
       .nodes |
       to_entries[] |
       "  " + (.key | tostring) +
              " [ label=\"" + .value.version + "\"" + (
-               if .value.metadata.url then " href=\"" + .value.metadata.url + "\\"" else "" end
+               if .value.metadata.url then " href=\"" + .value.metadata.url + "\"" else "" end
              ) +
              " ];"
     ] | join("\n")
-  ) as \$nodes |
+  ) as $nodes |
   (
     [
       .edges[] |
       "  " + (.[0] | tostring) + "->" + (.[1] | tostring) + ";"
     ] | join("\n")
-  ) as \$edges |
-  [\$header, \$nodes, \$edges, "}"] | join("\n")
-EOF
-)"
+  ) as $edges |
+  [$header, $nodes, $edges, "}"] | join("\n")
+'
+
 exec jq -r "${JQ_SCRIPT}"


### PR DESCRIPTION
I was running into a Bash error with the script,

```
./hack/graph.sh: line 12: unexpected EOF while looking for matching `)'
```

This commit removes the subshell, its associated heredoc, as well as the escaped `$` and `\` to enable the script to run on Bash 3.2.57(1)-release (for MacOS 10.14).