### PR TITLE
graph-builder: move registry into an internal plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ name = "actix-web-codegen"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -272,7 +272,7 @@ name = "actix_derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -323,44 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "async-std"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "async-task 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "broadcaster 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,31 +336,9 @@ name = "async-stream-impl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "async-tar"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "async-task"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -406,7 +346,7 @@ name = "async-trait"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -499,19 +439,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "broadcaster"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -735,28 +662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,7 +704,7 @@ name = "derive_more"
 version = "0.99.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -865,7 +770,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -876,7 +781,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -917,7 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "filetime"
-version = "0.2.8"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1008,22 +913,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel-preview"
-version = "0.3.0-alpha.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "futures-core-preview"
-version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1052,21 +943,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-locks-pre"
-version = "0.5.1-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1077,18 +959,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "futures-sink-preview"
-version = "0.3.0-alpha.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "futures-task"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "futures-timer"
-version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1106,17 +978,6 @@ dependencies = [
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "futures-util-preview"
-version = "0.3.0-alpha.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1165,19 +1026,17 @@ dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert-json-diff 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-compression 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-tar 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cincinnati 0.1.0",
  "commons 0.1.0",
+ "custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dkregistry 0.4.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=712f7dae50068948e8678af535ce90bb63afd878)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-locks-pre 0.5.1-pre (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1192,6 +1051,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,7 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "humantime"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1398,14 +1258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,14 +1356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memoffset"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "mime"
@@ -1665,11 +1509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,16 +1565,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1752,20 +1581,6 @@ dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,7 +1633,7 @@ name = "pin-project-internal"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1880,7 +1695,7 @@ name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1900,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1984,7 +1799,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2301,7 +2116,7 @@ name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2445,7 +2260,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2465,7 +2280,7 @@ name = "syn"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2491,7 +2306,7 @@ name = "tar"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2523,7 +2338,7 @@ name = "test-case"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2822,7 +2637,7 @@ dependencies = [
  "bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2853,7 +2668,7 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2873,7 +2688,7 @@ dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3027,12 +2842,8 @@ dependencies = [
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arc-swap 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "854ede29f7a0ce90519fb2439d030320c6201119b87dab0ee96044603e1130b9"
 "checksum assert-json-diff 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32946b6d31d50d0e35896c864907f9cb7e47b52bd875fa3c058618601cfdefb1"
-"checksum async-compression 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5c52622726d68ec35fec88edfb4ccb862d4f3b3bfa4af2f45142e69ef9b220"
-"checksum async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf6039b315300e057d198b9d3ab92ee029e31c759b7f1afae538145e6f18a3e"
 "checksum async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58982858be7540a465c790b95aaea6710e5139bf8956b1d1344d014fa40100b0"
 "checksum async-stream-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
-"checksum async-tar 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf8c4fd45c1ef482f5f79c78e097c6c49b62f3faa0a048cd606e6a2e3fa4ad7"
-"checksum async-task 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f20c6fda19d0fc02406779587ca4f9a4171cd32e4a5bda0bd016f0a1334c8d4a"
 "checksum async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
@@ -3044,7 +2855,6 @@ dependencies = [
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-"checksum broadcaster 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "07a1446420a56f1030271649ba0da46d23239b3a68c73591cea5247f15a788a0"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 "checksum built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2315cfb416f86e05360edc950b1d7d25ecfb00f7f8eba60dbd7882a0f2e944"
@@ -3066,8 +2876,6 @@ dependencies = [
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
-"checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
-"checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "51764d3d7ee61d1ac25cc99b2cd8cdd9aabffb1b9e8fb17e41dcc5b21a278119"
@@ -3085,7 +2893,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+"checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -3097,20 +2905,14 @@ dependencies = [
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
 "checksum futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
-"checksum futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
 "checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
-"checksum futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 "checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
 "checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
 "checksum futures-locks 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4297dd1d9d6268237e4f93aeb9c90fc1bf0d8cec7e1cef22798939e4c43a251"
-"checksum futures-locks-pre 0.5.1-pre (registry+https://github.com/rust-lang/crates.io-index)" = "9c44b6a2b29acd13a535b6d0b562ed07140a7d043d6f6bec2e7047833fb4c193"
 "checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
 "checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
-"checksum futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 "checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
-"checksum futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
-"checksum futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
@@ -3122,7 +2924,7 @@ dependencies = [
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e"
 "checksum hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
@@ -3135,7 +2937,6 @@ dependencies = [
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -3150,7 +2951,6 @@ dependencies = [
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
@@ -3165,7 +2965,6 @@ dependencies = [
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
-"checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openapiv3 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "13b7c44ac053754dff2ed0a805499f23a098a5173503bf5cf3a51874fb541ab2"
 "checksum openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8152bb5a9b5b721538462336e3bef9a539f892715e5037fda0f984577311af15"
@@ -3173,9 +2972,7 @@ dependencies = [
 "checksum openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)" = "f4fad9e54bd23bd4cbbe48fdc08a1b8091707ac869ef8508edea2fec77dcc884"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
-"checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
-"checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -3189,7 +2986,7 @@ dependencies = [
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
+"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)" = "<none>"
 "checksum protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8aefcec9f142b524d98fc81d07827743be89dd6586a1ba6ab21fa66a500b3fa5"
 "checksum protobuf-codegen 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31539be8028d6b9e8e1b3b7c74e2fa3555302e27b2cc20dbaee6ffba648f75e2"

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -14,9 +14,8 @@ commons = { path = "../commons" }
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "712f7dae50068948e8678af535ce90bb63afd878" }
 env_logger = "^0.6.0"
 failure = "^0.1.1"
-async-compression = { version = "^0.2.0", features = [ "stream", "futures-bufread", "gzip"] }
+flate2 = "^1.0.1"
 futures = "0.3"
-futures-locks-pre = "0.5.1-pre"
 itertools = "^0.8.2"
 lazy_static = "^1.2.0"
 log = "^0.4.3"
@@ -30,14 +29,14 @@ serde_derive = "^1.0.70"
 serde_json = "^1.0.22"
 smart-default = "^0.5.1"
 structopt = "^0.2.10"
-async-tar = "^0.1.1"
+tar = "^0.4.16"
 tokio = "0.2"
 toml = "^0.4.10"
 url = "^1.7.2"
 parking_lot = "^0.8.0"
 tempfile = "^3.1.0"
-async-stream = "0.2"
-async-std = "^1.4.0"
+async-trait = "^0.1"
+custom_debug_derive = "^0.1.7"
 
 [build-dependencies]
 built = "^0.3.2"
@@ -46,7 +45,6 @@ built = "^0.3.2"
 twoway = "^0.2"
 assert-json-diff = "1.0.0"
 test-case = "1.0.0"
-
 
 [features]
 test-net = []

--- a/graph-builder/src/config/cli.rs
+++ b/graph-builder/src/config/cli.rs
@@ -84,7 +84,10 @@ mod tests {
         let repo = "cincinnati/cli-test";
 
         let mut settings = AppSettings::default();
-        assert_eq!(settings.repository, "openshift".to_string());
+        assert_eq!(
+            settings.repository,
+            crate::plugins::release_scrape_dockerv2::DEFAULT_SCRAPE_REPOSITORY
+        );
 
         let args = vec!["argv0", "--upstream.registry.repository", repo];
         let cli = CliOptions::from_iter_safe(args).unwrap();

--- a/graph-builder/src/config/mod.rs
+++ b/graph-builder/src/config/mod.rs
@@ -12,3 +12,6 @@ mod options;
 mod settings;
 
 pub use self::settings::AppSettings;
+
+/// Common prefix for graph-builder metrics.
+pub const METRICS_PREFIX: &str = "cincinnati_gb";

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -37,11 +37,11 @@ pub struct AppSettings {
 
     // TODO(lucab): split this in (TLS, hostname+port).
     /// Target host for the registry scraper.
-    #[default("http://localhost:5000")]
+    #[default(crate::plugins::release_scrape_dockerv2::DEFAULT_SCRAPE_REGISTRY.to_string())]
     pub registry: String,
 
     /// Target image for the registry scraper.
-    #[default("openshift")]
+    #[default(crate::plugins::release_scrape_dockerv2::DEFAULT_SCRAPE_REPOSITORY.to_string())]
     pub repository: String,
 
     /// Listening address for the status service.
@@ -62,8 +62,15 @@ pub struct AppSettings {
     pub disable_quay_api_metadata: bool,
 
     /// Concurrency for graph fetching
-    #[default(16)]
+    #[default(crate::plugins::release_scrape_dockerv2::DEFAULT_FETCH_CONCURRENCY)]
     pub fetch_concurrency: usize,
+
+    /// Metrics which are required to be registered, to be specified without the `METRICS_PREFIX`.
+    /// If these are not registered by the time all plugins have been loaded an error will be thrown.
+    #[default([
+        "graph_upstream_raw_releases",
+    ].iter().cloned().map(Into::into).collect())]
+    pub metrics_required: HashSet<String>,
 }
 
 impl AppSettings {

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -15,9 +15,12 @@ extern crate structopt;
 
 pub mod config;
 pub mod graph;
-pub mod registry;
+pub mod plugins;
 pub mod release;
 pub mod status;
+
+#[cfg(test)]
+pub mod tests;
 
 #[allow(dead_code)]
 /// Build info

--- a/graph-builder/src/plugins/mod.rs
+++ b/graph-builder/src/plugins/mod.rs
@@ -1,0 +1,3 @@
+//! Plugins specific to the graph-builder
+
+pub mod release_scrape_dockerv2;

--- a/graph-builder/src/plugins/release_scrape_dockerv2/mod.rs
+++ b/graph-builder/src/plugins/release_scrape_dockerv2/mod.rs
@@ -1,0 +1,9 @@
+//! This plugin scrapes a Docker V2 compatible registry repository for release images.
+
+pub mod plugin;
+pub mod registry;
+
+pub use plugin::{
+    ReleaseScrapeDockerv2Plugin, ReleaseScrapeDockerv2Settings, DEFAULT_FETCH_CONCURRENCY,
+    DEFAULT_MANIFESTREF_KEY, DEFAULT_SCRAPE_REGISTRY, DEFAULT_SCRAPE_REPOSITORY,
+};

--- a/graph-builder/src/plugins/release_scrape_dockerv2/plugin.rs
+++ b/graph-builder/src/plugins/release_scrape_dockerv2/plugin.rs
@@ -1,0 +1,291 @@
+use super::registry;
+
+use async_trait::async_trait;
+use cincinnati::plugins::prelude::*;
+use cincinnati::plugins::InternalIO;
+use cincinnati::plugins::InternalPlugin;
+use custom_debug_derive::CustomDebug;
+use failure::{Fallible, ResultExt};
+use std::convert::TryInto;
+use std::path::PathBuf;
+
+/// Default registry to scrape.
+pub static DEFAULT_SCRAPE_REGISTRY: &str = "https://quay.io";
+
+/// Default repository to scrape.
+pub static DEFAULT_SCRAPE_REPOSITORY: &str = "openshift-release-dev/ocp-release";
+
+/// Default key for storing and retrieving the manifest reference from the metadata.
+pub static DEFAULT_MANIFESTREF_KEY: &str = "io.openshift.upgrades.graph.release.manifestref";
+
+/// Default fetch concurrency.
+pub static DEFAULT_FETCH_CONCURRENCY: usize = 16;
+
+/// Plugin settings.
+#[derive(Clone, Debug, Deserialize, SmartDefault)]
+#[serde(default)]
+pub struct ReleaseScrapeDockerv2Settings {
+    #[default(DEFAULT_SCRAPE_REGISTRY.to_string())]
+    registry: String,
+
+    #[default(DEFAULT_SCRAPE_REPOSITORY.to_string())]
+    repository: String,
+
+    /// Metadata key where to record the manifest-reference.
+    #[default(DEFAULT_MANIFESTREF_KEY.to_string())]
+    manifestref_key: String,
+
+    #[default(DEFAULT_FETCH_CONCURRENCY)]
+    fetch_concurrency: usize,
+
+    /// Username for authenticating with the registry
+    #[default(Option::None)]
+    username: Option<String>,
+
+    /// Password for authenticating with the registry
+    #[default(Option::None)]
+    password: Option<String>,
+
+    /// File containing the credentials for authenticating with the registry.
+    /// Takes precedence over username and password
+    #[default(Option::None)]
+    credentials_path: Option<PathBuf>,
+}
+
+impl PluginSettings for ReleaseScrapeDockerv2Settings {
+    fn build_plugin(&self, registry: Option<&prometheus::Registry>) -> Fallible<BoxedPlugin> {
+        let plugin = ReleaseScrapeDockerv2Plugin::try_new(self.clone(), None, registry)?;
+        Ok(new_plugin!(InternalPluginWrapper(plugin)))
+    }
+}
+
+/// Metadata fetcher for quay.io API.
+#[derive(CustomDebug)]
+pub struct ReleaseScrapeDockerv2Plugin {
+    settings: ReleaseScrapeDockerv2Settings,
+    registry: registry::Registry,
+    cache: registry::cache::Cache,
+
+    #[debug(skip)]
+    graph_upstream_raw_releases: prometheus::IntGauge,
+}
+
+impl ReleaseScrapeDockerv2Plugin {
+    pub fn try_new(
+        mut settings: ReleaseScrapeDockerv2Settings,
+        cache: Option<registry::cache::Cache>,
+        prometheus_registry: Option<&prometheus::Registry>,
+    ) -> failure::Fallible<Self> {
+        use prometheus::IntGauge;
+        let graph_upstream_raw_releases: IntGauge = IntGauge::new(
+            "graph_upstream_raw_releases",
+            "Number of releases fetched from upstream, before processing",
+        )?;
+
+        if let Some(prometheus_registry) = &prometheus_registry {
+            prometheus_registry.register(Box::new(graph_upstream_raw_releases.clone()))?;
+        }
+
+        let registry = registry::Registry::try_from_str(&settings.registry)
+            .context(format!("Parsing {} as Registry", &settings.registry))?;
+
+        if let Some(credentials_path) = &settings.credentials_path {
+            let (username, password) =
+                registry::read_credentials(Some(&credentials_path), &registry.host).context(
+                    format!("Reading registry credentials from {:?}", credentials_path),
+                )?;
+
+            settings.username = username;
+            settings.password = password;
+        }
+
+        Ok(Self {
+            settings,
+            registry,
+            cache: cache.unwrap_or_else(registry::cache::new),
+            graph_upstream_raw_releases,
+        })
+    }
+}
+
+#[async_trait]
+impl InternalPlugin for ReleaseScrapeDockerv2Plugin {
+    async fn run_internal(self: &Self, io: InternalIO) -> Fallible<InternalIO> {
+        let releases = registry::fetch_releases(
+            &self.registry,
+            &self.settings.repository,
+            self.settings.username.as_ref().map(String::as_ref),
+            self.settings.password.as_ref().map(String::as_ref),
+            self.cache.clone(),
+            &self.settings.manifestref_key,
+            self.settings.fetch_concurrency,
+        )
+        .await
+        .context("failed to fetch all release metadata")?;
+
+        if releases.is_empty() {
+            warn!(
+                "could not find any releases in {}/{}",
+                &self.registry.host_port_string(),
+                &self.settings.repository
+            );
+        };
+
+        self.graph_upstream_raw_releases
+            .set(releases.len().try_into()?);
+
+        let graph = crate::graph::create_graph(releases).unwrap();
+
+        Ok(InternalIO {
+            graph,
+            parameters: io.parameters,
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "test-net")]
+mod network_tests {
+    use super::*;
+    use crate::tests::common_init;
+    use cincinnati::testing::{TestGraphBuilder, TestMetadata};
+    use failure::{Fallible, ResultExt};
+    use std::collections::HashSet;
+
+    #[test]
+    fn scrape_public_multiarch_manual_succeeds() -> Fallible<()> {
+        let (mut runtime, _) = common_init();
+
+        let registry = "https://quay.io";
+        let repo = "redhat/openshift-cincinnati-test-public-multiarch-manual";
+
+        let plugin = Box::new(ReleaseScrapeDockerv2Plugin::try_new(
+            // settings
+            toml::from_str::<ReleaseScrapeDockerv2Settings>(&format!(
+                r#"
+                        registry = "{}"
+                        repository = "{}"
+                        manifestref_key = "{}"
+                        fetch_concurrency = {}
+                    "#,
+                &registry, &repo, DEFAULT_MANIFESTREF_KEY, DEFAULT_FETCH_CONCURRENCY,
+            ))?,
+            // cache
+            None,
+            // prometheus registry
+            None,
+        )?);
+
+        let graph: cincinnati::Graph = {
+            let mut graph_raw = runtime
+                .block_on(plugin.run_internal(InternalIO {
+                    graph: Default::default(),
+                    parameters: Default::default(),
+                }))?
+                .graph;
+
+            // remove unwanted metadata
+            let unwanted_metadata_keys = [
+                DEFAULT_MANIFESTREF_KEY,
+                "io.openshift.upgrades.graph.release.channels",
+                "io.openshift.upgrades.graph.previous.add",
+                "io.openshift.upgrades.graph.previous.remove",
+                "io.openshift.upgrades.graph.release.arch",
+            ]
+            .iter()
+            .cloned()
+            .map(String::from)
+            .collect::<HashSet<String>>();
+
+            graph_raw
+                .iter_releases_mut(|ref mut release| {
+                    match release {
+                        cincinnati::Release::Concrete(ref mut release) => {
+                            // replace digest by tag to match expectency
+                            let version = release.version.to_string();
+                            let source_front = release.payload.split('@').nth(0).unwrap();
+                            release.payload = format!("{}:{}", source_front, version);
+
+                            // remove unwanted metadata
+                            release
+                                .metadata
+                                .retain(|k, _| !unwanted_metadata_keys.contains(k));
+
+                            Ok(())
+                        }
+                        _ => panic!("should not get here"),
+                    }
+                })
+                .context("Post-processing the received graph to match the test expectations")?;
+
+            graph_raw
+        };
+
+        let expected_graph: cincinnati::Graph = {
+            let input_edges = Some(vec![(0, 1), (1, 2), (2, 3), (3, 4), (5, 6)]);
+            let input_metadata: TestMetadata = vec![
+                (
+                    0,
+                    [(String::from("version_suffix"), String::from("+amd64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+                (
+                    1,
+                    [(String::from("version_suffix"), String::from("+amd64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+                (
+                    2,
+                    [(String::from("version_suffix"), String::from("+amd64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+                (
+                    3,
+                    [(String::from("version_suffix"), String::from("+amd64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+                (
+                    4,
+                    [(String::from("version_suffix"), String::from("+amd64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+                (
+                    2,
+                    [(String::from("version_suffix"), String::from("+arm64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+                (
+                    3,
+                    [(String::from("version_suffix"), String::from("+arm64"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+            ];
+
+            TestGraphBuilder::new()
+                .with_image(&format!("quay.io/{}", repo))
+                .with_metadata(input_metadata)
+                .with_edges(input_edges)
+                .with_version_template("0.0.{{i}}")
+                .enable_payload_suffix(true)
+                .build()
+        };
+
+        assert_eq!(expected_graph, graph);
+
+        Ok(())
+    }
+}

--- a/graph-builder/src/plugins/release_scrape_dockerv2/registry/network_tests.rs
+++ b/graph-builder/src/plugins/release_scrape_dockerv2/registry/network_tests.rs
@@ -1,16 +1,19 @@
+use crate as graph_builder;
+use crate::tests::common_init;
+use crate::tests::remove_metadata_by_key;
 use cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_MANIFESTREF_KEY as MANIFESTREF_KEY;
-use cincinnati::testing::{TestGraphBuilder, TestMetadata};
 use cincinnati::{Empty, WouldCycle};
-use failure::{Fallible, ResultExt};
+use failure::Fallible;
 use graph_builder::graph::create_graph;
-use graph_builder::registry::{self, fetch_releases, Registry, Release};
+use graph_builder::plugins::release_scrape_dockerv2::registry::{self, fetch_releases, Registry};
+use graph_builder::release::Release;
 use graph_builder::release::{Metadata, MetadataKind::V0};
 use itertools::Itertools;
 use semver::Version;
 use std::collections::HashMap;
 
 #[cfg(feature = "test-net-private")]
-use graph_builder::registry::read_credentials;
+use graph_builder::plugins::release_scrape_dockerv2::registry::read_credentials;
 
 lazy_static::lazy_static! {
     static ref FETCH_CONCURRENCY: usize = {
@@ -18,21 +21,6 @@ lazy_static::lazy_static! {
         app_settings.fetch_concurrency
     };
 
-}
-
-fn init_logger() {
-    let _ = env_logger::try_init_from_env(env_logger::Env::default());
-}
-
-fn common_init() -> (
-    tokio::runtime::Runtime,
-    graph_builder::registry::cache::Cache,
-) {
-    init_logger();
-    (
-        tokio::runtime::Runtime::new().unwrap(),
-        graph_builder::registry::cache::new(),
-    )
 }
 
 fn expected_releases(
@@ -112,26 +100,12 @@ macro_rules! assert_permutation_results {
     };
 }
 
-fn remove_metadata_by_key(releases: &mut Vec<Release>, key: &str) {
-    for release in releases.iter_mut() {
-        release.metadata.metadata.remove(key);
-    }
-}
-
-fn replace_sha_by_version_in_source(releases: &mut Vec<Release>) {
-    for release in releases.iter_mut() {
-        let version = release.metadata.version.to_string();
-        let source_front = release.source.split("@").nth(0).unwrap();
-        release.source = format!("{}:{}", source_front, version);
-    }
-}
-
 #[cfg(feature = "test-net-private")]
 #[test]
 fn fetch_release_private_with_credentials_must_succeed() {
     use std::path::PathBuf;
 
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let registry = Registry::try_from_str("quay.io").unwrap();
     let repo = "redhat/openshift-cincinnati-test-private-manual";
@@ -149,7 +123,7 @@ fn fetch_release_private_with_credentials_must_succeed() {
             &repo,
             username.as_ref().map(String::as_ref),
             password.as_ref().map(String::as_ref),
-            &mut cache,
+            cache,
             MANIFESTREF_KEY,
             *FETCH_CONCURRENCY,
         ))
@@ -184,7 +158,7 @@ fn fetch_release_private_with_credentials_must_succeed() {
 
 #[test]
 fn fetch_release_private_without_credentials_must_fail() {
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let registry = Registry::try_from_str("quay.io").unwrap();
     let repo = "redhat/openshift-cincinnati-test-private-manual";
@@ -193,7 +167,7 @@ fn fetch_release_private_without_credentials_must_fail() {
         &repo,
         None,
         None,
-        &mut cache,
+        cache,
         MANIFESTREF_KEY,
         *FETCH_CONCURRENCY,
     ));
@@ -210,7 +184,7 @@ fn fetch_release_private_without_credentials_must_fail() {
 
 #[test]
 fn fetch_release_public_with_no_release_metadata_must_not_error() {
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let registry = Registry::try_from_str("quay.io").unwrap();
     let repo = "redhat/openshift-cincinnati-test-nojson-public-manual";
@@ -220,7 +194,7 @@ fn fetch_release_public_with_no_release_metadata_must_not_error() {
             &repo,
             None,
             None,
-            &mut cache,
+            cache,
             MANIFESTREF_KEY,
             *FETCH_CONCURRENCY,
         ))
@@ -230,7 +204,7 @@ fn fetch_release_public_with_no_release_metadata_must_not_error() {
 
 #[test]
 fn fetch_release_public_with_first_empty_tag_must_succeed() {
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let registry = Registry::try_from_str("quay.io").unwrap();
     let repo = "redhat/openshift-cincinnati-test-emptyfirsttag-public-manual";
@@ -240,7 +214,7 @@ fn fetch_release_public_with_first_empty_tag_must_succeed() {
             &repo,
             None,
             None,
-            &mut cache,
+            cache,
             MANIFESTREF_KEY,
             *FETCH_CONCURRENCY,
         ))
@@ -273,7 +247,7 @@ fn fetch_release_public_with_first_empty_tag_must_succeed() {
 
 #[test]
 fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let test = |registry: Registry| {
         let repo = "redhat/openshift-cincinnati-test-public-manual";
@@ -284,7 +258,7 @@ fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
                 &repo,
                 username.as_ref().map(String::as_ref),
                 password.as_ref().map(String::as_ref),
-                &mut cache,
+                cache.clone(),
                 MANIFESTREF_KEY,
                 *FETCH_CONCURRENCY,
             ))
@@ -329,7 +303,7 @@ fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
 
 #[test]
 fn fetch_release_with_cyclic_metadata_fails() -> Fallible<()> {
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let registry = Registry::try_from_str("quay.io").unwrap();
     let repo = "redhat/openshift-cincinnati-test-cyclic-public-manual";
@@ -342,7 +316,7 @@ fn fetch_release_with_cyclic_metadata_fails() -> Fallible<()> {
             &repo,
             username,
             password,
-            &mut cache,
+            cache,
             MANIFESTREF_KEY,
             *FETCH_CONCURRENCY,
         ))
@@ -363,7 +337,7 @@ fn fetch_release_with_cyclic_metadata_fails() -> Fallible<()> {
 
 #[test]
 fn fetch_releases_public_multiarch_manual_succeeds() -> Fallible<()> {
-    let (mut runtime, mut cache) = common_init();
+    let (mut runtime, cache) = common_init();
 
     let registry = registry::Registry::try_from_str("https://quay.io")?;
     let repo = "redhat/openshift-cincinnati-test-public-multiarch-manual";
@@ -374,120 +348,13 @@ fn fetch_releases_public_multiarch_manual_succeeds() -> Fallible<()> {
             &repo,
             username.as_ref().map(String::as_ref),
             password.as_ref().map(String::as_ref),
-            &mut cache,
+            cache,
             MANIFESTREF_KEY,
             *FETCH_CONCURRENCY,
         ))
         .expect("fetch_releases failed: ");
 
     assert_eq!(7, releases.len());
-
-    Ok(())
-}
-
-#[test]
-fn create_graph_public_multiarch_manual_succeeds() -> Fallible<()> {
-    let (mut runtime, mut cache) = common_init();
-
-    let registry = registry::Registry::try_from_str("https://quay.io")?;
-    let repo = "redhat/openshift-cincinnati-test-public-multiarch-manual";
-    let (username, password) = (None, None);
-
-    let releases = {
-        let mut fetched_releases = runtime
-            .block_on(fetch_releases(
-                &registry,
-                &repo,
-                username.as_ref().map(String::as_ref),
-                password.as_ref().map(String::as_ref),
-                &mut cache,
-                MANIFESTREF_KEY,
-                *FETCH_CONCURRENCY,
-            ))
-            .context("fetch_releases failed: ")?;
-
-        replace_sha_by_version_in_source(&mut fetched_releases);
-
-        // remove unwanted metadata
-        [
-            MANIFESTREF_KEY,
-            "io.openshift.upgrades.graph.release.channels",
-            "io.openshift.upgrades.graph.previous.add",
-            "io.openshift.upgrades.graph.previous.remove",
-            "io.openshift.upgrades.graph.release.arch",
-        ]
-        .iter()
-        .for_each(|key| remove_metadata_by_key(&mut fetched_releases, key));
-
-        fetched_releases
-    };
-
-    let graph = create_graph(releases).expect("create_graph failed");
-
-    let expected_graph: cincinnati::Graph = {
-        let input_edges = Some(vec![(0, 1), (1, 2), (2, 3), (3, 4), (5, 6)]);
-        let input_metadata: TestMetadata = vec![
-            (
-                0,
-                [(String::from("version_suffix"), String::from("+amd64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-            (
-                1,
-                [(String::from("version_suffix"), String::from("+amd64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-            (
-                2,
-                [(String::from("version_suffix"), String::from("+amd64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-            (
-                3,
-                [(String::from("version_suffix"), String::from("+amd64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-            (
-                4,
-                [(String::from("version_suffix"), String::from("+amd64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-            (
-                2,
-                [(String::from("version_suffix"), String::from("+arm64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-            (
-                3,
-                [(String::from("version_suffix"), String::from("+arm64"))]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ),
-        ];
-
-        TestGraphBuilder::new()
-            .with_image(&format!("quay.io/{}", repo))
-            .with_metadata(input_metadata.clone())
-            .with_edges(input_edges.clone())
-            .with_version_template("0.0.{{i}}")
-            .enable_payload_suffix(true)
-            .build()
-    };
-
-    assert_eq!(expected_graph, graph);
 
     Ok(())
 }

--- a/graph-builder/src/release.rs
+++ b/graph-builder/src/release.rs
@@ -17,7 +17,23 @@ use semver::Version;
 use std::collections::HashMap;
 use std::fmt;
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Release {
+    pub source: String,
+    pub metadata: Metadata,
+}
+
+impl Into<cincinnati::Release> for Release {
+    fn into(self) -> cincinnati::Release {
+        cincinnati::Release::Concrete(cincinnati::ConcreteRelease {
+            version: self.metadata.version.to_string(),
+            payload: self.source,
+            metadata: self.metadata.metadata,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Metadata {
     pub kind: MetadataKind,
     pub version: Version,
@@ -43,7 +59,7 @@ impl fmt::Display for Metadata {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum MetadataKind {
     #[serde(rename = "cincinnati-metadata-v0")]
     V0,

--- a/graph-builder/src/tests/mod.rs
+++ b/graph-builder/src/tests/mod.rs
@@ -1,0 +1,22 @@
+//! Common functionality for graph-builder tests
+
+use crate as graph_builder;
+use graph_builder::plugins::release_scrape_dockerv2::registry::{self};
+
+fn init_logger() {
+    let _ = env_logger::try_init_from_env(env_logger::Env::default());
+}
+
+pub fn common_init() -> (tokio::runtime::Runtime, registry::cache::Cache) {
+    init_logger();
+    (
+        tokio::runtime::Runtime::new().unwrap(),
+        registry::cache::new(),
+    )
+}
+
+pub fn remove_metadata_by_key(releases: &mut Vec<graph_builder::release::Release>, key: &str) {
+    for release in releases.iter_mut() {
+        release.metadata.metadata.remove(key);
+    }
+}

--- a/graph-builder/tests/mod.rs
+++ b/graph-builder/tests/mod.rs
@@ -1,9 +1,2 @@
-#[cfg(feature = "test-net")]
-#[macro_use]
-extern crate failure;
-
-#[cfg(feature = "test-net")]
-mod net;
-
 #[cfg(feature = "test-e2e")]
 mod e2e;

--- a/graph-builder/tests/net/mod.rs
+++ b/graph-builder/tests/net/mod.rs
@@ -1,1 +1,0 @@
-mod quay_io;


### PR DESCRIPTION
Moving the container registry scraper functionality into a plugin gives
very high flexibility to swap the release metadata out for something
else very easily. It also allows it to be reused by any code which knows
how to execute internal cincinnati plugins. To not make this change more
invasive, I decided to leave the code of the new plugin in the
graph-builder crate as opposed to moving it to the cincinnati crate.

Other notable changes:

* Changed metrics semantics and organization

  Because code which lives in the new plugin responsible for the
  `graph_upstream_raw_releases` metric, I found it necessary to
  introduce a mechanism to help ensure that certain metrics are
  registered after the plugin chain is loaded.
  This mechanism can be refined in the future, and could possibly be
  turned into a contract API between the main service and the plugins,
  which could specify what metrics are handled by which plugin.

* Moved the graph-builder/tests/net tests to the plugin

  Because these tests are all specific to fetching releases from a
  container registry, they belong to this plugin now. The registry tests
  were moved verbatim and corrected to match its environmment. One
  exception tot his is `create_graph_public_multiarch_manual_succeeds`,
  which also uses the higher-level `create_graph` function and was
  therefore renamed to `scrape_public_multiarch_manual_succeeds` and
  refactored to test the outcome of the plugin introduced in this
  change.

* Reverted async metadata processing

  Unfortunately it was necessary to revert recent code which used an async
  interface for the metadata assembly. The reason is that even though the
  code is async, it doesn't fulfill the `Sync + Send` trait bound required
  by the cincinnati plugin interface. For now, the synchronous metadata
  assembly is spawned using tokio's spawn_blocking [0], which offloads
  blocking task to a dedicated thread-pool.

  > Revert "Merge pull request #206 from steveeJ-forks/pr/gb-parse-metadata-async"

  > This reverts commit 3780abe,
  > reversing changes made to f957a5f.

  [0]: https://docs.rs/tokio/0.2.11/tokio/task/fn.spawn_blocking.html