### PR TITLE
e2e: use multistage dockerfile to prepare e2e image with artifacts

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -32,3 +32,5 @@ RUN \
   mkdir -p $HOME/.cargo/git/ && \
   find $HOME/. -type d -exec chmod 777 {} \; && \
   find $HOME/. -type f -exec chmod ugo+rw {} \;
+
+WORKDIR /go/src/github.com/openshift/cincinnati

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,3 +1,14 @@
+FROM cincinnati:build as builder
+# build e2e tests
+COPY . .
+
+RUN cd graph-builder && \
+    cargo build --tests --features test-e2e --no-default-features && \
+    mkdir -p /opt/cincinnati/bin && \
+    cp -rvf ../target/debug/mod-* /opt/cincinnati/bin && \
+    rm -rf /opt/cincinnati/bin/mod-*.d && \
+    mv /opt/cincinnati/bin/mod-* /opt/cincinnati/bin/cincinnati-e2e-test
+
 FROM centos:7
 
 ENV HOME="/root"
@@ -9,6 +20,8 @@ WORKDIR "${HOME}/cincinnati"
 RUN mkdir -p ${HOME}/bin && \
     curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
 ENV PATH="${PATH}:${HOME}/bin"
-COPY . .
+
+# cargo would create test file with a randomized name
+COPY --from=builder /opt/cincinnati/bin/cincinnati-e2e-test /usr/bin
 
 ENTRYPOINT ["hack/e2e.sh"]

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -55,7 +55,4 @@ while [ $ATTEMPTS -ge 0 ]; do
 done
 
 # Run e2e tests
-pushd graph-builder
-  curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.40.0 -y
-  cargo test --features test-e2e e2e --no-default-features  -- --nocapture
-popd
+/usr/bin/cincinnati-e2e-test


### PR DESCRIPTION
This ensures e2e image we're running would be slimmer, since tests are
being built in a separate stage.

Its safe to merge now, since its not yet used by e2e tests