### PR TITLE
Dockerfile: rename base image in multistage builds

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM cincinnati:build AS builder
+FROM local/cincinnati-build:latest AS builder
 # build
 COPY . .
 RUN cargo build --release && \

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM cincinnati:build AS builder
+FROM local/cincinnati-build:latest AS builder
 # build e2e tests
 COPY . .
 


### PR DESCRIPTION

Use `local/cincinnati-build:latest` to align with what internal stage builder uses