### PR TITLE
policy-engine/src/main: Add request logging

### DIFF
--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), Error> {
     registry.register(Box::new(BUILD_INFO.clone()))?;
     HttpServer::new(move || {
         App::new()
+            .wrap(actix_web::middleware::Logger::default())
             .register_data(actix_web::web::Data::new(RegistryWrapper(registry)))
             .service(
                 actix_web::web::resource("/metrics")


### PR DESCRIPTION
The default log format [is][1]:

```
%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T
```

This will give us a user-agent to help debug broken clients.  Before this commit, logs looked like:

```
[2019-12-06T20:14:16Z ERROR policy_engine::graph] Error serving request with parameters '"channel=stable-4.1&version=4.2.4"': mandatory client parameters missing
[2019-12-06T20:14:29Z ERROR policy_engine::graph] Error serving request with parameters '"channel=stable-4.2&version=4.2.4"': mandatory client parameters missing
[2019-12-06T20:14:52Z ERROR policy_engine::graph] Error serving request with parameters '"channel=fast-4.2&version=4.2.4"': mandatory client parameters missing
```

which makes it hard to track down the broken clients.  Ideally we'd only include the user-agent logs for invalid requests, but I'm not clear on how to set that up.

Not sure how to test this either...

[1]: https://actix.rs/docs/middleware/#usage