### PR TITLE
e2e: wait for default serviceaccount to appear

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -22,7 +22,7 @@ oc create secret generic cincinnati-registry-credentials --from-file=registry-cr
 oc create secret generic ci-pull-secret --from-file=.dockercfg=/tmp/cluster/pull-secret --type=kubernetes.io/dockercfg
 
 # Wait for default service account to appear
-for ATTEMPT is $(seq 0 5); do
+for ATTEMPT in $(seq 0 5); do
   oc get serviceaccount default && break
   sleep 5
 done

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -20,6 +20,13 @@ oc create secret generic cincinnati-registry-credentials --from-file=registry-cr
 
 # Use this pull secret to fetch images from CI
 oc create secret generic ci-pull-secret --from-file=.dockercfg=/tmp/cluster/pull-secret --type=kubernetes.io/dockercfg
+
+# Wait for default service account to appear
+for ATTEMPT is $(seq 0 5); do
+  oc get serviceaccount default && break
+  sleep 5
+done
+# Allow default serviceaccount to use CI pull secret
 oc secrets link default ci-pull-secret --for=pull
 
 # Apply oc template


### PR DESCRIPTION

Default serviceaccount is created after new project, so before linking
a pull request to it the script should wait for default SA to exist