### PR TITLE
dist/openshift/graph-data-sync: Syncer Deployment

### DIFF
--- a/dist/openshift/graph-data-sync.yaml
+++ b/dist/openshift/graph-data-sync.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: cincinnati
+objects:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: cincinnati-graph-data-sync
+      name: cincinnati-graph-data-sync
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: cincinnati-graph-data-sync
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: cincinnati-graph-data-sync
+          name: cincinnati-graph-data-sync
+        spec:
+          containers:
+            - args:
+                - -c
+                - |
+                  set -euo pipefail
+
+                  pip install --user PyYAML
+
+                  cd /tmp
+                  while sleep 600
+                  do
+                    rm -rf blocked-edges channels
+                    curl -L https://github.com/openshift/cincinnati-graph-data/archive/master.tar.gz |
+                      tar -xzv --strip-components=1
+                    hack/graph-util.py push-to-quay --token-file /etc/secrets/registry-credentials
+                  done
+              command:
+                - /bin/bash
+              env:
+                - name: HOME
+                  value: /tmp
+              image: docker.io/library/python:3
+              imagePullPolicy: Always
+              name: cincinnati-graph-data-sync
+              resources:
+                limits:
+                  cpu: 300m
+                  memory: 128Mi
+                requests:
+                  cpu: 100m
+                  memory: 32Mi
+              volumeMounts:
+                - mountPath: /etc/secrets
+                  name: secrets
+                  readOnly: 'true'
+          volumes:
+            - name: secrets
+              secret:
+                secretName: cincinnati-graph-data-sync-registry-credentials


### PR DESCRIPTION
I tried to use CentOS 8 from docker.io, since that seems to be [their canonical container image][1].  We only need Python, Bash, tar, and POSIX utilities.  But jobs launched with that base failed with:

```
env: 'python': No such file or directory
```

so now I'm using Docker's Python container.

Setting HOME avoids:

```
Installing collected packages: PyYAML
ERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/.local'
```

Docs on Templates [here][2], but if you don't want to read through all of that, you can apply this to a cluster with:

```console
$ oc process -f graph-data-sync.yaml --local -o yaml | oc -n "${YOUR_NAMESPACE}" create -f -
```

(after creating a secret in that namespace with the quay.io token to use).

This should provide a functional stopgap until we have time to teach the graph builder about consuming the cincinnati-graph-data format directly.  I don't think it's worth putting all that much polish on the stopgap.

[1]: https://www.centos.org/download/
[2]: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/images/using-templates