### PR TITLE
dist/Dockerfile.deploy/Dockerfile: install openssl

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -2,6 +2,10 @@ FROM centos:7
 
 ENV RUST_LOG=actix_web=error,dkregistry=error
 
+RUN yum update -y && \
+    yum install -y openssl && \
+    yum clean all
+
 COPY graph-builder policy-engine /usr/bin/
 
 ENTRYPOINT ["/usr/bin/graph-builder"]


### PR DESCRIPTION
Update existing packages and install openssl, since binaries depend on
it.

e2e images don't fail since they are using src container as a base (this would be changed later)