### PR TITLE
graph-builder,policy-engine: log cincinnati crate

### DIFF
--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -28,6 +28,7 @@ fn main() -> Result<(), Error> {
     let settings = config::AppSettings::assemble().context("could not assemble AppSettings")?;
     env_logger::Builder::from_default_env()
         .filter(Some(module_path!()), settings.verbosity)
+        .filter(Some("cincinnati"), settings.verbosity)
         .init();
     debug!("application settings:\n{:#?}", settings);
 

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -61,6 +61,7 @@ fn main() -> Result<(), Error> {
     let settings = config::AppSettings::assemble()?;
     env_logger::Builder::from_default_env()
         .filter(Some(module_path!()), settings.verbosity)
+        .filter(Some("cincinnati"), settings.verbosity)
         .init();
     debug!("application settings:\n{:#?}", &settings);
 


### PR DESCRIPTION
This change applies a new log filter to permit logs from the cincinnati
crate with the configured levels. This is because most functionality has
been moved to plugins.