### PR TITLE
Dockerfile.build: bump rust to 1.42.0

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -11,10 +11,11 @@ ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # build: Rust stable toolchain + 2 previous versions
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.41.0 -y && \
-  rustup install 1.40.0 && \
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.42.0 -y && \
   rustup install 1.39.0 && \
-  rustup default 1.41.0
+  rustup install 1.40.0 && \
+  rustup install 1.41.0 && \
+  rustup default 1.42.0
 
 # test: linters
 RUN yum -y install yamllint

--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -12,9 +12,9 @@ ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # build: Rust stable toolchain + 2 previous versions
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.41.0 -y && \
-    rustup install 1.40.0 && \
-    rustup install 1.39.0 && \
-    rustup default 1.41.0
+  rustup install 1.40.0 && \
+  rustup install 1.39.0 && \
+  rustup default 1.41.0
 
 # test: linters
 RUN yum -y install yamllint


### PR DESCRIPTION
Since our CI configuration is decoupled from this repository, it's not
possible to atomically merge a change which switches the rust version.
By leaving the oldest version installed, we can cleanly make the switch
without introducing a predictable failure state on CI.

---

Coupled with https://github.com/openshift/release/pull/7811