### PR TITLE
dist/openshift/cincinnati: fix registry credentials path

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -307,7 +307,7 @@ parameters:
       registry = "quay.io"
       repository = "openshift-release-dev/ocp-release"
       fetch_concurrency = 16
-      credentials_path = "/etc/secrets/registry-credentials"
+      credentials_path = "/etc/secrets/registry_credentials_docker.json"
 
       [[plugin_settings]]
       name = "quay-metadata"
@@ -321,7 +321,5 @@ parameters:
   - name: RUST_BACKTRACE
     value: "0"
     displayName: Set RUST_BACKTRACE env var
-  - name: GB_REGISTRY_CREDENTIALS_PATH
-    value: "/etc/secrets/registry_credentials_docker.json"
   - name: GB_CONFIG_PATH
     value: "/etc/configs/gb.toml"


### PR DESCRIPTION
The secrets have been renamed, so the config has to be updated
accordingly.