### PR TITLE
WIP prow_rustfmt: run cargo build

### DIFF
--- a/dist/prow_rustfmt.sh
+++ b/dist/prow_rustfmt.sh
@@ -8,3 +8,6 @@ test -z ${1} || TOOLCHAIN_ARG="--toolchain ${1}"
 test -z ${1} || CARGO="rustup run ${1} cargo"
 rustup component add rustfmt ${TOOLCHAIN_ARG}
 ${CARGO} fmt --all -- --check
+
+# Run the test build
+cargo build


### PR DESCRIPTION

This ensures the project builds in all 3 Rust versions, instead of
just the latest