### PR TITLE
tests/e2e: gate SLO tests with `test-e2e-slo` feature

### DIFF
--- a/graph-builder/tests/mod.rs
+++ b/graph-builder/tests/mod.rs
@@ -1,4 +1,4 @@
 #[cfg(feature = "test-e2e")]
 mod e2e;
-#[cfg(feature = "test-e2e")]
+#[cfg(feature = "test-e2e-slo")]
 mod slo;


### PR DESCRIPTION
CI currently isn't set up to run these tests properly and they fail by
default. An additional feature gate works around that.