### PR TITLE
dist/openshift: migrate graph-builder to toml config

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -34,31 +34,6 @@ objects:
               imagePullPolicy: Always
               name: cincinnati-graph-builder
               env:
-                - name: ADDRESS
-                  valueFrom:
-                    configMapKeyRef:
-                      key: gb.address
-                      name: cincinnati
-                - name: STATUS_ADDRESS
-                  valueFrom:
-                    configMapKeyRef:
-                      key: gb.status.address
-                      name: cincinnati
-                - name: REGISTRY
-                  valueFrom:
-                    configMapKeyRef:
-                      key: gb.registry
-                      name: cincinnati
-                - name: REPOSITORY
-                  valueFrom:
-                    configMapKeyRef:
-                      key: gb.repository
-                      name: cincinnati
-                - name: GB_LOG_VERBOSITY
-                  valueFrom:
-                    configMapKeyRef:
-                      key: gb.log.verbosity
-                      name: cincinnati
                 - name: "RUST_BACKTRACE"
                   valueFrom:
                     configMapKeyRef:
@@ -67,15 +42,7 @@ objects:
               command:
                 - ${GB_BINARY}
               args: [
-                "-$(GB_LOG_VERBOSITY)",
-                "--service.address", "$(ADDRESS)",
-                "--service.port", "${GB_PORT}",
-                "--status.address", "$(STATUS_ADDRESS)",
-                "--status.port", "${GB_STATUS_PORT}",
-                "--upstream.registry.url", "$(REGISTRY)",
-                "--upstream.registry.repository", "$(REPOSITORY)",
-                "--upstream.registry.credentials_path", "${GB_REGISTRY_CREDENTIALS_PATH}",
-                "--upstream.registry.fetch_concurrency", "${GB_UPSTREAM_FETCH_CONCURRENCY}",
+                "-c", "${GB_CONFIG_PATH}"
               ]
               ports:
                 - name: graph-builder
@@ -106,6 +73,9 @@ objects:
               volumeMounts:
                 - name: secrets
                   mountPath: /etc/secrets
+                  readOnly: true
+                - name: configs
+                  mountPath: /etc/configs
                   readOnly: true
             - image: ${IMAGE}:${IMAGE_TAG}
               name: cincinnati-policy-engine
@@ -175,6 +145,9 @@ objects:
             - name: secrets
               secret:
                 secretName: cincinnati-credentials
+            - name: configs
+              configMap:
+                name: cincinnati-configs
       triggers:
         - type: ConfigChange
   - apiVersion: v1
@@ -218,11 +191,6 @@ objects:
     metadata:
       name: cincinnati
     data:
-      gb.address: "0.0.0.0"
-      gb.status.address: "0.0.0.0"
-      gb.registry: "quay.io"
-      gb.repository: ${{GB_CINCINNATI_REPO}}
-      gb.log.verbosity: ${{GB_LOG_VERBOSITY}}
       gb.rust_backtrace: "${RUST_BACKTRACE}"
       pe.address: "0.0.0.0"
       pe.status.address: "0.0.0.0"
@@ -230,7 +198,24 @@ objects:
       pe.log.verbosity: ${{PE_LOG_VERBOSITY}}
       pe.mandatory_client_parameters: "channel"
       pe.rust_backtrace: "${RUST_BACKTRACE}"
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cincinnati-configs
+    data:
+      gb.toml: |
+        verbosity = ${GB_LOG_VERBOSITY}
 
+        [service]
+        pause_secs = ${GB_PAUSE_SECS}
+        address = "${GB_ADDRESS}"
+        port = ${GB_PORT}
+
+        [status]
+        address = "${GB_STATUS_ADDRESS}"
+        port = ${GB_STATUS_PORT}
+
+        ${GB_PLUGIN_SETTINGS}
 parameters:
   - name: IMAGE
     value: "quay.io/app-sre/cincinnati"
@@ -272,12 +257,24 @@ parameters:
     value: "350m"
     displayName: "Policy-engine CPU request"
     description: "Requested amount of CPU (millicores) allowed for policy-engine (default: 350m)"
+  - name: GB_PAUSE_SECS
+    value: "30"
+    displayName: Seconds to pause between scrapes
   - name: GB_PORT
     value: "8080"
     displayName: Graph builder port
