### PR TITLE
pe/graph: verbose-log request on error

### DIFF
--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -95,8 +95,11 @@ pub(crate) fn index(req: HttpRequest) -> Box<dyn Future<Item = HttpResponse, Err
 
             if let Err(e) = &r {
                 error!(
-                    "Error serving request with parameters '{:?}': {}",
-                    req.query_string(),
+                    "Error serving request '{}' from '{}': {:?}",
+                    format!("{:?}", &req).replace("\n", " ").replace("\t", " "),
+                    &req.peer_addr()
+                        .map(|addr| addr.to_string())
+                        .unwrap_or("<not available>".into()),
                     e
                 );
             }


### PR DESCRIPTION
This will make the output look like

```
[2019-12-06T21:57:22Z ERROR policy_engine::graph] Error serving request ' HttpRequest HTTP/1.1 GET:/api/upgrades_info/v1/graph   query: ?"channel=stable-4.1"   headers:     "accept": "application/json"     "host": "localhost:8081"     "user-agent": "curl/7.65.3" ' from '127.0.0.1:34370': MissingParams(["arch", "version"])
```

when a request lead to an error.

Alternative to #185.