### PR TITLE
dist/Dockerfile.build/Dockerfile: use Rust 1.40.0

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -11,10 +11,10 @@ ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # build: Rust stable toolchain + 2 previous versions
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.39.0 -y && \
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.40.0 -y && \
+    rustup install 1.39.0 && \
     rustup install 1.38.0 && \
-    rustup install 1.37.0 && \
-    rustup default 1.39.0
+    rustup default 1.40.0
 
 # test: linters
 RUN yum -y install yamllint


### PR DESCRIPTION
Use latest stable Rust.

rustfmt test added in https://github.com/openshift/release/pull/6901