### PR TITLE
commons/src/lib: Relax Accept header parsing

### DIFF
--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -91,21 +91,38 @@ pub fn ensure_query_params(
     Ok(())
 }
 
-/// Make sure client requested a valid content type.
-pub fn ensure_content_type(
+/// Make sure the client can accept the provided media type.
+pub fn validate_content_type(
     headers: &HeaderMap,
     content_type: &'static str,
 ) -> Result<(), GraphError> {
-    let content_json = header::HeaderValue::from_static(content_type);
+    let header_value = match headers.get(header::ACCEPT) {
+        None => return Ok(()),
+        Some(v) => v,
+    };
 
-    if !headers
-        .get(header::ACCEPT)
-        .map(|accept| accept == content_json)
-        .unwrap_or(false)
-    {
-        Err(GraphError::InvalidContentType)
-    } else {
+    let full_type = header::HeaderValue::from_static(content_type);
+    let wildcard = header::HeaderValue::from_static("*");
+    let double_wildcard = header::HeaderValue::from_static("*/*");
+    let top_type = content_type.split("/").next().unwrap_or("");
+    let top_type_wildcard = header::HeaderValue::from_str(&format!("{}/*", top_type));
+    assert!(
+        top_type_wildcard.is_ok(),
+        format!("could not form top-type wildcard from {}", top_type)
+    );
+
+    let acceptable_content_types: Vec<actix_web::http::HeaderValue> = vec![
+        full_type,
+        wildcard,
+        double_wildcard,
+        top_type_wildcard.unwrap(),
+    ];
+
+    // FIXME: this is not a full-blown Accept parser
+    if acceptable_content_types.iter().any(|c| c == header_value) {
         Ok(())
+    } else {
+        Err(GraphError::InvalidContentType)
     }
 }
 
@@ -152,10 +169,21 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_content_type() {
+    fn test_validate_content_type() {
         let mut headers = actix_web::http::HeaderMap::new();
-        headers.insert(header::ACCEPT, "application/json".parse().unwrap());
-        ensure_content_type(&headers, "application/json").unwrap();
-        ensure_content_type(&headers, "text/html").unwrap_err();
+        validate_content_type(&headers, "application/json").unwrap(); // if the request leaves Accept empty, we can return whatever we want
+        headers.insert(
+            header::ACCEPT,
+            //"application/json, text/*; q=0.2".parse().unwrap(), // prefer JSON, but also accept any text/* after an 80% markdown in quality.  FIXME: needs a smarter parser in validate_content_type
+            "application/json".parse().unwrap(),
+        );
+        validate_content_type(&headers, "application/json").unwrap();
+        headers.insert(
+            // FIXME: drop once validate_content_type gets a smarter parser and the previous insert can include the text/* entry
+            header::ACCEPT,
+            "text/*".parse().unwrap(),
+        );
+        validate_content_type(&headers, "text/plain").unwrap();
+        validate_content_type(&headers, "image/png").unwrap_err();
     }
 }

--- a/docs/design/cincinnati.md
+++ b/docs/design/cincinnati.md
@@ -132,13 +132,12 @@ The Graph API defines the interface exposed by implementations of Graph Builders
 
 ### Request ###
 
-HTTP GET requests are used to fetch the DAG from the Graph API endpoint. Requests can be made to `/v1/graph` and must include the following in the header:
-
-```
-Accept: application/json
-```
+HTTP GET requests are used to fetch the DAG from the Graph API endpoint. Requests can be made to `/v1/graph` and, if an [`Accept` header][http-accept] is set, it must allow [the `application/json` media type][json-media-type].
 
 Clients may provide additional parameters as URL query parameters in the request. The contract for those parameters is defined by the client and Policy Engine implementation.
+
+[http-accept]: https://tools.ietf.org/html/rfc7231#section-5.3.2
+[json-media-type]: https://tools.ietf.org/html/rfc8259#section-1.2
 
 ### Response ###
 

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -104,7 +104,7 @@ pub async fn index(
     V1_GRAPH_INCOMING_REQS.inc();
 
     // Check that the client can accept JSON media type.
-    commons::ensure_content_type(req.headers(), CONTENT_TYPE)?;
+    commons::validate_content_type(req.headers(), CONTENT_TYPE)?;
 
     // Check for required client parameters.
     let mandatory_params = &app_data.mandatory_params;


### PR DESCRIPTION
~WIP because I haven't actually relaxed anything yet ;).~ implemented-ish since e9b3d5c -> ddff926

Before this pull request:

```console
$ curl -isH 'Accept: */*' 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.2'
HTTP/1.1 406 Not Acceptable
Date: Sat, 18 Jan 2020 05:51:02 GMT
Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
content-length: 72
content-type: application/json
Set-Cookie: ...; path=/; HttpOnly; Secure
Set-Cookie: ...; path=/; HttpOnly; Secure
{"kind":"invalid_content_type","value":"invalid Content-Type requested"}
```

and:

```console
$ curl -is 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.2'
HTTP/1.1 406 Not Acceptable
Date: Sat, 18 Jan 2020 05:51:11 GMT
Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
content-length: 72
content-type: application/json
Set-Cookie: ...; path=/; HttpOnly; Secure
Set-Cookie: ...; path=/; HttpOnly; Secure
{"kind":"invalid_content_type","value":"invalid Content-Type requested"}
```

But both of those should be valid requests for "I accept all content types.  Server, pick your favorite" ([spec][1]).  This pull-request relaxes our media-type handling to support clients who set no constraints, or makes a request that includes `*`, `*/*`, `application/*`, or `application/json`.  This will make it easier for new Cincy clients to make successful Cincy requests.

[1]: https://tools.ietf.org/html/rfc7231#section-5.3.2