+  - name: GB_ADDRESS
+    value: "0.0.0.0"
+    displayName: Graph builder address
+  - name: GB_STATUS_ADDRESS
+    value: "0.0.0.0"
+    displayName: Graph builder status address
   - name: GB_STATUS_PORT
     value: "9080"
     displayName: Graph builder status port
+  - name: GB_PATH_PREFIX
+    value: "/api/upgrades_info"
+    displayName: Graph builder path prefix
   - name: PE_PORT
     value: "8081"
     displayName: Policy engine port
@@ -288,7 +285,7 @@ parameters:
     value: "/api/upgrades_info"
     displayName: Policy engine path prefix
   - name: GB_LOG_VERBOSITY
-    value: "vvv"
+    value: "3"
     displayName: Graph builder log verbosity
   - name: PE_LOG_VERBOSITY
     value: "vv"
@@ -302,11 +299,29 @@ parameters:
   - name: PE_BINARY
     value: /usr/bin/policy-engine
     displayName: Path to policy-engine binary
-  - name: GB_UPSTREAM_FETCH_CONCURRENCY
-    value: "16"
-    displayName: Concurrency when fetching the upstream metadata
+  - name: GB_PLUGIN_SETTINGS
+    displayName: Graph builder plugin settings, passed through verbatim.
+    value: |
+      [[plugin_settings]]
+      name = "release-scrape-dockerv2"
+      registry = "quay.io"
+      repository = "openshift-release-dev/ocp-release"
+      fetch_concurrency = 16
+      credentials_path = "/etc/secrets/registry-credentials"
+
+      [[plugin_settings]]
+      name = "quay-metadata"
+      repository = "openshift-release-dev/ocp-release"
+
+      [[plugin_settings]]
+      name = "node-remove"
+
+      [[plugin_settings]]
+      name = "edge-add-remove"
   - name: RUST_BACKTRACE
     value: "0"
     displayName: Set RUST_BACKTRACE env var
   - name: GB_REGISTRY_CREDENTIALS_PATH
     value: "/etc/secrets/registry_credentials_docker.json"
+  - name: GB_CONFIG_PATH
+    value: "/etc/configs/gb.toml"

--- a/graph-builder/src/config/file.rs
+++ b/graph-builder/src/config/file.rs
@@ -2,12 +2,10 @@
 
 use super::options;
 use super::AppSettings;
-use crate::config::options::de_duration_secs;
 use commons::de::de_loglevel;
 use commons::MergeOptions;
 use failure::{Fallible, ResultExt};
 use std::io::Read;
-use std::time::Duration;
 use std::{fs, io, path};
 
 /// TOML configuration, top-level.
