### PR TITLE
cincinnati: expose customizable testgraph generator

### DIFF
--- a/cincinnati/src/plugins/external/web.rs
+++ b/cincinnati/src/plugins/external/web.rs
@@ -18,7 +18,7 @@ mod tests {
     use crate as cincinnati;
     use crate::plugins::AsyncIO;
     use crate::plugins::{interface, ExternalIO, ExternalPlugin, InternalIO, PluginResult};
-    use crate::tests::generate_graph;
+    use crate::testing::generate_graph;
     use commons::testing::init_runtime;
     use failure::Fallible;
     use std::convert::TryInto;

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -113,6 +113,7 @@ impl InternalPlugin for ChannelFilterPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing::generate_custom_graph;
     use commons::testing::init_runtime;
     use std::collections::HashMap;
 
@@ -173,7 +174,7 @@ mod tests {
         fn generate_test_metadata(
             key_prefix: &str,
             key_suffix: &str,
-        ) -> HashMap<usize, HashMap<String, String>> {
+        ) -> Vec<(usize, HashMap<String, String>)> {
             [
                 (
                     0,
@@ -239,15 +240,10 @@ mod tests {
                     .collect(),
                 input_graph: {
                     let metadata = generate_test_metadata(&key_prefix, &key_suffix);
-                    crate::tests::generate_custom_graph(
-                        0,
-                        metadata.len(),
-                        metadata,
-                        Some(vec![(0, 1), (1, 2), (2, 3)]),
-                    )
+                    generate_custom_graph("image", metadata, Some(vec![(0, 1), (1, 2), (2, 3)]))
                 },
                 expected_graph: {
-                    let metadata: HashMap<usize, HashMap<String, String>> = [
+                    let metadata: Vec<(usize, HashMap<String, String>)> = [
                         (
                             0,
                             [(
@@ -273,7 +269,7 @@ mod tests {
                     .cloned()
                     .collect();
 
-                    crate::tests::generate_custom_graph(0, metadata.len(), metadata, None)
+                    generate_custom_graph("image", metadata, None)
                 },
             },
             Datum {
@@ -285,15 +281,10 @@ mod tests {
                     .collect(),
                 input_graph: {
                     let metadata = generate_test_metadata(&key_prefix, &key_suffix);
-                    crate::tests::generate_custom_graph(
-                        0,
-                        metadata.len(),
-                        metadata,
-                        Some(vec![(0, 1), (1, 2), (2, 3)]),
-                    )
+                    generate_custom_graph("image", metadata, Some(vec![(0, 1), (1, 2), (2, 3)]))
                 },
                 expected_graph: {
-                    let metadata: HashMap<usize, HashMap<String, String>> = [
+                    let metadata: Vec<(usize, HashMap<String, String>)> = [
                         (
                             2,
                             [(
@@ -319,7 +310,7 @@ mod tests {
                     .cloned()
                     .collect();
 
-                    crate::tests::generate_custom_graph(2, metadata.len(), metadata, None)
+                    generate_custom_graph("image", metadata, None)
                 },
             },
             Datum {
@@ -331,15 +322,10 @@ mod tests {
                     .collect(),
                 input_graph: {
                     let metadata = generate_test_metadata(&key_prefix, &key_suffix);
-                    crate::tests::generate_custom_graph(
-                        0,
-                        metadata.len(),
-                        metadata,
-                        Some(vec![(0, 1), (1, 2), (2, 3)]),
-                    )
+                    generate_custom_graph("image", metadata, Some(vec![(0, 1), (1, 2), (2, 3)]))
                 },
                 expected_graph: {
-                    let metadata: HashMap<usize, HashMap<String, String>> = [
+                    let metadata: Vec<(usize, HashMap<String, String>)> = [
                         (
                             0,
                             [(
@@ -385,7 +371,7 @@ mod tests {
                     .cloned()
                     .collect();
 
-                    crate::tests::generate_custom_graph(0, metadata.len(), metadata, None)
+                    generate_custom_graph("image", metadata, None)
                 },
             },
         ];

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -141,7 +141,7 @@ impl InternalPlugin for CincinnatiGraphFetchPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::generate_custom_graph;
+    use crate::testing::generate_custom_graph;
     use actix_web::test::TestRequest;
     use commons::metrics::{self, RegistryWrapper};
     use commons::testing::{self, init_runtime};
@@ -204,15 +204,13 @@ mod tests {
     fetch_upstream_success_test!(
         name: fetch_success_simple_graph_fetch,
         mock_body: &serde_json::to_string(&generate_custom_graph(
-            0,
-            3,
-            Default::default(),
+            "image",
+            (0..3).into_iter().map(|i|(i, Default::default())).collect(),
             Some(vec![(0, 1), (1, 2)]),
         ))?,
         expected_graph: generate_custom_graph(
-            0,
-            3,
-            Default::default(),
+            "image",
+            (0..3).into_iter().map(|i|(i, Default::default())).collect(),
             Some(vec![(0, 1), (1, 2)]),
         ),
     );

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -209,6 +209,7 @@ impl EdgeAddRemovePlugin {
 mod tests {
     use super::*;
     use crate as cincinnati;
+    use crate::testing::generate_custom_graph;
     use commons::testing::init_runtime;
     use failure::ResultExt;
     use std::collections::HashMap;
@@ -222,7 +223,7 @@ mod tests {
         let key_prefix = "test_prefix".to_string();
         let key_suffix = "previous.remove".to_string();
 
-        let metadata: HashMap<usize, HashMap<String, String>> = [
+        let metadata: Vec<(usize, HashMap<String, String>)> = [
             (0, [].iter().cloned().collect()),
             (1, [].iter().cloned().collect()),
             (
@@ -240,19 +241,14 @@ mod tests {
         .cloned()
         .collect();
 
-        let input_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
+        let input_graph: cincinnati::Graph = generate_custom_graph(
+            "image",
             metadata.clone(),
             Some(vec![(0, 1), (0, 2), (1, 2)]),
         );
 
-        let expected_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
-            metadata,
-            Some([(0, 1)].to_vec()),
-        );
+        let expected_graph: cincinnati::Graph =
+            generate_custom_graph("image", metadata, Some([(0, 1)].to_vec()));
 
         let future_processed_graph = Box::new(EdgeAddRemovePlugin {
             key_prefix,
@@ -279,7 +275,7 @@ mod tests {
         let key_prefix = "test_prefix".to_string();
         let key_suffix = "previous.remove".to_string();
 
-        let metadata: HashMap<usize, HashMap<String, String>> = [
+        let metadata: Vec<(usize, HashMap<String, String>)> = [
             (0, [].iter().cloned().collect()),
             (1, [].iter().cloned().collect()),
             (
@@ -298,19 +294,14 @@ mod tests {
         .cloned()
         .collect();
 
-        let input_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
+        let input_graph: cincinnati::Graph = generate_custom_graph(
+            "image",
             metadata.clone(),
             Some(vec![(0, 1), (0, 2), (1, 2), (2, 3)]),
         );
 
-        let expected_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
-            metadata,
-            Some([(0, 1), (2, 3)].to_vec()),
-        );
+        let expected_graph: cincinnati::Graph =
+            generate_custom_graph("image", metadata, Some([(0, 1), (2, 3)].to_vec()));
 
         let future_processed_graph = Box::new(EdgeAddRemovePlugin {
             key_prefix,
@@ -338,7 +329,7 @@ mod tests {
         let key_prefix = "test_prefix".to_string();
         let key_suffix = "next.remove".to_string();
 
-        let metadata: HashMap<usize, HashMap<String, String>> = [
+        let metadata: Vec<(usize, HashMap<String, String>)> = [
             (
                 0,
                 [(
@@ -365,15 +356,14 @@ mod tests {
         .cloned()
         .collect();
 
-        let input_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
+        let input_graph: cincinnati::Graph = generate_custom_graph(
+            "image",
             metadata.clone(),
             Some(vec![(0, 1), (0, 2), (1, 2)]),
         );
 
         let expected_graph: cincinnati::Graph =
-            crate::tests::generate_custom_graph(0, metadata.len(), metadata, Some(vec![]));
+            generate_custom_graph("image", metadata, Some(vec![]));
 
         let future_processed_graph = Box::new(EdgeAddRemovePlugin {
             key_prefix,
@@ -401,7 +391,7 @@ mod tests {
         let key_prefix = "test_prefix".to_string();
         let key_suffix = "previous.add".to_string();
 
-        let metadata: HashMap<usize, HashMap<String, String>> = [
+        let metadata: Vec<(usize, HashMap<String, String>)> = [
             (0, [].iter().cloned().collect()),
             (1, [].iter().cloned().collect()),
             (
@@ -419,19 +409,11 @@ mod tests {
         .cloned()
         .collect();
 
-        let input_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
-            metadata.clone(),
-            Some(vec![(0, 1)]),
-        );
+        let input_graph: cincinnati::Graph =
+            generate_custom_graph("image", metadata.clone(), Some(vec![(0, 1)]));
 
-        let expected_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
-            metadata,
-            Some(vec![(0, 1), (0, 2), (1, 2)]),
-        );
+        let expected_graph: cincinnati::Graph =
+            generate_custom_graph("image", metadata, Some(vec![(0, 1), (0, 2), (1, 2)]));
 
         let future_processed_graph = Box::new(EdgeAddRemovePlugin {
             key_prefix,
@@ -459,7 +441,7 @@ mod tests {
         let key_prefix = "test_prefix".to_string();
         let key_suffix = "next.add".to_string();
 
-        let metadata: HashMap<usize, HashMap<String, String>> = [
+        let metadata: Vec<(usize, HashMap<String, String>)> = [
             (
                 0,
                 [(
@@ -478,12 +460,10 @@ mod tests {
         .cloned()
         .collect();
 
-        let input_graph: cincinnati::Graph =
-            crate::tests::generate_custom_graph(0, metadata.len(), metadata.clone(), None);
+        let input_graph: cincinnati::Graph = generate_custom_graph("image", metadata.clone(), None);
 
-        let expected_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-            0,
-            metadata.len(),
+        let expected_graph: cincinnati::Graph = generate_custom_graph(
+            "image",
             metadata,
             Some(vec![(0, 1), (0, 2), (0, 3), (1, 2), (2, 3)]),
         );
@@ -518,7 +498,7 @@ mod tests {
             fn $name() -> Fallible<()> {
                 let mut runtime = init_runtime()?;
 
-                let input_metadata: HashMap<usize, HashMap<String, String>> = $input_metadata
+                let input_metadata: Vec<(usize, HashMap<String, String>)> = $input_metadata
                     .iter()
                     .map(|(n, metadata)| {
                         (
@@ -531,19 +511,11 @@ mod tests {
                     })
                     .collect();
 
-                let input_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-                    0,
-                    input_metadata.len(),
-                    input_metadata.clone(),
-                    $input_edges.to_owned(),
-                );
+                let input_graph: cincinnati::Graph =
+                    generate_custom_graph("image", input_metadata.clone(), $input_edges.to_owned());
 
-                let expected_graph: cincinnati::Graph = crate::tests::generate_custom_graph(
-                    0,
-                    input_metadata.len(),
-                    input_metadata,
-                    $expected_edges.to_owned(),
-                );
+                let expected_graph: cincinnati::Graph =
+                    generate_custom_graph("image", input_metadata, $expected_edges.to_owned());
 
                 let future_processed_graph = Box::new(EdgeAddRemovePlugin {
                     key_prefix: KEY_PREFIX.to_string(),

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -190,25 +190,22 @@ impl InternalPlugin for QuayMetadataFetchPlugin {
 #[cfg(feature = "test-net")]
 mod tests_net {
     use super::*;
+    use crate::testing::{generate_custom_graph, TestMetadata};
     use commons::testing::init_runtime;
     use std::collections::HashMap;
 
-    fn input_metadata_labels_test_annoated(
-        manifestrefs: HashMap<usize, &str>,
-    ) -> HashMap<usize, HashMap<String, String>> {
+    fn input_metadata_labels_test_annoated(manifestrefs: HashMap<usize, &str>) -> TestMetadata {
         metadata_labels_test_annoated(manifestrefs, true)
     }
 
-    fn expected_metadata_labels_test_annoated(
-        manifestrefs: HashMap<usize, &str>,
-    ) -> HashMap<usize, HashMap<String, String>> {
+    fn expected_metadata_labels_test_annoated(manifestrefs: HashMap<usize, &str>) -> TestMetadata {
         metadata_labels_test_annoated(manifestrefs, false)
     }
 
     fn metadata_labels_test_annoated(
         manifestrefs: HashMap<usize, &str>,
         input: bool,
-    ) -> HashMap<usize, HashMap<String, String>> {
+    ) -> TestMetadata {
         [
             (0, HashMap::new()),
             (
@@ -331,15 +328,9 @@ mod tests_net {
 
         let expected_metadata = expected_metadata_labels_test_annoated(manifestrefs);
 
-        let input_graph: crate::Graph =
-            crate::tests::generate_custom_graph(0, input_metadata.len(), input_metadata, None);
+        let input_graph: crate::Graph = generate_custom_graph("image", input_metadata, None);
 
-        let expected_graph: crate::Graph = crate::tests::generate_custom_graph(
-            0,
-            expected_metadata.len(),
-            expected_metadata,
-            None,
-        );
+        let expected_graph: crate::Graph = generate_custom_graph("image", expected_metadata, None);
 
         let future_processed_graph = Box::new(
             QuayMetadataFetchPlugin::try_new(
@@ -394,16 +385,10 @@ mod tests_net {
         .collect();
 
         let input_metadata = input_metadata_labels_test_annoated(manifestrefs.clone());
-        let input_graph: crate::Graph =
-            crate::tests::generate_custom_graph(0, input_metadata.len(), input_metadata, None);
+        let input_graph: crate::Graph = generate_custom_graph("image", input_metadata, None);
 
         let expected_metadata = expected_metadata_labels_test_annoated(manifestrefs);
-        let expected_graph: crate::Graph = crate::tests::generate_custom_graph(
-            0,
-            expected_metadata.len(),
-            expected_metadata,
-            None,
-        );
+        let expected_graph: crate::Graph = generate_custom_graph("image", expected_metadata, None);
 
         let future_processed_graph = Box::new(
             QuayMetadataFetchPlugin::try_new(

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -71,12 +71,10 @@ impl InternalPlugin for NodeRemovePlugin {
 mod tests {
     use super::*;
     use crate as cincinnati;
+    use crate::testing::{generate_custom_graph, TestMetadata};
     use commons::testing::init_runtime;
     use failure::ResultExt;
     use maplit::hashmap;
-    use std::collections::HashMap;
-
-    type MetadataMap = HashMap<usize, HashMap<String, String>>;
 
     #[test]
     fn ensure_release_remove() -> Fallible<()> {
@@ -86,20 +84,24 @@ mod tests {
         let key_suffix = "release.remove".to_string();
 
         let input_graph: cincinnati::Graph = {
-            let metadata: MetadataMap = hashmap! {
-                0 => hashmap!{ format!("{}.{}", key_prefix, key_suffix) => String::from("true") },
-                1 => hashmap!{},
-                2 => hashmap!{ format!("{}.{}", key_prefix, key_suffix) => String::from("true") },
-            };
-            crate::tests::generate_custom_graph(0, metadata.len(), metadata, None)
+            let metadata: TestMetadata = vec![
+                (
+                    0,
+                    hashmap! { format!("{}.{}", key_prefix, key_suffix) => String::from("true") },
+                ),
+                (1, hashmap! {}),
+                (
+                    2,
+                    hashmap! { format!("{}.{}", key_prefix, key_suffix) => String::from("true") },
+                ),
+            ];
+            generate_custom_graph("image", metadata, None)
         };
 
         let expected_graph: cincinnati::Graph = {
-            let metadata: MetadataMap = hashmap! {
-                1 => hashmap!{},
-            };
+            let metadata: TestMetadata = vec![(1, hashmap! {})];
 
-            crate::tests::generate_custom_graph(1, metadata.len(), metadata, None)
+            generate_custom_graph("image", metadata, None)
         };
 
         let future_processed_graph =

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -343,7 +343,7 @@ where
 mod tests {
     use super::*;
     use crate::plugins::Plugin;
-    use crate::tests::generate_graph;
+    use crate::testing::generate_graph;
     use futures_locks::Mutex as FuturesMutex;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
This code is useful for generating Graphs for testing purposes and can
be used in other crates as well. In addition to exposing the existing
functionality a builder with a few possible customizations have been
added.