### PR TITLE
plugins/internal/cincinnati_graph_fetch: Fix "ghis" -> "this" typo

### DIFF
--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -1,6 +1,6 @@
 //! Plugin which implements fetching a Cincinnati graph via HTTP from a `/v1/graph`-compliant endpoint.
 //!
-//! Instead of processing the input graph, ghis plugin fetches a graph from a
+//! Instead of processing the input graph, this plugin fetches a graph from a
 //! remote endpoint, which makes it effectively discard any given input graph.
 
 use crate::plugins::{


### PR DESCRIPTION
Typo is from 8498d967fb (#138).