### PR TITLE
Dockerfiles: use uppercase AS so that CI would replace these correctly

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM cincinnati:build as builder
+FROM cincinnati:build AS builder
 # build
 COPY . .
 RUN cargo build --release && \

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM cincinnati:build as builder
+FROM cincinnati:build AS builder
 # build e2e tests
 COPY . .
 


### PR DESCRIPTION
Imagebuilder doesn't recognize alias without this apparently. See rehearse results in https://github.com/openshift/release/pull/7133