### PR TITLE
template: fix a typo in default value for graph-builder

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -284,7 +284,7 @@ parameters:
     value: "openshift-release-dev/ocp-release"
     displayName: Graph builder quay repo
   - name: GB_BINARY
-    value: /usr/bin/graph-binary
+    value: /usr/bin/graph-builder
     displayName: Path to graph-builder binary
   - name: PE_BINARY
     value: /usr/bin/policy-engine


### PR DESCRIPTION

`graph-binary` -> `graph-builder` in GB_BINARY name. e2e is redefining
this var so it was not caught on e2e, but it breaks rolls outs on stage