### PR TITLE
e2e: sort received keys by version

### DIFF
--- a/graph-builder/tests/e2e/testdata/a-amd64.json
+++ b/graph-builder/tests/e2e/testdata/a-amd64.json
@@ -7,20 +7,20 @@
     ],
     "nodes": [
         {
-            "version": "0.0.0",
-            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
-            "metadata": {
-                "io.openshift.upgrades.graph.release.channels": "a, test",
-                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
-            }
-        },
-        {
             "version": "0.0.1",
             "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
             "metadata": {
                 "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
                 "io.openshift.upgrades.graph.release.channels": "a,b, test",
                 "kind": "test"
+            }
+        },
+        {
+            "version": "0.0.0",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
             }
         }
     ]

--- a/graph-builder/tests/e2e/testdata/test-amd64.json
+++ b/graph-builder/tests/e2e/testdata/test-amd64.json
@@ -1,20 +1,20 @@
 {
     "nodes": [
         {
-            "version": "0.0.0",
-            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
-            "metadata": {
-                "io.openshift.upgrades.graph.release.channels": "a, test",
-                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
-            }
-        },
-        {
             "version": "0.0.1",
             "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
             "metadata": {
                 "io.openshift.upgrades.graph.release.channels": "a,b, test",
                 "io.openshift.upgrades.graph.release.manifestref": "sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
                 "kind": "test"
+            }
+        },
+        {
+            "version": "0.0.0",
+            "payload": "quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
+            "metadata": {
+                "io.openshift.upgrades.graph.release.channels": "a, test",
+                "io.openshift.upgrades.graph.release.manifestref": "sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
             }
         }
     ],


### PR DESCRIPTION

Cincinnati may return unsorted list of nodes if tags are processed
in parallel.

e2e tests would now sort nodes by version before comparison