### PR TITLE
build_deploy: fix docker build CLI syntax

### DIFF
--- a/dist/build_deploy.sh
+++ b/dist/build_deploy.sh
@@ -12,7 +12,7 @@ ensure_build_container "${DOCKERFILE_BUILD}"
 
 DOCKERFILE_DEPLOY="$ABSOLUTE_PATH/Dockerfile.deploy/Dockerfile"
 
-docker build -t "${IMAGE}:${IMAGE_TAG}" $DOCKERFILE_DEPLOY
+docker build -t "${IMAGE}:${IMAGE_TAG}" -f $DOCKERFILE_DEPLOY .
 
 if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     DOCKER_CONF="$PWD/.docker"


### PR DESCRIPTION
docker build needs `-f <dockerfile path> <directory>` args

Fixes stage build:
```
+ DOCKERFILE_DEPLOY=/var/lib/jenkins/workspace/openshift-cincinnati-gh-build-master/dist/Dockerfile.deploy/Dockerfile
+ docker build -t quay.io/app-sre/cincinnati:024bf30 /var/lib/jenkins/workspace/openshift-cincinnati-gh-build-master/dist/Dockerfile.deploy/Dockerfile
unable to prepare context: context must be a directory: /var/lib/jenkins/workspace/openshift-cincinnati-gh-build-master/dist/Dockerfile.deploy/Dockerfile
Build step 'Execute shell' marked build as failure
```