### PR TITLE
dist/openshift: don't require 'version' param in policy-engine

### DIFF
--- a/dist/openshift/cincinnati.configmap.yaml
+++ b/dist/openshift/cincinnati.configmap.yaml
@@ -14,4 +14,4 @@ data:
   pe.status.address: "0.0.0.0"
   pe.upstream: "http://cincinnati-graph-builder.cincinnati-staging.svc:8080/v1/graph"
   pe.log.verbosity: "vvv"
-  pe.mandatory_client_parameters: "channel,version"
+  pe.mandatory_client_parameters: "channel"


### PR DESCRIPTION
This lets the arch_filter plugin alone deal with the combination of
'version' and 'arch' query-parameters.

Split off of #176.