### PR TITLE
graph-builder/tests/e2e: make sorting algorithm (hopefully) fully predictable

### DIFF
--- a/commons/src/testing.rs
+++ b/commons/src/testing.rs
@@ -22,3 +22,98 @@ pub fn dummy_gauge(registry: &prometheus::Registry, value: f64) -> Fallible<()> 
     registry.register(Box::new(test_gauge))?;
     Ok(())
 }
+
+/// Sort the JSON value represantion of a graph by version.
+pub fn sort_json_graph_by_version(v: &mut serde_json::Value) {
+    if !v.is_object() {
+        panic!("not an object");
+    }
+    let obj = v.as_object_mut().unwrap();
+
+    let mut index_map = std::collections::HashMap::<usize, usize>::new();
+
+    {
+        let mut version_index =
+            std::collections::HashMap::<String, (Option<usize>, Option<usize>)>::new();
+
+        let nodes = obj.get_mut("nodes").unwrap();
+        nodes
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .for_each(|(i, node)| {
+                let version = node.get("version").unwrap().as_str().unwrap();
+                version_index.insert(version.to_string(), (Some(i), None));
+            });
+
+        nodes.as_array_mut().unwrap().sort_unstable_by(|a, b| {
+            a.get("version")
+                .unwrap()
+                .as_str()
+                .cmp(&b.get("version").unwrap().as_str())
+        });
+
+        nodes
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .for_each(|(i, node)| {
+                let version = node.get("version").unwrap().as_str().unwrap();
+                version_index
+                    .entry(version.to_string())
+                    .and_modify(|(from, to)| {
+                        *to = Some(i);
+                        println!(
+                            "{} changed index from {} to {}",
+                            version,
+                            from.unwrap(),
+                            to.unwrap()
+                        );
+                        index_map.insert(from.unwrap(), to.unwrap());
+                    });
+            });
+    }
+
+    obj.get_mut("edges")
+        .unwrap()
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .for_each(|ref mut edge: &mut serde_json::Value| {
+            if edge.as_array().unwrap().len() < 2 {
+                return;
+            }
+
+            macro_rules! rewrite_edge_index {
+                ($edge_index:expr) => {
+                    let old = edge.get_mut($edge_index).unwrap();
+                    let new = {
+                        let old_usize = old.as_u64().unwrap() as usize;
+                        let new_i64 = *index_map.get(&old_usize).unwrap() as i64;
+                        serde_json::Value::Number(serde_json::Number::from(new_i64))
+                    };
+                    println!("Rewriting {:?} -> {:?})", old, new);
+                    *old = new;
+                };
+            }
+
+            rewrite_edge_index!(0);
+            rewrite_edge_index!(1);
+        });
+
+    // Sort the edges array. This is necessary in case of nodes having multiple edges.
+    obj.get_mut("edges")
+        .unwrap()
+        .as_array_mut()
+        .unwrap()
+        .sort_unstable_by(|a, b| {
+            let a0 = a.get(0).unwrap().as_u64().unwrap();
+            let a1 = a.get(1).unwrap().as_u64().unwrap();
+            let b0 = b.get(0).unwrap().as_u64().unwrap();
+            let b1 = b.get(1).unwrap().as_u64().unwrap();
+
+            a0.cmp(&b0).then_with(|| a1.cmp(&b1))
+        });
+}

--- a/graph-builder/tests/e2e/mod.rs
+++ b/graph-builder/tests/e2e/mod.rs
@@ -1,90 +1,10 @@
-#[cfg(feature = "test-e2e")]
 use assert_json_diff::assert_json_include;
+use commons::testing::sort_json_graph_by_version;
 use reqwest::header::{HeaderValue, ACCEPT};
 use serde_json::Value;
 use std::env;
 use test_case::test_case;
 use url::Url;
-
-pub fn sort_by_version(v: &mut Value) {
-    if !v.is_object() {
-        return;
-    }
-    let obj = v.as_object_mut().unwrap();
-
-    let mut index_map = std::collections::HashMap::<usize, usize>::new();
-
-    {
-        let mut version_index =
-            std::collections::HashMap::<String, (Option<usize>, Option<usize>)>::new();
-
-        let nodes = obj.get_mut("nodes").unwrap();
-        nodes
-            .as_array()
-            .unwrap()
-            .iter()
-            .enumerate()
-            .for_each(|(i, node)| {
-                let version = node.get("version").unwrap().as_str().unwrap();
-                version_index.insert(version.to_string(), (Some(i), None));
-            });
-
-        nodes.as_array_mut().unwrap().sort_unstable_by(|a, b| {
-            a.get("version")
-                .unwrap()
-                .as_str()
-                .cmp(&b.get("version").unwrap().as_str())
-        });
-
-        nodes
-            .as_array()
-            .unwrap()
-            .iter()
-            .enumerate()
-            .for_each(|(i, node)| {
-                let version = node.get("version").unwrap().as_str().unwrap();
-                version_index
-                    .entry(version.to_string())
-                    .and_modify(|(from, to)| {
-                        *to = Some(i);
-                        println!(
-                            "{} changed index from {} to {}",
-                            version,
-                            from.unwrap(),
-                            to.unwrap()
-                        );
-                        index_map.insert(from.unwrap(), to.unwrap());
-                    });
-            });
-    }
-
-    obj.get_mut("edges")
-        .unwrap()
-        .as_array_mut()
-        .unwrap()
-        .iter_mut()
-        .for_each(|ref mut edge: &mut serde_json::Value| {
-            if edge.as_array().unwrap().len() < 2 {
-                return;
-            }
-
-            macro_rules! rewrite_edge_index {
-                ($edge_index:expr) => {
-                    let old = edge.get_mut($edge_index).unwrap();
-                    let new = {
-                        let old_usize = old.as_u64().unwrap() as usize;
-                        let new_i64 = *index_map.get(&old_usize).unwrap() as i64;
-                        serde_json::Value::Number(serde_json::Number::from(new_i64))
-                    };
-                    println!("Rewriting {:?} -> {:?})", old, new);
-                    *old = new;
-                };
-            }
-
-            rewrite_edge_index!(0);
-            rewrite_edge_index!(1);
-        })
-}
 
 #[test_case("a",    "amd64", include_str!("./testdata/a-amd64.json");    "channel a amd64")]
 #[test_case("b",    "amd64", include_str!("./testdata/b-amd64.json");    "channel b amd64")]
@@ -98,7 +18,7 @@ fn e2e_channel_success(channel: &'static str, arch: &'static str, testdata: &str
     };
 
     let mut expected: Value = serde_json::from_str(testdata).unwrap();
-    sort_by_version(&mut expected);
+    sort_json_graph_by_version(&mut expected);
 
     let mut graph_url = Url::parse(&graph_base_url).unwrap();
     graph_url
@@ -122,6 +42,6 @@ fn e2e_channel_success(channel: &'static str, arch: &'static str, testdata: &str
     assert_eq!(res.status().is_success(), true);
     let text = runtime.block_on(res.text()).unwrap();
     let mut actual = serde_json::from_str(&text).unwrap();
-    sort_by_version(&mut actual);
+    sort_json_graph_by_version(&mut actual);
     assert_json_include!(actual: actual, expected: expected)
 }


### PR DESCRIPTION
This adds a fix to also sort the
edges array in itself. This is required to make the output fully
predictable in case a node has multiple edges, and thus makes the output assertable for equality.

The function has also been moved to a common place for reusage in other tests.

/cc @vrutkovs 