### PR TITLE
e2e: set RUST_BACKTRACE in e2e tests and handle missing git commit data

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,6 +1,12 @@
 FROM quay.io/app-sre/cincinnati:builder AS builder
+
+WORKDIR /go/src/github.com/openshift/cincinnati/
+
 # build
 COPY . .
+# copy git information for built crate
+COPY .git/ ./.git/
+
 RUN cargo build --release && \
     mkdir -p /opt/cincinnati/bin && \
     cp -rvf target/release/graph-builder /opt/cincinnati/bin && \

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -59,6 +59,11 @@ objects:
                     configMapKeyRef:
                       key: gb.log.verbosity
                       name: cincinnati
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: gb.rust_backtrace
+                      name: cincinnati
               command:
                 - ${GB_BINARY}
               args: [
@@ -130,6 +135,11 @@ objects:
                   valueFrom:
                     configMapKeyRef:
                       key: pe.mandatory_client_parameters
+                      name: cincinnati
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.rust_backtrace
                       name: cincinnati
               command:
                 - ${PE_BINARY}
@@ -213,11 +223,13 @@ objects:
       gb.registry: "quay.io"
       gb.repository: ${{GB_CINCINNATI_REPO}}
       gb.log.verbosity: ${{GB_LOG_VERBOSITY}}
+      gb.rust_backtrace: "${RUST_BACKTRACE}"
       pe.address: "0.0.0.0"
       pe.status.address: "0.0.0.0"
       pe.upstream: "http://localhost:8080/v1/graph"
       pe.log.verbosity: ${{PE_LOG_VERBOSITY}}
       pe.mandatory_client_parameters: "channel"
+      pe.rust_backtrace: "${RUST_BACKTRACE}"
 
 parameters:
   - name: IMAGE
@@ -293,3 +305,6 @@ parameters:
   - name: GB_UPSTREAM_FETCH_CONCURRENCY
     value: "16"
     displayName: Concurrency when fetching the upstream metadata
+  - name: RUST_BACKTRACE
+    value: "0"
+    displayName: Set RUST_BACKTRACE env var

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -75,7 +75,12 @@ lazy_static! {
     static ref BUILD_INFO: Counter = Counter::with_opts(opts!(
         "build_info",
         "Build information",
-        labels!{"git_commit" => built_info::GIT_VERSION.unwrap(),}
+        labels!{
+            "git_commit" => match built_info::GIT_VERSION {
+                Some(commit) => commit,
+                None => "unknown"
+            },
+        }
     ))
     .unwrap();
 }

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -28,7 +28,8 @@ oc new-app -f template/cincinnati.yaml \
   -p IMAGE_TAG=deploy \
   -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual" \
   -p GB_CPU_REQUEST=50m \
-  -p PE_CPU_REQUEST=50m
+  -p PE_CPU_REQUEST=50m \
+  -p RUST_BACKTRACE="1"
 
 # Wait for dc to rollout
 oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -58,7 +58,12 @@ lazy_static! {
     static ref BUILD_INFO: Counter = Counter::with_opts(opts!(
         "build_info",
         "Build information",
-        labels! {"git_commit" => built_info::GIT_VERSION.unwrap(),}
+        labels! {
+            "git_commit" => match built_info::GIT_VERSION {
+                Some(commit) => commit,
+                None => "unknown"
+            },
+        }
     ))
     .unwrap();
 }


### PR DESCRIPTION
* Update template to support RUST_BACKTRACE=1 (set to 0 by default) for
both containers
* Install `git` in Dockerfile.build so that `built_info::GIT_VERSION` would be set
* Handle missing commit info by setting "unknown" version