### PR TITLE
cincinnati: fix cargo fmt

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -872,7 +872,10 @@ mod tests {
     #[test]
     fn serialize_graph() {
         let graph = generate_graph();
-        assert_eq!(serde_json::to_string(&graph).unwrap(), r#"{"nodes":[{"version":"1.0.0","payload":"image/1.0.0","metadata":{}},{"version":"2.0.0","payload":"image/2.0.0","metadata":{}},{"version":"3.0.0","payload":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#);
+        assert_eq!(
+            serde_json::to_string(&graph).unwrap(),
+            r#"{"nodes":[{"version":"1.0.0","payload":"image/1.0.0","metadata":{}},{"version":"2.0.0","payload":"image/2.0.0","metadata":{}},{"version":"3.0.0","payload":"image/3.0.0","metadata":{}}],"edges":[[0,1],[1,2],[0,2]]}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
I'm unclear why the format changed now, but CI has caught it and I can
reproduce it locally, so fixing it seems fine.