### PR TITLE
graph-builder/plugins/github scraper: add token authorization handling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ coverage: test _coverage
 test-pwd +args="":
 	#!/usr/bin/env bash
 	set -e
-	export RUST_BACKTRACE=0 RUST_LOG="graph-builder=trace,cincinnati=trace,dkregistry=trace"
+	export RUST_BACKTRACE=1 RUST_LOG="graph-builder=trace,cincinnati=trace,dkregistry=trace"
 	pushd {{invocation_directory()}}
 	cargo test {{args}}
 

--- a/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/mod.rs
@@ -9,4 +9,5 @@ pub mod plugin;
 
 pub use plugin::{
     GithubOpenshiftSecondaryMetadataScraperPlugin, GithubOpenshiftSecondaryMetadataScraperSettings,
+    GITHUB_SCRAPER_TOKEN_PATH_ENV,
 };

--- a/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
@@ -66,6 +66,8 @@ pub struct GithubOpenshiftSecondaryMetadataScraperPlugin {
     #[default(FuturesMutex::new(Default::default()))]
     state: FuturesMutex<State>,
     oauth_token: Option<String>,
+
+    client: reqwest::Client,
 }
 
 impl GithubOpenshiftSecondaryMetadataScraperPlugin {
@@ -117,7 +119,8 @@ impl GithubOpenshiftSecondaryMetadataScraperPlugin {
         trace!("Getting branches from {}", &url);
 
         let request = {
-            let request = reqwest::Client::new()
+            let request = self
+                .client
                 .get(&url)
                 .header(reqwest::header::USER_AGENT, USER_AGENT)
                 .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json");

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -39,6 +39,9 @@ objects:
                     configMapKeyRef:
                       key: gb.rust_backtrace
                       name: cincinnati
+              envFrom:
+                - configMapRef:
+                    name: environment-secrets
               command:
                 - ${GB_BINARY}
               args: [
@@ -201,6 +204,11 @@ objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
+      name: environment-secrets
+    data: ${{ENVIRONMENT_SECRETS}}
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
       name: cincinnati-configs
     data:
       gb.toml: |
@@ -323,3 +331,5 @@ parameters:
     displayName: Set RUST_BACKTRACE env var
   - name: GB_CONFIG_PATH
     value: "/etc/configs/gb.toml"
+  - name: ENVIRONMENT_SECRETS
+    value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -67,6 +67,7 @@ oc new-app -f dist/openshift/cincinnati.yaml \
       [[plugin_settings]]
       name = "edge-add-remove"
   ' \
+  -p ENVIRONMENT_SECRETS="{}" \
   ;
 
 # Wait for dc to rollout


### PR DESCRIPTION
This implements reading a token from a file and setting the authorization header on the request towards the GitHub API.

It also adjusts the deployment template.

- [x] Github API token for CI https://github.com/openshift/release/pull/7356
- [x] Github API token for stage https://gitlab.cee.redhat.com/service/app-interface/merge_requests/3392
- [x] Based on #245