### PR TITLE
cincinnati/src: Drop AbstractRelease

### DIFF
--- a/cincinnati/src/plugins/internal/arch_filter.rs
+++ b/cincinnati/src/plugins/internal/arch_filter.rs
@@ -100,15 +100,12 @@ impl InternalPlugin for ArchFilterPlugin {
         let to_remove = {
             graph
                 .find_by_fn_mut(|release| {
-                    match release {
-                        cincinnati::Release::Concrete(concrete_release) => concrete_release
-                            .metadata
-                            .remove(&format!("{}.{}", self.key_prefix, self.key_suffix))
-                            .map_or(true, |values| {
-                                !values.split(',').any(|value| value.trim() == arch)
-                            }),
-                        // remove if it's not a ConcreteRelease
-                        _ => true,
+                    release
+                        .metadata
+                        .remove(&format!("{}.{}", self.key_prefix, self.key_suffix))
+                        .map_or(true, |values| {
+                            !values.split(',').any(|value| value.trim() == arch)
+                        })
                     }
                 })
                 .into_iter()
@@ -139,10 +136,7 @@ impl InternalPlugin for ArchFilterPlugin {
                         })?
                 };
 
-                match &mut release {
-                    cincinnati::Release::Abstract(release) => release.version = version,
-                    cincinnati::Release::Concrete(release) => release.version = version,
-                };
+                release.version = version,
 
                 Ok(())
             })

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -70,15 +70,12 @@ impl InternalPlugin for ChannelFilterPlugin {
         let to_remove = {
             graph
                 .find_by_fn_mut(|release| {
-                    match release {
-                        cincinnati::Release::Concrete(concrete_release) => concrete_release
-                            .metadata
-                            .get_mut(&format!("{}.{}", self.key_prefix, self.key_suffix))
-                            .map_or(true, |values| {
-                                !values.split(',').any(|value| value.trim() == channel)
-                            }),
-                        // remove if it's not a ConcreteRelease
-                        _ => true,
+                    release
+                        .metadata
+                        .get_mut(&format!("{}.{}", self.key_prefix, self.key_suffix))
+                        .map_or(true, |values| {
+                            !values.split(',').any(|value| value.trim() == channel)
+                        })
                     }
                 })
                 .into_iter()

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -232,7 +232,7 @@ impl OpenshiftSecondaryMetadataParserPlugin {
                         (Ok(release_semver), Ok(version_semver))
                             if release_semver == version_semver =>
                         {
-                            release.get_metadata_mut().map(|metadata| {
+                            Some(&mut release.metadata).map(|metadata| {
                                 metadata
                                     .entry((*key).to_string())
                                     .and_modify(|previous_add| {
@@ -378,8 +378,7 @@ impl OpenshiftSecondaryMetadataParserPlugin {
         // Sort the channels as some tests and consumers might already depend on
         // the sorted output which existed in the hack util which is replaced by this plugin.
         let sorted_releases = io.graph.find_by_fn_mut(|release| {
-            release
-                .get_metadata_mut()
+            Some(&mut release.metadata)
                 .map(|metadata| {
                     metadata.entry(channels_key.clone()).and_modify(|channels| {
                         let mut channels_split = channels.split(',').collect::<Vec<_>>();

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -224,22 +224,17 @@ mod network_tests {
 
             graph_raw
                 .iter_releases_mut(|ref mut release| {
-                    match release {
-                        cincinnati::Release::Concrete(ref mut release) => {
-                            // replace digest by tag to match expectency
-                            let version = release.version.to_string();
-                            let source_front = release.payload.split('@').nth(0).unwrap();
-                            release.payload = format!("{}:{}", source_front, version);
+                    // replace digest by tag to match expectency
+                    let version = release.version.to_string();
+                    let source_front = release.payload.split('@').nth(0).unwrap();
+                    release.payload = format!("{}:{}", source_front, version);
 
-                            // remove unwanted metadata
-                            release
-                                .metadata
-                                .retain(|k, _| !unwanted_metadata_keys.contains(k));
+                    // remove unwanted metadata
+                    release
+                        .metadata
+                        .retain(|k, _| !unwanted_metadata_keys.contains(k));
 
-                            Ok(())
-                        }
-                        _ => panic!("should not get here"),
-                    }
+                    Ok(())
                 })
                 .context("Post-processing the received graph to match the test expectations")?;
 


### PR DESCRIPTION
We've had `AbstractRelease` since at least 05c049fe13 (2018-07-13).  The motivation wasn't spelled out in Git history, and [this comment][1] doesn't add much.  Because abstract releases were pruned in the graph builder, there's no loss of functionality by moving to using only concrete releases (now just `Release`, since we no longer need to distinguish).  The "how to add an edge if we haven't ingested one endpoint yet?" issue is addressed by removing all edge management from the graph engine and instead handling it all in the `edge-add-remove` plugin (which operates on the metadata assembed by previous layers, including the metadata extracted from the release images themselves and secondary metadata extracted from Quay labels, GitHub repositories, etc.).

[1]: https://github.com/openshift/cincinnati/pull/188#discussion_r375799508