### PR TITLE
e2e: reconfigure monitoring operator to scrape Cincinnati

### DIFF
--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -25,5 +25,6 @@ ENV PATH="${PATH}:${HOME}/bin"
 COPY --from=builder /opt/cincinnati/bin/cincinnati-e2e-test /usr/bin
 COPY --from=builder hack/e2e.sh hack/
 COPY --from=builder dist/openshift/cincinnati.yaml dist/openshift/
+COPY --from=builder dist/openshift/observability.yaml dist/openshift/
 
 ENTRYPOINT ["hack/e2e.sh"]

--- a/dist/openshift/observability.yaml
+++ b/dist/openshift/observability.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: cincinnati-observability
+objects:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: cincinnati-graph-builder
+    spec:
+      endpoints:
+        - interval: 5s
+          path: /metrics
+          port: status-gb
+      namespaceSelector:
+        matchNames:
+          - ${NAMESPACE}
+      selector:
+        matchLabels:
+          app: cincinnati-graph-builder
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: cincinnati-policy-engine
+    spec:
+      endpoints:
+        - interval: 5s
+          path: /metrics
+          port: status-pe
+      namespaceSelector:
+        matchNames:
+          - ${NAMESPACE}
+      selector:
+        matchLabels:
+          app: cincinnati-policy-engine
+  - apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+      name: cincinnati-slo
+    spec:
+      groups:
+        - name: cincinnati-graphbuilder.slo.rules
+          interval: 5s
+          rules:
+            # graph builder is up
+            - record: component:slo_availability:5s
+              expr: sum(up{namespace="${NAMESPACE}",job="cincinnati-graph-builder"})
+              labels:
+                component: graphbuilder
+                service: cincinnati
+            # alert: graph builder is down for 1 minute
+            - alert: graphBuilderDown
+              annotations:
+                message: "Graph builder is not available"
+              expr: |
+                absent(component:slo_availability:5s{service="cincinnati",component="graphbuilder"} == 1)
+              for: 1m
+              labels:
+                service: cincinnati
+                component: graphbuilder
+                severity: critical
+
+        - name: cincinnati-policyengine.slo.rules
+          interval: 5s
+          rules:
+            # policy engine is up
+            - record: component:slo_availability:5s
+              expr: sum(up{job="cincinnati-policy-engine"})
+              labels:
+                component: policyengine
+                service: cincinnati
+            # policy engine latency
+            - record: component:slo_latency:5s
+              expr: |
+                histogram_quantile(0.99,
+                  cincinnati_pe_v1_graph_serve_duration_seconds_bucket{
+                    namespace="${NAMESPACE}",job="cincinnati-policy-engine"})
+              labels:
+                component: policyengine
+                service: cincinnati
+            # policy engine error rate
+            - record: component:slo_upstream_error_rate:1m
+              expr: rate(cincinnati_pe_v1_graph_response_errors_total{namespace="${NAMESPACE}",code="500"}[1m])
+              labels:
+                component: policyengine
+                service: cincinnati
+            # alert: policy engine is down for 1m
+            - alert: policyEngineDown
+              annotations:
+                message: "Policy engine is not available"
+              expr: |
+                absent(component:slo_availability:5s{service="cincinnati",component="policyengine"} == 1)
+              for: 1m
+              labels:
+                service: cincinnati
+                component: policyengine
+                severity: critical
+            # alert: 99 quantile of policy engine response times are more than 1 second
+            - alert: policyEngineHighLatency
+              annotations:
+                message: "Policy engine latency is too high"
+              expr: |
+                component:slo_latency:5s{service="cincinnati",component="policyengine"} > 1
+              for: 1m
+              labels:
+                service: cincinnati
+                component: policyengine
+                severity: high
+            # alert: policy engine throws more than 1 HTTP 500 error in 5 seconds
+            - alert: policyEngineHTTP500
+              annotations:
+                message: "Policy engine HTTP 500 error rate is too high"
+              expr: |
+                component:slo_upstream_error_rate:1m{service="cincinnati",component="policyengine"} > 1
+              for: 1m
+              labels:
+                service: cincinnati
+                component: policyengine
+                severity: critical
+
+parameters:
+  - name: NAMESPACE
+    value: "cincinnati-e2e"

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -50,3 +50,4 @@ pretty_assertions = "0.6.1"
 test-net = []
 test-net-private = []
 test-e2e = []
+test-e2e-slo = []

--- a/graph-builder/tests/mod.rs
+++ b/graph-builder/tests/mod.rs
@@ -1,2 +1,3 @@
 #[cfg(feature = "test-e2e")]
 mod e2e;
+mod slo;

