### PR TITLE
dist/Dockerfile.build/Dockerfile: Install protobuf-compiler

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -5,7 +5,7 @@ RUN yum -y install epel-release
 
 # build: system utilities and libraries
 RUN yum -y groupinstall 'Development Tools'
-RUN yum -y install openssl-devel
+RUN yum -y install openssl-devel protobuf-compiler
 
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"


### PR DESCRIPTION
To make protoc available, so we can generate (and check freshness of) cincinnati/src/plugins/interface.rs in CI, avoiding [this][1]:

    thread 'main' panicked at 'protoc: Custom { kind: NotFound, error: "failed to spawn `\"protoc\" \"--version\"`: No such file or directory (os error 2)" }', src/libcore/result.rs:1188:5

[1]: https://github.com/openshift/release/pull/6935#issuecomment-580955178