### PR TITLE
graph-builder/registry: concurrent tag processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-locks-pre"
+version = "0.5.1-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,7 +1177,8 @@ dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-locks-pre 0.5.1-pre (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1349,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.7.11"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3093,6 +3103,7 @@ dependencies = [
 "checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
 "checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
 "checksum futures-locks 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4297dd1d9d6268237e4f93aeb9c90fc1bf0d8cec7e1cef22798939e4c43a251"
+"checksum futures-locks-pre 0.5.1-pre (registry+https://github.com/rust-lang/crates.io-index)" = "9c44b6a2b29acd13a535b6d0b562ed07140a7d043d6f6bec2e7047833fb4c193"
 "checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
 "checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
 "checksum futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
@@ -3119,7 +3130,7 @@ dependencies = [
 "checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
-"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -70,6 +70,7 @@ objects:
                 "--upstream.registry.url", "$(REGISTRY)",
                 "--upstream.registry.repository", "$(REPOSITORY)",
                 "--upstream.registry.credentials_path", "/etc/secrets/registry-credentials",
+                "--upstream.registry.fetch_concurrency", "${GB_UPSTREAM_FETCH_CONCURRENCY}",
               ]
               ports:
                 - name: graph-builder
@@ -289,3 +290,6 @@ parameters:
   - name: PE_BINARY
     value: /usr/bin/policy-engine
     displayName: Path to policy-engine binary
+  - name: GB_UPSTREAM_FETCH_CONCURRENCY
+    value: "16"
+    displayName: Concurrency when fetching the upstream metadata

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -16,7 +16,8 @@ env_logger = "^0.6.0"
 failure = "^0.1.1"
 async-compression = { version = "^0.2.0", features = [ "stream", "futures-bufread", "gzip"] }
 futures = "0.3"
-itertools = "^0.7.8"
+futures-locks-pre = "0.5.1-pre"
+itertools = "^0.8.2"
 lazy_static = "^1.2.0"
 log = "^0.4.3"
 prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a02b0d2943f8fffce672e236e22c6f925184d93"}

--- a/graph-builder/src/config/options.rs
+++ b/graph-builder/src/config/options.rs
@@ -75,6 +75,10 @@ pub struct DockerRegistryOptions {
     /// Metadata key where to record the manifest-reference
     #[structopt(long = "upstream.registry.manifestref_key")]
     pub manifestref_key: Option<String>,
+
+    /// Concurrency for graph fetching
+    #[structopt(long = "upstream.registry.fetch_concurrency")]
+    pub fetch_concurrency: Option<usize>,
 }
 
 impl MergeOptions<Option<ServiceOptions>> for AppSettings {
@@ -109,6 +113,7 @@ impl MergeOptions<Option<DockerRegistryOptions>> for AppSettings {
             assign_if_some!(self.repository, registry.repository);
             assign_if_some!(self.credentials_path, registry.credentials_path);
             assign_if_some!(self.manifestref_key, registry.manifestref_key);
+            assign_if_some!(self.fetch_concurrency, registry.fetch_concurrency);
         }
         Ok(())
     }

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -60,6 +60,10 @@ pub struct AppSettings {
     /// Disable quay-metadata (Satellite compat).
     #[default(false)]
     pub disable_quay_api_metadata: bool,
+
+    /// Concurrency for graph fetching
+    #[default(16)]
+    pub fetch_concurrency: usize,
 }
 
 impl AppSettings {

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -164,7 +164,7 @@ impl HasRegistry for State {
 }
 
 #[allow(clippy::useless_let_if_seq)]
-pub async fn run<'a>(settings: &'a config::AppSettings, state: &State) -> ! {
+pub async fn run(settings: &config::AppSettings, state: &State) -> ! {
     // Grow-only cache, mapping tag (hashed layers) to optional release metadata.
     let mut cache = HashMap::new();
 

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -25,7 +25,7 @@ use lazy_static;
 pub use parking_lot::RwLock;
 use prometheus::{self, histogram_opts, labels, opts, Counter, Gauge, Histogram, IntGauge};
 use serde_json;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::thread;
 
@@ -166,7 +166,7 @@ impl HasRegistry for State {
 #[allow(clippy::useless_let_if_seq)]
 pub async fn run(settings: &config::AppSettings, state: &State) -> ! {
     // Grow-only cache, mapping tag (hashed layers) to optional release metadata.
-    let mut cache = HashMap::new();
+    let mut cache = registry::cache::new();
 
     let registry = Registry::try_from_str(&settings.registry)
         .unwrap_or_else(|_| panic!("failed to parse '{}' as Url", &settings.registry));

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -210,6 +210,7 @@ pub async fn run(settings: &config::AppSettings, state: &State) -> ! {
             password.as_ref().map(String::as_ref),
             &mut cache,
             &settings.manifestref_key,
+            settings.fetch_concurrency,
         )
         .await;
         UPSTREAM_SCRAPES.inc();

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -90,10 +90,10 @@ fn main() -> Result<(), Error> {
         let ready = Arc::new(RwLock::new(false));
 
         graph::State::new(
-            json_graph.clone(),
+            json_graph,
             settings.mandatory_client_parameters.clone(),
-            live.clone(),
-            ready.clone(),
+            live,
+            ready,
             Box::leak(Box::new(plugins)),
             Box::leak(Box::new(registry)),
         )
@@ -131,7 +131,7 @@ fn main() -> Result<(), Error> {
     .run();
 
     // Main service.
-    let main_state = state.clone();
+    let main_state = state;
     HttpServer::new(move || {
         App::new()
             .app_data(actix_web::web::Data::new(main_state.clone()))
@@ -171,14 +171,7 @@ mod tests {
             metrics::new_registry(Some(METRICS_PREFIX.to_string())).unwrap(),
         ));
 
-        State::new(
-            json_graph.clone(),
-            HashSet::new(),
-            live.clone(),
-            ready.clone(),
-            plugins,
-            registry,
-        )
+        State::new(json_graph, HashSet::new(), live, ready, plugins, registry)
     }
 
     #[test]

--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -195,6 +195,7 @@ pub async fn fetch_releases(
     password: Option<&str>,
     cache: &mut crate::registry::cache::Cache,
     manifestref_key: &str,
+    concurrency: usize,
 ) -> Result<Vec<Release>, Error> {
     let authenticated_client = dkregistry::v2::Client::configure()
         .registry(&registry.host_port_string())
@@ -218,7 +219,7 @@ pub async fn fetch_releases(
         Arc::new(FuturesMutex::new(Vec::with_capacity(estimated_releases)))
     };
 
-    tags.try_for_each_concurrent(8, |tag| {
+    tags.try_for_each_concurrent(concurrency, |tag| {
         let authenticated_client = authenticated_client.clone();
         let cache = cache.clone();
         let releases = releases.clone();

--- a/graph-builder/src/registry.rs
+++ b/graph-builder/src/registry.rs
@@ -17,14 +17,15 @@ use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
 use cincinnati;
 use failure::{Error, Fallible, ResultExt};
+use futures::lock::Mutex as FuturesMutex;
 use futures::prelude::*;
 use futures::TryStreamExt;
 use serde_json;
-use std::collections::HashMap;
 use std::fs::File;
 use std::iter::Iterator;
 use std::path::PathBuf;
 use std::string::String;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Release {
@@ -39,6 +40,21 @@ impl Into<cincinnati::Release> for Release {
             payload: self.source,
             metadata: self.metadata.metadata,
         })
+    }
+}
+
+/// Module for the release cache
+pub mod cache {
+    use crate::registry::Release;
+    use futures_locks_pre::RwLock as FuturesRwLock;
+    use std::collections::HashMap;
+
+    /// The cache type to hold the release cache
+    pub type Cache = FuturesRwLock<HashMap<u64, Option<Release>>>;
+
+    /// Instantiates a new release cache
+    pub fn new() -> Cache {
+        FuturesRwLock::new(HashMap::new())
     }
 }
 
@@ -172,12 +188,12 @@ pub fn read_credentials(
 
 /// Fetches a vector of all release metadata from the given repository, hosted on the given
 /// registry.
-pub async fn fetch_releases<S: ::std::hash::BuildHasher>(
+pub async fn fetch_releases(
     registry: &Registry,
     repo: &str,
     username: Option<&str>,
     password: Option<&str>,
-    cache: &mut HashMap<u64, Option<Release>, S>,
+    cache: &mut crate::registry::cache::Cache,
     manifestref_key: &str,
 ) -> Result<Vec<Release>, Error> {
     let authenticated_client = dkregistry::v2::Client::configure()
@@ -191,107 +207,116 @@ pub async fn fetch_releases<S: ::std::hash::BuildHasher>(
         .await
         .map_err(|e| format_err!("{}", e))?;
 
-    let manifest_and_ref_by_tag = {
-        let tags: Vec<String> = get_tags(repo, &authenticated_client)
-            .await
-            .try_collect()
-            .await?;
+    let authenticated_client_get_tags = authenticated_client.clone();
+    let tags = Box::pin(get_tags(repo, &authenticated_client_get_tags).await);
 
-        let mut manifest_and_ref_by_tag = Vec::with_capacity(tags.len());
-
-        for tag in tags {
-            manifest_and_ref_by_tag
-                .push(get_manifest_and_ref(tag, repo.to_owned(), &authenticated_client).await?);
-        }
-
-        manifest_and_ref_by_tag
+    let releases = {
+        let estimated_releases = match tags.size_hint() {
+            (_, Some(upper)) => upper,
+            (lower, None) => lower,
+        };
+        Arc::new(FuturesMutex::new(Vec::with_capacity(estimated_releases)))
     };
 
-    let mut releases = Vec::with_capacity(manifest_and_ref_by_tag.len());
+    tags.try_for_each_concurrent(8, |tag| {
+        let authenticated_client = authenticated_client.clone();
+        let cache = cache.clone();
+        let releases = releases.clone();
 
-    for (tag, manifest, manifestref) in manifest_and_ref_by_tag {
-        // Try to read the architecture from the manifest
-        let arch = match manifest.architectures() {
-            Ok(archs) => {
-                // We don't support ManifestLists now, so we expect only 1
-                // architecture for the given manifest
-                ensure!(
-                    archs.len() == 1,
-                    "[{}] broke assumption of exactly one architecture per tag: {:?}",
-                    tag,
-                    archs
+        async move {
+            trace!("[{}] Fetching release", tag);
+            let (tag, manifest, manifestref) =
+                get_manifest_and_ref(tag, repo.to_owned(), &authenticated_client).await?;
+
+            // Try to read the architecture from the manifest
+            let arch = match manifest.architectures() {
+                Ok(archs) => {
+                    // We don't support ManifestLists now, so we expect only 1
+                    // architecture for the given manifest
+                    ensure!(
+                        archs.len() == 1,
+                        "[{}] broke assumption of exactly one architecture per tag: {:?}",
+                        tag,
+                        archs
+                    );
+                    archs.first().map(std::string::ToString::to_string)
+                }
+                Err(e) => {
+                    error!(
+                        "could not get architecture from manifest for tag {}: {}",
+                        tag, e
+                    );
+                    None
+                }
+            };
+
+            let layers_digests = manifest
+                .layers_digests(arch.as_ref().map(String::as_str))
+                .map_err(|e| format_err!("{}", e))
+                .context(format!(
+                    "[{}] could not get layers_digests from manifest",
+                    tag
+                ))?
+                // Reverse the order to start with the top-most layer
+                .into_iter()
+                .rev()
+                .collect();
+
+            let mut release = match cache_release(
+                layers_digests,
+                authenticated_client.to_owned(),
+                registry.host.to_owned().to_string(),
+                repo.to_owned(),
+                tag.to_owned(),
+                cache.clone(),
+            )
+            .await?
+            {
+                Some(release) => release,
+                None => {
+                    // Reminder: this means the layer_digests point to layers
+                    // without any release and we've cached this before
+                    return Ok(());
+                }
+            };
+
+            // Replace the tag specifier with the manifestref
+            release.source = {
+                let mut source_split: Vec<&str> = release.source.split(':').collect();
+                let _ = source_split.pop();
+
+                format!("{}@{}", source_split.join(":"), manifestref)
+            };
+
+            // Attach the manifestref this release was found in for further processing
+            release
+                .metadata
+                .metadata
+                .insert(manifestref_key.to_owned(), manifestref);
+
+            // Process the manifest architecture if given
+            if let Some(arch) = arch {
+                // Encode the architecture as SemVer information
+                release.metadata.version.build =
+                    vec![semver::Identifier::AlphaNumeric(arch.to_string())];
+
+                // Attach the architecture for later processing
+                release.metadata.metadata.insert(
+                    "io.openshift.upgrades.graph.release.arch".to_owned(),
+                    arch.to_string(),
                 );
-                archs.first().map(std::string::ToString::to_string)
-            }
-            Err(e) => {
-                error!(
-                    "could not get architecture from manifest for tag {}: {}",
-                    tag, e
-                );
-                None
-            }
-        };
+            };
 
-        let layers_digests = manifest
-            .layers_digests(arch.as_ref().map(String::as_str))
-            .map_err(|e| format_err!("{}", e))
-            .context(format!(
-                "[{}] could not get layers_digests from manifest",
-                tag
-            ))?
-            // Reverse the order to start with the top-most layer
-            .into_iter()
-            .rev()
-            .collect();
+            releases.lock().await.push(release);
 
-        let mut release = match cache_release(
-            layers_digests,
-            authenticated_client.to_owned(),
-            registry.host.to_owned().to_string(),
-            repo.to_owned(),
-            tag.to_owned(),
-            cache,
-        )
-        .await?
-        {
-            Some(release) => release,
-            None => {
-                // Reminder: this means the layer_digests point to layers
-                // without any release and we've cached this before
-                continue;
-            }
-        };
+            Ok(())
+        }
+    })
+    .await?;
 
-        // Replace the tag specifier with the manifestref
-        release.source = {
-            let mut source_split: Vec<&str> = release.source.split(':').collect();
-            let _ = source_split.pop();
-
-            format!("{}@{}", source_split.join(":"), manifestref)
-        };
-
-        // Attach the manifestref this release was found in for further processing
-        release
-            .metadata
-            .metadata
-            .insert(manifestref_key.to_owned(), manifestref);
-
-        // Process the manifest architecture if given
-        if let Some(arch) = arch {
-            // Encode the architecture as SemVer information
-            release.metadata.version.build =
-                vec![semver::Identifier::AlphaNumeric(arch.to_string())];
-
-            // Attach the architecture for later processing
-            release.metadata.metadata.insert(
-                "io.openshift.upgrades.graph.release.arch".to_owned(),
-                arch.to_string(),
-            );
-        };
-
-        releases.push(release);
-    }
-    releases.shrink_to_fit();
+    let releases = Arc::<FuturesMutex<Vec<Release>>>::try_unwrap(releases)
+        .map_err(|_| format_err!("Unwrapping the shared Releases vector. This must not fail."))?
+        .into_inner();
 
     Ok(releases)
 }
@@ -305,13 +330,13 @@ pub async fn fetch_releases<S: ::std::hash::BuildHasher>(
 /// Update Images with release metadata should be immutable, but
 /// tags on registry can be mutated at any time. Thus, the cache
 /// is keyed on the hash of tag layers.
-async fn cache_release<S: ::std::hash::BuildHasher>(
+async fn cache_release(
     layer_digests: Vec<String>,
     authenticated_client: dkregistry::v2::Client,
     registry_host: String,
     repo: String,
     tag: String,
-    cache: &mut HashMap<u64, Option<Release>, S>,
+    cache: crate::registry::cache::Cache,
 ) -> Fallible<Option<Release>> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -322,8 +347,8 @@ async fn cache_release<S: ::std::hash::BuildHasher>(
         hasher.finish()
     };
 
-    if let Some(release) = cache.get(&hashed_tag_layers) {
-        trace!("Using cached release metadata for tag {}", &tag);
+    if let Some(release) = cache.read().await.get(&hashed_tag_layers) {
+        trace!("[{}] Using cached release metadata", &tag);
         return Ok(release.clone());
     }
 
@@ -337,8 +362,11 @@ async fn cache_release<S: ::std::hash::BuildHasher>(
     .await
     .context("failed to find first release")?;
 
-    trace!("Caching release metadata for new tag {}", &tag);
-    cache.insert(hashed_tag_layers, release.clone());
+    trace!("[{}] Caching release metadata", &tag);
+    cache
+        .write()
+        .await
+        .insert(hashed_tag_layers, release.clone());
     Ok(release)
 }
 
@@ -346,7 +374,7 @@ async fn cache_release<S: ::std::hash::BuildHasher>(
 async fn get_tags<'a, 'b: 'a>(
     repo: &'b str,
     authenticated_client: &'b dkregistry::v2::Client,
-) -> impl Stream<Item = Fallible<String>> + 'a {
+) -> impl TryStreamExt<Item = Fallible<String>> + 'a {
     authenticated_client
         // According to https://docs.docker.com/registry/spec/api/#listing-image-tags
         // the tags should be ordered lexically but they aren't
@@ -359,7 +387,7 @@ async fn get_manifest_and_ref(
     repo: String,
     authenticated_client: &dkregistry::v2::Client,
 ) -> Result<(String, dkregistry::v2::manifest::Manifest, String), failure::Error> {
-    trace!("processing: {}:{}", &repo, &tag);
+    trace!("[{}] Processing {}", &tag, &repo);
     let (manifest, manifestref) = authenticated_client
         .get_manifest_and_ref(&repo, &tag)
         .map_err(|e| format_err!("{}", e))
@@ -381,7 +409,7 @@ async fn find_first_release(
     let tag = repo_tag.clone();
 
     for layer_digest in layer_digests {
-        trace!("Downloading layer {}...", &layer_digest);
+        trace!("[{}] Downloading layer {}", &tag, &layer_digest);
         let (registry_host, repo, tag) = (registry_host.clone(), repo.clone(), repo_tag.clone());
 
         let blob = authenticated_client
@@ -392,7 +420,7 @@ async fn find_first_release(
         let metadata_filename = "release-manifests/release-metadata";
 
         trace!(
-            "{}: Looking for {} in archive {} with {} bytes",
+            "[{}] Looking for {} in archive {} with {} bytes",
             &tag,
             &metadata_filename,
             &layer_digest,
@@ -411,14 +439,14 @@ async fn find_first_release(
             }
             Err(e) => {
                 debug!(
-                    "could not assemble metadata from layer ({}) of tag '{}': {}",
-                    &layer_digest, &tag, e,
+                    "[{}] Could not assemble metadata from layer ({}): {}",
+                    &tag, &layer_digest, e,
                 );
             }
         }
     }
 
-    warn!("could not find any release in tag {}", tag);
+    warn!("[{}] Could not find any release", tag);
     Ok((tag, None))
 }
 

--- a/graph-builder/tests/e2e/mod.rs
+++ b/graph-builder/tests/e2e/mod.rs
@@ -6,6 +6,86 @@ use std::env;
 use test_case::test_case;
 use url::Url;
 
+pub fn sort_by_version(v: &mut Value) {
+    if !v.is_object() {
+        return;
+    }
+    let obj = v.as_object_mut().unwrap();
+
+    let mut index_map = std::collections::HashMap::<usize, usize>::new();
+
+    {
+        let mut version_index =
+            std::collections::HashMap::<String, (Option<usize>, Option<usize>)>::new();
+
+        let nodes = obj.get_mut("nodes").unwrap();
+        nodes
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .for_each(|(i, node)| {
+                let version = node.get("version").unwrap().as_str().unwrap();
+                version_index.insert(version.to_string(), (Some(i), None));
+            });
+
+        nodes.as_array_mut().unwrap().sort_unstable_by(|a, b| {
+            a.get("version")
+                .unwrap()
+                .as_str()
+                .cmp(&b.get("version").unwrap().as_str())
+        });
+
+        nodes
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .for_each(|(i, node)| {
+                let version = node.get("version").unwrap().as_str().unwrap();
+                version_index
+                    .entry(version.to_string())
+                    .and_modify(|(from, to)| {
+                        *to = Some(i);
+                        println!(
+                            "{} changed index from {} to {}",
+                            version,
+                            from.unwrap(),
+                            to.unwrap()
+                        );
+                        index_map.insert(from.unwrap(), to.unwrap());
+                    });
+            });
+    }
+
+    obj.get_mut("edges")
+        .unwrap()
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .for_each(|ref mut edge: &mut serde_json::Value| {
+            if edge.as_array().unwrap().len() < 2 {
+                return;
+            }
+
+            macro_rules! rewrite_edge_index {
+                ($edge_index:expr) => {
+                    let old = edge.get_mut($edge_index).unwrap();
+                    let new = {
+                        let old_usize = old.as_u64().unwrap() as usize;
+                        let new_i64 = *index_map.get(&old_usize).unwrap() as i64;
+                        serde_json::Value::Number(serde_json::Number::from(new_i64))
+                    };
+                    println!("Rewriting {:?} -> {:?})", old, new);
+                    *old = new;
+                };
+            }
+
+            rewrite_edge_index!(0);
+            rewrite_edge_index!(1);
+        })
+}
+
 #[test_case("a",    "amd64", include_str!("./testdata/a-amd64.json");    "channel a amd64")]
 #[test_case("b",    "amd64", include_str!("./testdata/b-amd64.json");    "channel b amd64")]
 #[test_case("test", "amd64", include_str!("./testdata/test-amd64.json"); "channel test amd64")]
@@ -17,7 +97,8 @@ fn e2e_channel_success(channel: &'static str, arch: &'static str, testdata: &str
         _ => panic!("GRAPH_URL unset"),
     };
 
-    let expected: Value = serde_json::from_str(testdata).unwrap();
+    let mut expected: Value = serde_json::from_str(testdata).unwrap();
+    sort_by_version(&mut expected);
 
     let mut graph_url = Url::parse(&graph_base_url).unwrap();
     graph_url
@@ -40,6 +121,7 @@ fn e2e_channel_success(channel: &'static str, arch: &'static str, testdata: &str
         .unwrap();
     assert_eq!(res.status().is_success(), true);
     let text = runtime.block_on(res.text()).unwrap();
-    let actual = serde_json::from_str(&text).unwrap();
+    let mut actual = serde_json::from_str(&text).unwrap();
+    sort_by_version(&mut actual);
     assert_json_include!(actual: actual, expected: expected)
 }

--- a/graph-builder/tests/e2e/testdata/a-amd64.json
+++ b/graph-builder/tests/e2e/testdata/a-amd64.json
@@ -1,19 +1,11 @@
 {
     "edges": [
         [
-            0,
-            1
+            1,
+            0
         ]
     ],
     "nodes": [
-        {
-            "version": "0.0.0",
-            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
-            "metadata": {
-                "io.openshift.upgrades.graph.release.channels": "a, test",
-                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
-            }
-        },
         {
             "version": "0.0.1",
             "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
@@ -21,6 +13,14 @@
                 "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
                 "io.openshift.upgrades.graph.release.channels": "a,b, test",
                 "kind": "test"
+            }
+        },
+        {
+            "version": "0.0.0",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
             }
         }
     ]

--- a/graph-builder/tests/e2e/testdata/test-amd64.json
+++ b/graph-builder/tests/e2e/testdata/test-amd64.json
@@ -1,14 +1,6 @@
 {
     "nodes": [
         {
-            "version": "0.0.0",
-            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
-            "metadata": {
-                "io.openshift.upgrades.graph.release.channels": "a, test",
-                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
-            }
-        },
-        {
             "version": "0.0.1",
             "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
             "metadata": {
@@ -16,12 +8,20 @@
                 "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
                 "kind": "test"
             }
+        },
+        {
+            "version": "0.0.0",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
+            }
         }
     ],
     "edges": [
         [
-            0,
-            1
+            1,
+            0
         ]
     ]
 }

--- a/graph-builder/tests/net/quay_io/mod.rs
+++ b/graph-builder/tests/net/quay_io/mod.rs
@@ -21,6 +21,14 @@ use std::collections::HashMap;
 #[cfg(feature = "test-net-private")]
 use self::graph_builder::registry::read_credentials;
 
+lazy_static::lazy_static! {
+    static ref FETCH_CONCURRENCY: usize = {
+        let app_settings = graph_builder::config::AppSettings::default();
+        app_settings.fetch_concurrency
+    };
+
+}
+
 fn init_logger() {
     let _ = env_logger::try_init_from_env(env_logger::Env::default());
 }
@@ -152,6 +160,7 @@ fn fetch_release_private_with_credentials_must_succeed() {
             password.as_ref().map(String::as_ref),
             &mut cache,
             MANIFESTREF_KEY,
+            *FETCH_CONCURRENCY,
         ))
         .expect("fetch_releases failed: ");
     assert_eq!(2, releases.len());
@@ -195,6 +204,7 @@ fn fetch_release_private_without_credentials_must_fail() {
         None,
         &mut cache,
         MANIFESTREF_KEY,
+        *FETCH_CONCURRENCY,
     ));
     assert_eq!(true, releases.is_err());
     assert_eq!(
@@ -221,6 +231,7 @@ fn fetch_release_public_with_no_release_metadata_must_not_error() {
             None,
             &mut cache,
             MANIFESTREF_KEY,
+            *FETCH_CONCURRENCY,
         ))
         .expect("should not error on emtpy repo");
     assert!(releases.is_empty())
@@ -240,6 +251,7 @@ fn fetch_release_public_with_first_empty_tag_must_succeed() {
             None,
             &mut cache,
             MANIFESTREF_KEY,
+            *FETCH_CONCURRENCY,
         ))
         .expect("fetch_releases failed: ");
     assert_eq!(2, releases.len());
@@ -283,6 +295,7 @@ fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
                 password.as_ref().map(String::as_ref),
                 &mut cache,
                 MANIFESTREF_KEY,
+                *FETCH_CONCURRENCY,
             ))
             .expect("fetch_releases failed: ");
         assert_eq!(2, releases.len());
@@ -340,6 +353,7 @@ fn fetch_release_with_cyclic_metadata_fails() -> Fallible<()> {
             password,
             &mut cache,
             MANIFESTREF_KEY,
+            *FETCH_CONCURRENCY,
         ))
         .expect("fetch_releases failed: ");
 
@@ -371,6 +385,7 @@ fn fetch_releases_public_multiarch_manual_succeeds() -> Fallible<()> {
             password.as_ref().map(String::as_ref),
             &mut cache,
             MANIFESTREF_KEY,
+            *FETCH_CONCURRENCY,
         ))
         .expect("fetch_releases failed: ");
 
@@ -396,6 +411,7 @@ fn create_graph_public_multiarch_manual_succeeds() -> Fallible<()> {
                 password.as_ref().map(String::as_ref),
                 &mut cache,
                 MANIFESTREF_KEY,
+                *FETCH_CONCURRENCY,
             ))
             .context("fetch_releases failed: ")?;
 


### PR DESCRIPTION
This introduces concurrent processing of tags to potentially reduce
scrape time significantly. This causes the resulting release vector to
be ordered non-deterministically, which had to be considered in the
tests.

Other notable changes:
* Standardize log output throughout all operations when processing a tag
* Introduce graph_builder::registry::cache for convenience

---

TODO
* [x] Depends on https://github.com/camallo/dkregistry-rs/pull/120
* [x] Depends on #195 
* [x] Depends on #206 
* [x] Includes #207 
* [x] minimize critical section for cache locking
* [x] allow unordered processing of the tags
* [x] Make parallelization configurable?
