### PR TITLE
graph-builder/create_graph: add all releases before adding edges

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -157,8 +157,7 @@ impl InternalPlugin for ReleaseScrapeDockerv2Plugin {
         self.graph_upstream_raw_releases
             .set(releases.len().try_into()?);
 
-        let graph =
-            cincinnati::plugins::internal::graph_builder::release::create_graph(releases).unwrap();
+        let graph = cincinnati::plugins::internal::graph_builder::release::create_graph(releases)?;
 
         Ok(InternalIO {
             graph,


### PR DESCRIPTION
This gives the algorithm the chance to detect and warn about edges which
refer to a non-existing release.

/cc @LalatenduMohanty 