### PR TITLE
e2e improvements

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -59,6 +59,8 @@ objects:
                     configMapKeyRef:
                       key: gb.log.verbosity
                       name: cincinnati
+              command:
+                - /go/src/github.com/openshift/cincinnati/target/release/graph-builder
               args: [
                 "-$(GB_LOG_VERBOSITY)",
                 "--service.address", "$(ADDRESS)",
@@ -128,7 +130,8 @@ objects:
                     configMapKeyRef:
                       key: pe.mandatory_client_parameters
                       name: cincinnati
-              command: ["/usr/bin/policy-engine"]
+              command:
+                - /go/src/github.com/openshift/cincinnati/target/release/policy-engine
               args: [
                 "-$(PE_LOG_VERBOSITY)",
                 "--service.address", "$(ADDRESS)",

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -60,7 +60,7 @@ objects:
                       key: gb.log.verbosity
                       name: cincinnati
               command:
-                - /go/src/github.com/openshift/cincinnati/target/release/graph-builder
+                - ${GB_BINARY}
               args: [
                 "-$(GB_LOG_VERBOSITY)",
                 "--service.address", "$(ADDRESS)",
@@ -131,7 +131,7 @@ objects:
                       key: pe.mandatory_client_parameters
                       name: cincinnati
               command:
-                - /go/src/github.com/openshift/cincinnati/target/release/policy-engine
+                - ${PE_BINARY}
               args: [
                 "-$(PE_LOG_VERBOSITY)",
                 "--service.address", "$(ADDRESS)",
@@ -163,7 +163,7 @@ objects:
           volumes:
             - name: secrets
               secret:
-                secretName: cincinnati-registry-credetials
+                secretName: cincinnati-registry-credentials
       triggers:
         - type: ConfigChange
   - apiVersion: v1
@@ -283,3 +283,9 @@ parameters:
   - name: GB_CINCINNATI_REPO
     value: "openshift-release-dev/ocp-release"
     displayName: Graph builder quay repo
+  - name: GB_BINARY
+    value: /usr/bin/graph-binary
+    displayName: Path to graph-builder binary
+  - name: PE_BINARY
+    value: /usr/bin/policy-engine
+    displayName: Path to policy-engine binary

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -26,7 +26,9 @@ oc secrets link default ci-pull-secret --for=pull
 oc new-app -f dist/openshift/cincinnati.yaml \
   -p IMAGE="${IMAGE_FORMAT%/*}/stable" \
   -p IMAGE_TAG=deploy \
-  -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual"
+  -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual" \
+  -p GB_BINARY="/go/src/github.com/openshift/cincinnati/target/release/graph-builder" \
+  -p PE_BINARY="/go/src/github.com/openshift/cincinnati/target/release/policy-engine"
 
 # Wait for dc to rollout
 oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -5,20 +5,50 @@
 # * Prepares a graph using test data
 # * Ensures generated graph is valid
 
-# Debug information
-oc whoami
-oc project
+# Prerequirements:
+#   * pull secret (with registry.svc.ci.openshift.org) part in `/tmp/cluster/pull-secret`
+#   * env var IMAGE_FORMAT (e.g `registry.svc.ci.openshift.org/ci-op-ish8m5dt/stable:${component}`)
+
+set -euo pipefail
+
+# Create a new project
+oc new-project cincinnati-e2e
+oc project cincinnati-e2e
+
+# Use pull secret in cincinnati
+oc create secret generic cincinnati-registry-credentials --from-file=registry-credentials=/tmp/cluster/pull-secret
+
+# Use this pull secret to fetch images from CI
+oc create secret generic ci-pull-secret --from-file=.dockercfg=/tmp/cluster/pull-secret --type=kubernetes.io/dockercfg
+oc secrets link default ci-pull-secret --for=pull
 
 # Apply oc template
-oc new-app -f ../dist/openshift/cincinnati.yaml \
-  -p IMAGE=${CINCINNATI_E2E_IMAGE:-pipeline} \
-  -p IMAGE_TAG=${CINCINNATI_E2E_IMAGE_TAG:-deploy} \
-  -p PE_PORT=${CINCINNATI_PE_PORT:-8081} \
+oc new-app -f dist/openshift/cincinnati.yaml \
+  -p IMAGE="${IMAGE_FORMAT%/*}/stable" \
+  -p IMAGE_TAG=deploy \
   -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual"
 
 # Wait for dc to rollout
-oc wait --for=condition=available deploymentconfig/cincinnati
+oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati
+
+# Expose services
+oc expose service cincinnati-policy-engine --port=policy-engine
+PE_URL=$(oc get route cincinnati-policy-engine -o jsonpath='{.spec.host}')
+GRAPH_URL="http://${PE_URL}/api/upgrades_info/v1/graph?channel=a"
+
+# Wait for route to become available
+ATTEMPTS=10
+DELAY=10
+
+while [ $ATTEMPTS -ge 0 ]; do
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" --header 'Accept:application/json' "${GRAPH_URL}")
+  if [ "${CODE}" == "200" ]; then
+    break
+  else
+    sleep ${DELAY}
+    ATTEMPTS=$((ATTEMPTS-1))
+  fi
+done
 
 # Check that policy engine returns channel data respond
-GRAPH_URL="http://${CINCINNATI_PE_BASE_URL:-cincinnati-policy-engine}:${CINCINNATI_PE_PORT:-8081}/v1/graph"
-curl --verbose --header 'Accept:application/json' "${GRAPH_URL}?channel=a"
+curl --header 'Accept:application/json' "${GRAPH_URL}"


### PR DESCRIPTION
This PR updates `hack/e2e.sh` script to setup latest Cincinnati version on a temporary Openshift cluster and runs e2e tests (currently just a simple curl)

https://issues.redhat.com/browse/OTA-103