### PR TITLE
dist/openshift: configure oauth_token_path

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -323,6 +323,7 @@ parameters:
       github_repo = "cincinnati-graph-data"
       reference_branch = "master"
       output_directory = "/tmp/cincinnati/graph-data"
+      oauth_token_path = "/etc/secrets/github_token.key"
 
       [[plugin_settings]]
       name = "openshift-secondary-metadata-parse"


### PR DESCRIPTION
Configuring this secret helps preventing to reach the GitHub rate limit.