### PR TITLE
cargo_test: run `cargo kcov` to collect coverage in unittests

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -26,7 +26,6 @@ RUN \
   pushd $HOME/kcov && \
   curl https://codeload.github.com/SimonKagstrom/kcov/tar.gz/v36 | tar -xz --strip-components=1 && \
   cmake . && make && make install
-RUN cargo install cargo-kcov
 
 RUN \
   mkdir -p $HOME/.cargo/git/ && \

--- a/dist/cargo_test.sh
+++ b/dist/cargo_test.sh
@@ -14,6 +14,7 @@ if [[ -n "${CINCINNATI_TEST_CREDENTIALS_PATH}" && -n "${CINCINNATI_TEST_QUAY_API
     cargo_test_flags["cincinnati"]+=",test-net-private"
     cargo_test_flags["graph-builder"]+=",test-net-private"
     cargo_test_flags["quay"]+=",test-net-private"
+
     export CINCINNATI_TEST_QUAY_API_TOKEN="$(cat ${CINCINNATI_TEST_QUAY_API_TOKEN_PATH})"
 fi
 
@@ -22,16 +23,50 @@ executors["cargo"]="execute_native"
 executors["docker"]="execute_docker"
 
 function run_tests() {
+  set -x
+  export CARGO_TARGET_DIR="$PWD/target"
+
+  if [[ $(type -f kcov) ]]; then
+    export HAS_KOV="${HAS_KOV:-1}"
+    rm -rf "${CARGO_TARGET_DIR}"/cov
+  fi
+
   for directory in ${!cargo_test_flags[*]}; do
+    if [[ ${HAS_KOV} -eq 1 ]]; then
+      # we want to prevent completely untested functions to be stripped
+      export RUSTFLAGS='-C link-dead-code'
+      export CARGO_ARGS="test --no-run"
+
+      # delete leftover test executibles
+      [[ ! -d "${CARGO_TARGET_DIR}"/debug ]] || find "${CARGO_TARGET_DIR}"/debug/ -maxdepth 1 -type f -executable -print -delete
+    fi
+
     (
-      set -x;
       ${1} /usr/bin/env bash -c "\
-        cd ${directory} && \
-        export CARGO_TARGET_DIR=\"../target\" && \
-        cargo ${CARGO_ARGS:-test --release} ${cargo_test_flags[${directory}]} && \
-      :"
+        cd ${directory}
+        cargo ${CARGO_ARGS:-test} ${cargo_test_flags[${directory}]}
+
+        if [[ ${HAS_KOV} -eq 1 ]]; then
+          rm -f \"${CARGO_TARGET_DIR}\"/debug/${directory}
+          find \"${CARGO_TARGET_DIR}\"/debug/ -maxdepth 1 -type f -executable -print -exec \
+          kcov \
+              --exclude-pattern=$HOME/.cargo \
+              --verify \
+              ${CARGO_TARGET_DIR}/cov \
+              {} \\;
+        fi
+      "
     )
+
   done
+
+  if [[ ${HAS_KOV} -eq 1 && -n "${ARTIFACTS_DIR}" ]]; then
+    mkdir -p "${ARTIFACTS_DIR}"
+    [[ ! -e "${ARTIFACTS_DIR}"/cov ]] || rm -rf "${ARTIFACTS_DIR}"/cov
+    cp -rf "${CARGO_TARGET_DIR}"/cov "${ARTIFACTS_DIR}"/
+  fi
+
+  set +x
 }
 
 function execute_native() {


### PR DESCRIPTION
TODO:

* [x] Improve `cargo-test` to take less time
* [x] Save coverage report to test artifacts

kcov report would be stored in artifacts - `cargo-test/kcov-merged/index.html`.

[Current results](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cincinnati/228/pull-ci-openshift-cincinnati-master-cargo-test/927/artifacts/cargo-test/cov/kcov-merged/index.html)