--- a/graph-builder/tests/slo/mod.rs
+++ b/graph-builder/tests/slo/mod.rs
@@ -1,0 +1,93 @@
+use failure::{format_err, Fallible};
+use reqwest::header::{HeaderValue, AUTHORIZATION};
+use reqwest::Response;
+use serde::Deserialize;
+use std::env;
+use test_case::test_case;
+use tokio::runtime::Runtime;
+use url::Url;
+
+#[derive(Deserialize)]
+struct PromMetric {
+    value: (f64, String),
+}
+
+#[derive(Deserialize)]
+struct PromData {
+    result: Vec<PromMetric>,
+}
+
+#[derive(Deserialize)]
+struct PromResponse {
+    status: String,
+    data: PromData,
+}
+
+async fn prom_http_request(url: String, token: String) -> Fallible<Response> {
+    let header_value = format!("Bearer {}", token);
+    let authorization_header = HeaderValue::from_str(&header_value).unwrap();
+    reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap()
+        .get(&url)
+        .header(AUTHORIZATION, authorization_header)
+        .send()
+        .await
+        .map_err(Into::into)
+}
+
+fn query_prom(runtime: &mut Runtime, url: String, token: String) -> Fallible<String> {
+    let res = runtime.block_on(prom_http_request(url, token)).unwrap();
+    let text = runtime.block_on(res.text()).unwrap();
+    println!("Prom response: {}", text);
+
+    let r: PromResponse = match serde_json::from_str(&text) {
+        Ok(r) => r,
+        Err(e) => panic!("Failed to serialize json: {}", e),
+    };
+    match r.status.as_str() {
+        "success" => match r.data.result.len() {
+            1 => Ok(r.data.result[0].value.1.clone()),
+            n => Err(format_err!("unexpected number of results: {}", n)),
+        },
+        status => Err(format_err!("incorrect query status: {}", status)),
+    }
+}
+
+// Service reports at all times
+#[test_case(r#"min_over_time(up{job="cincinnati-policy-engine"}[1h])"#, "1")]
+#[test_case(r#"min_over_time(up{job="cincinnati-graph-builder"}[1h])"#, "1")]
+// No upstream errors
+#[test_case("max_over_time(cincinnati_pe_http_upstream_errors_total[1h])", "0")]
+#[test_case("max_over_time(cincinnati_gb_graph_upstream_errors_total[1h])", "0")]
+// Use clamp_min to bring up the minimal serve duration to 0.1 seconds
+// If the quantile would produce a bigger result this test would fail
+#[test_case(
+    "clamp_min(histogram_quantile(0.90, sum(cincinnati_pe_v1_graph_serve_duration_seconds_bucket) by (le)), 0.1)",
+    "0.1"
+)]
+// At least one scrape has been performed
+#[test_case("clamp_max(cincinnati_gb_graph_upstream_scrapes_total, 1)", "1")]
+// No scrape errors
+#[test_case("cincinnati_gb_graph_upstream_errors_total", "0")]
+fn zz_check_slo(query: &'static str, expected: &'static str) {
+    let prom_url = match env::var("PROM_ENDPOINT") {
+        Ok(env) => format!("https://{}/api/v1/query", env),
+        _ => panic!("PROM_ENDPOINT unset"),
+    };
+
+    let prom_token = match env::var("PROM_TOKEN") {
+        Ok(env) => env,
+        _ => panic!("PROM_TOKEN unset"),
+    };
+
+    let mut runtime = commons::testing::init_runtime().unwrap();
+
+    let mut query_url = Url::parse(&prom_url).unwrap();
+    query_url.query_pairs_mut().append_pair("query", query);
+
+    println!("Querying {}", query_url.to_string());
+    let actual = query_prom(&mut runtime, query_url.to_string(), prom_token).unwrap();
+    pretty_assertions::assert_eq!(actual, expected)
+}

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -112,8 +112,8 @@ done
 # Wait for cincinnati metrics to be recorded
 # Find out the token Prometheus uses from its serviceaccount secrets
 # and use it to query for GB build info
-PROM_ENDPOINT=$(oc -n openshift-monitoring get route thanos-querier -o jsonpath="{.spec.host}")
-PROM_TOKEN=$(oc -n openshift-monitoring get secret \
+export PROM_ENDPOINT=$(oc -n openshift-monitoring get route thanos-querier -o jsonpath="{.spec.host}")
+export PROM_TOKEN=$(oc -n openshift-monitoring get secret \
   $(oc -n openshift-monitoring get serviceaccount prometheus-k8s \
     -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep prometheus-k8s-token) \
   -o go-template='{{.data.token | base64decode}}')
@@ -126,5 +126,5 @@ for i in $(seq 1 10); do
   sleep ${DELAY}
 done
 
-# Run e2e tests
-/usr/bin/cincinnati-e2e-test
+# Run e2e tests in sequential mode to have SLO tests in the end
+env RUST_TEST_TASKS=1 /usr/bin/cincinnati-e2e-test


### PR DESCRIPTION
Enable user workloads feature in monitoring operator, install Cincinnati ServiceMonitors and collect app data. This would allow us to define SLO in upstream repo and collect metrics during e2e tests / load testing - and fail the build if the performance is below a certain threshold.

This also adds several tests which ensure app metrics are sane after e2e test