### PR TITLE
Dockerfile.deploy: don't run `cargo build` if binaries are prepared

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,8 +1,8 @@
 FROM local/cincinnati-build:latest AS builder
 # build
 COPY . .
-RUN cargo build --release && \
-    mkdir -p /opt/cincinnati/bin && \
+RUN if [ ! -z target/release/graph-builder ]; then cargo build --release; fi
+RUN mkdir -p /opt/cincinnati/bin && \
     cp -rvf target/release/graph-builder /opt/cincinnati/bin && \
     cp -rvf target/release/policy-engine /opt/cincinnati/bin
 


### PR DESCRIPTION

Internal builder is running `cargo build --release` outside of the container
and copies then to docker context. This ensures deploy build won't attempt
to run cargo build if the binaries (at least graph-builder) are already
present