### PR TITLE
e2e: add cargo-based e2e test and run it after the instance is stood up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert-json-diff 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
@@ -1068,6 +1069,7 @@ dependencies = [
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "twoway 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2413,6 +2415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,6 +2833,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "want"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,6 +3199,7 @@ dependencies = [
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum test-case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "199464148b42bcf3da8b2a56f6ee87ca68f47402496d1268849291ec9fb463c8"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
@@ -3222,6 +3241,7 @@ dependencies = [
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -41,7 +41,10 @@ built = "^0.3.2"
 
 [dev-dependencies]
 twoway = "^0.2"
+assert-json-diff = "1.0.0"
+test-case = "1.0.0"
 
 [features]
 test-net = []
 test-net-private = []
+test-e2e = []

--- a/graph-builder/tests/e2e/mod.rs
+++ b/graph-builder/tests/e2e/mod.rs
@@ -1,0 +1,39 @@
+#[cfg(feature = "test-e2e")]
+use assert_json_diff::assert_json_include;
+use reqwest::header::{HeaderValue, ACCEPT};
+use serde_json::Value;
+use std::env;
+use test_case::test_case;
+use url::Url;
+
+#[test_case("a",    "amd64", include_str!("./testdata/a-amd64.json");    "channel a amd64")]
+#[test_case("b",    "amd64", include_str!("./testdata/b-amd64.json");    "channel b amd64")]
+#[test_case("test", "amd64", include_str!("./testdata/test-amd64.json"); "channel test amd64")]
+fn e2e_channel_success(channel: &'static str, arch: &'static str, testdata: &str) {
+    let graph_base_url = match env::var("GRAPH_URL") {
+        Ok(env) => env,
+        _ => panic!("GRAPH_URL unset"),
+    };
+
+    let expected: Value = serde_json::from_str(testdata).unwrap();
+
+    let mut graph_url = Url::parse(&graph_base_url).unwrap();
+    graph_url
+        .query_pairs_mut()
+        .append_pair("channel", channel)
+        .append_pair("arch", arch);
+
+    println!("Querying {}", graph_url.to_string());
+
+    let mut res = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap()
+        .get(&graph_url.to_string())
+        .header(ACCEPT, HeaderValue::from_static("application/json"))
+        .send()
+        .unwrap();
+    assert_eq!(res.status().is_success(), true);
+    let actual = serde_json::from_str(&res.text().unwrap()).unwrap();
+    assert_json_include!(actual: actual, expected: expected)
+}

--- a/graph-builder/tests/e2e/testdata/a-amd64.json
+++ b/graph-builder/tests/e2e/testdata/a-amd64.json
@@ -1,0 +1,27 @@
+{
+    "edges": [
+        [
+            0,
+            1
+        ]
+    ],
+    "nodes": [
+        {
+            "version": "0.0.0",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
+            }
+        },
+        {
+            "version": "0.0.1",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
+                "io.openshift.upgrades.graph.release.channels": "a,b, test",
+                "kind": "test"
+            }
+        }
+    ]
+}

--- a/graph-builder/tests/e2e/testdata/b-amd64.json
+++ b/graph-builder/tests/e2e/testdata/b-amd64.json
@@ -1,0 +1,14 @@
+{
+    "nodes": [
+        {
+            "version": "0.0.1",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
+                "kind": "test",
+                "io.openshift.upgrades.graph.release.channels": "a,b, test"
+            }
+        }
+    ],
+    "edges": []
+}

--- a/graph-builder/tests/e2e/testdata/test-amd64.json
+++ b/graph-builder/tests/e2e/testdata/test-amd64.json
@@ -1,0 +1,27 @@
+{
+    "nodes": [
+        {
+            "version": "0.0.0",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
+            }
+        },
+        {
+            "version": "0.0.1",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a,b, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
+                "kind": "test"
+            }
+        }
+    ],
+    "edges": [
+        [
+            0,
+            1
+        ]
+    ]
+}

--- a/graph-builder/tests/mod.rs
+++ b/graph-builder/tests/mod.rs
@@ -4,3 +4,6 @@ extern crate failure;
 
 #[cfg(feature = "test-net")]
 mod net;
+
+#[cfg(feature = "test-e2e")]
+mod e2e;

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -28,7 +28,9 @@ oc new-app -f dist/openshift/cincinnati.yaml \
   -p IMAGE_TAG=deploy \
   -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual" \
   -p GB_BINARY="/go/src/github.com/openshift/cincinnati/target/release/graph-builder" \
-  -p PE_BINARY="/go/src/github.com/openshift/cincinnati/target/release/policy-engine"
+  -p PE_BINARY="/go/src/github.com/openshift/cincinnati/target/release/policy-engine" \
+  -p GB_CPU_REQUEST=50m \
+  -p PE_CPU_REQUEST=50m
 
 # Wait for dc to rollout
 oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati


### PR DESCRIPTION
Add several tests which use `reqwest` to ensure returned test data graph is valid. These tests won't run during `cargo test`, instead they'd be a part of e2e suite

Part of OTA-103