### PR TITLE
settings: use occurrences notation for file settings

### DIFF
--- a/commons/src/de.rs
+++ b/commons/src/de.rs
@@ -6,12 +6,12 @@ where
     D: serde::Deserializer<'de>,
 {
     use serde::Deserialize;
-    let numlevel = u8::deserialize(deserializer)?;
+    let occurrences = String::deserialize(deserializer)?;
 
-    let verbosity = match numlevel {
-        0 => log::LevelFilter::Warn,
-        1 => log::LevelFilter::Info,
-        2 => log::LevelFilter::Debug,
+    let verbosity = match occurrences.as_str() {
+        "" => log::LevelFilter::Warn,
+        "v" => log::LevelFilter::Info,
+        "vv" => log::LevelFilter::Debug,
         _ => log::LevelFilter::Trace,
     };
     Ok(Some(verbosity))

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -204,7 +204,7 @@ objects:
       name: cincinnati-configs
     data:
       gb.toml: |
-        verbosity = ${GB_LOG_VERBOSITY}
+        verbosity = "${GB_LOG_VERBOSITY}"
 
         [service]
         pause_secs = ${GB_PAUSE_SECS}
@@ -285,7 +285,7 @@ parameters:
     value: "/api/upgrades_info"
     displayName: Policy engine path prefix
   - name: GB_LOG_VERBOSITY
-    value: "3"
+    value: "vvv"
     displayName: Graph builder log verbosity
   - name: PE_LOG_VERBOSITY
     value: "vv"

--- a/graph-builder/src/config/cli.rs
+++ b/graph-builder/src/config/cli.rs
@@ -94,7 +94,7 @@ mod tests {
         let mut settings = AppSettings::default();
         assert_eq!(settings.verbosity, log::LevelFilter::Warn);
 
-        let toml_verbosity = "verbosity=3";
+        let toml_verbosity = r#"verbosity="vvv""#;
         let file_opts: FileOptions = toml::from_str(toml_verbosity).unwrap();
         assert_eq!(file_opts.verbosity, Some(log::LevelFilter::Trace));
 

--- a/graph-builder/src/config/file.rs
+++ b/graph-builder/src/config/file.rs
@@ -139,7 +139,7 @@ mod tests {
             use std::io::Write;
 
             let sample_config = r#"
-                verbosity = 3
+                verbosity = "vvv"
 
                 [upstream]
                 method = "registry"

--- a/policy-engine/src/config/cli.rs
+++ b/policy-engine/src/config/cli.rs
@@ -100,7 +100,7 @@ mod tests {
         let mut settings = AppSettings::default();
         assert_eq!(settings.verbosity, log::LevelFilter::Warn);
 
-        let toml_verbosity = "verbosity=3";
+        let toml_verbosity = r#"verbosity="vvv""#;
         let file_opts: FileOptions = toml::from_str(toml_verbosity).unwrap();
         assert_eq!(file_opts.verbosity, Some(log::LevelFilter::Trace));
 

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -133,7 +133,7 @@ mod tests {
             use std::io::Write;
 
             let sample_config = r#"
-                verbosity = 3
+                verbosity = "vvv"
 
                 [upstream]
                 method = "cincinnati"


### PR DESCRIPTION
This allows using the same notation for verbosity in the deployment
template, regardless of whether its passed as to the graph-builder as a
CLI flag or config file entry.