### PR TITLE
 Add scripts for upstream e2e tests 

### DIFF
--- a/dist/Dockerfile.e2e/Dockefile
+++ b/dist/Dockerfile.e2e/Dockefile
@@ -1,0 +1,14 @@
+FROM centos:7
+
+ENV HOME="/root"
+
+RUN mkdir -p "${HOME}/cincinnati"
+WORKDIR "${HOME}/cincinnati"
+
+# Get oc CLI
+RUN mkdir -p ${HOME}/bin && \
+    curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
+ENV PATH="${PATH}:${HOME}/bin"
+COPY . .
+
+ENTRYPOINT ["hack/e2e.sh"]

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -265,10 +265,10 @@ parameters:
     displayName: Graph builder status port
   - name: PE_PORT
     value: "8081"
-    displayName: Policy enigine port
+    displayName: Policy engine port
   - name: PE_STATUS_PORT
     value: "9081"
-    displayName: Policy enigine status port
+    displayName: Policy engine status port
   - name: PE_PATH_PREFIX
     value: "/api/upgrades_info"
     displayName: Policy engine path prefix

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -208,7 +208,7 @@ objects:
       gb.address: "0.0.0.0"
       gb.status.address: "0.0.0.0"
       gb.registry: "quay.io"
-      gb.repository: "openshift-release-dev/ocp-release"
+      gb.repository: ${{GB_CINCINNATI_REPO}}
       gb.log.verbosity: ${{GB_LOG_VERBOSITY}}
       pe.address: "0.0.0.0"
       pe.status.address: "0.0.0.0"
@@ -278,3 +278,6 @@ parameters:
   - name: PE_LOG_VERBOSITY
     value: "vv"
     displayName: Policy engine log verbosity
+  - name: GB_CINCINNATI_REPO
+    value: "openshift-release-dev/ocp-release"
+    displayName: Graph builder quay repo

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# This script assumes its running from a pod and does the following:
+# * Processes the template to setup a local cincy instance
+# * Prepares a graph using test data
+# * Ensures generated graph is valid
+
+# Debug information
+oc whoami
+oc project
+
+# Apply oc template
+oc new-app -f ../dist/openshift/cincinnati.yaml \
+  -p IMAGE=${CINCINNATI_E2E_IMAGE:-pipeline} \
+  -p IMAGE_TAG=${CINCINNATI_E2E_IMAGE_TAG:-deploy} \
+  -p PE_PORT=${CINCINNATI_PE_PORT:-8081} \
+  -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual"
+
+# Wait for dc to rollout
+oc wait --for=condition=available deploymentconfig/cincinnati
+
+# Check that policy engine returns channel data respond
+GRAPH_URL="http://${CINCINNATI_PE_BASE_URL:-cincinnati-policy-engine}:${CINCINNATI_PE_PORT:-8081}/v1/graph"
+curl --verbose --header 'Accept:application/json' "${GRAPH_URL}?channel=a"


### PR DESCRIPTION
This adds a minimal e2e test, which starts a new Cincinnati instance, 
pointing to test data, and attempts to fetch channel data.

In order to point test Cincy to a different repo the template is modified so that GB repo can be updated

Related to https://github.com/openshift/release/pull/6600