@@ -16,10 +14,6 @@ pub struct FileOptions {
     /// Verbosity level.
     #[serde(default = "Option::default", deserialize_with = "de_loglevel")]
     pub verbosity: Option<log::LevelFilter>,
-
-    /// Duration of the pause (in seconds) between registry scans
-    #[serde(default = "Option::default", deserialize_with = "de_duration_secs")]
-    pub pause_secs: Option<Duration>,
 
     /// Upstream options.
     pub upstream: Option<UpstreamOptions>,
@@ -60,7 +54,6 @@ impl MergeOptions<Option<FileOptions>> for AppSettings {
     fn try_merge(&mut self, opts: Option<FileOptions>) -> Fallible<()> {
         if let Some(file) = opts {
             assign_if_some!(self.verbosity, file.verbosity);
-            assign_if_some!(self.pause_secs, file.pause_secs);
             self.try_merge(file.upstream)?;
             self.try_merge(file.service)?;
             self.try_merge(file.status)?;

--- a/graph-builder/src/config/file.rs
+++ b/graph-builder/src/config/file.rs
@@ -42,8 +42,9 @@ impl FileOptions {
         let mut content = vec![];
         bufrd.read_to_end(&mut content)?;
         let cfg = toml::from_slice(&content).context(format!(
-            "failed to read config file {}",
-            cfg_path.as_ref().display()
+            "failed to parse config file {}:\n{}",
+            cfg_path.as_ref().display(),
+            std::str::from_utf8(&content).unwrap_or("file not decodable")
         ))?;
 
         Ok(cfg)

--- a/graph-builder/src/config/options.rs
+++ b/graph-builder/src/config/options.rs
@@ -28,7 +28,7 @@ pub struct StatusOptions {
 pub struct ServiceOptions {
     /// Duration of the pause (in seconds) between registry scans
     #[structopt(
-        long = "upstream.registry.pause_secs",
+        long = "service.pause_secs",
         parse(try_from_str = "duration_from_secs")
     )]
     #[serde(default = "Option::default", deserialize_with = "de_duration_secs")]

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -121,11 +121,7 @@ impl AppSettings {
         Ok(self)
     }
 
-    fn default_openshift_plugin_settings(
-        &self,
-        // registry: Option<&prometheus::Registry>,
-    ) -> Fallible<Vec<Box<dyn PluginSettings>>> {
-        use cincinnati::plugins::internal::edge_add_remove::DEFAULT_REMOVE_ALL_EDGES_VALUE;
+    fn default_openshift_plugin_settings(&self) -> Fallible<Vec<Box<dyn PluginSettings>>> {
         use cincinnati::plugins::prelude::*;
 
         let plugins = vec![
@@ -153,18 +149,10 @@ impl AppSettings {
             plugin_config!(
                 ("name", QuayMetadataFetchPlugin::PLUGIN_NAME),
                 ("repository", &self.repository),
-                ("manifestref_key", &self.manifestref_key),
-                ("api-base", quay::v1::DEFAULT_API_BASE)
+                ("manifestref_key", &self.manifestref_key)
             )?,
-            plugin_config!(
-                ("name", NodeRemovePlugin::PLUGIN_NAME,),
-                ("key_prefix", &self.manifestref_key)
-            )?,
-            plugin_config!(
-                ("name", EdgeAddRemovePlugin::PLUGIN_NAME),
-                ("key_prefix", &self.manifestref_key),
-                ("remove_all_edges_value", DEFAULT_REMOVE_ALL_EDGES_VALUE)
-            )?,
+            plugin_config!(("name", NodeRemovePlugin::PLUGIN_NAME))?,
+            plugin_config!(("name", EdgeAddRemovePlugin::PLUGIN_NAME))?,
         ];
 
         Ok(plugins)

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -55,7 +55,18 @@ oc new-app -f template/cincinnati.yaml \
   ;
 
 # Wait for dc to rollout
-oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati
+oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati || {
+    status=$?
+    set +e -x
+
+    # Print various information about the deployment
+    oc get events
+    oc describe deploymentconfig/cincinnati
+    oc get configmap/cincinnati-configs -o yaml
+    oc logs --all-containers=true --timestamps=true --selector='app=cincinnati'
+
+    exit $status
+}
 
 # Expose services
 oc expose service cincinnati-policy-engine --port=policy-engine

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -33,11 +33,25 @@ oc secrets link default ci-pull-secret --for=pull
 oc new-app -f template/cincinnati.yaml \
   -p IMAGE="${IMAGE_FORMAT%/*}/stable" \
   -p IMAGE_TAG=deploy \
-  -p GB_CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual" \
   -p GB_CPU_REQUEST=50m \
   -p PE_CPU_REQUEST=50m \
   -p RUST_BACKTRACE="1" \
-  -p GB_REGISTRY_CREDENTIALS_PATH="" \
+  -p GB_PLUGIN_SETTINGS='
+      [[plugin_settings]]
+      name = "release-scrape-dockerv2"
+      repository = "redhat/openshift-cincinnati-test-public-manual"
+      fetch_concurrency = 128
+
+      [[plugin_settings]]
+      name = "quay-metadata"
+      repository = "redhat/openshift-cincinnati-test-public-manual"
+
+      [[plugin_settings]]
+      name = "node-remove"
+
+      [[plugin_settings]]
+      name = "edge-add-remove"
+  ' \
   ;
 
 # Wait for dc to rollout

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -43,8 +43,9 @@ impl FileOptions {
         let mut content = vec![];
         bufrd.read_to_end(&mut content)?;
         let cfg = toml::from_slice(&content).context(format!(
-            "failed to read config file {}",
-            cfg_path.as_ref().display()
+            "failed to parse config file {}:\n{}",
+            cfg_path.as_ref().display(),
+            std::str::from_utf8(&content).unwrap_or("file not decodable")
         ))?;
 
         Ok(cfg)


### PR DESCRIPTION
This will allow passing in different plugin configuration, which we may
require for e2e tests at one point.

- [x] Depends on #242.