### PR TITLE
Adjust max workers in load testing scenarios and improve PE <-> GB connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2434,7 @@ name = "reqwest"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "async-compression 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3539,6 +3552,7 @@ dependencies = [
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum assert-json-diff 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32946b6d31d50d0e35896c864907f9cb7e47b52bd875fa3c058618601cfdefb1"
+"checksum async-compression 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5c52622726d68ec35fec88edfb4ccb862d4f3b3bfa4af2f45142e69ef9b220"
 "checksum async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58982858be7540a465c790b95aaea6710e5139bf8956b1d1344d014fa40100b0"
 "checksum async-stream-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
 "checksum async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -19,7 +19,7 @@ prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a
 protobuf = "2.0"
 quay = { path = "../quay" }
 regex = "^1.1.0"
-reqwest = "^0.10"
+reqwest = { version = "^0.10", features = ["gzip"] }
 serde = "1.0.70"
 serde_derive = "1.0.70"
 serde_json = "^1.0.22"

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -19,12 +19,18 @@ use std::time::Duration;
 /// Default URL to upstream graph provider.
 pub static DEFAULT_UPSTREAM_URL: &str = "http://localhost:8080/v1/graph";
 
+/// Default graph-builder connection timeout in seconds.
+pub static DEFAULT_TIMEOUT_SECS: u64 = 30;
+
 /// Plugin settings.
 #[derive(Clone, CustomDebug, Deserialize, SmartDefault)]
 #[serde(default)]
 struct CincinnatiGraphFetchSettings {
     #[default(DEFAULT_UPSTREAM_URL.to_string())]
     upstream: String,
+
+    #[default(DEFAULT_TIMEOUT_SECS)]
+    timeout: u64,
 }
 
 /// Graph fetcher for Cincinnati `/v1/graph` endpoints.
@@ -48,7 +54,7 @@ pub struct CincinnatiGraphFetchPlugin {
 impl PluginSettings for CincinnatiGraphFetchSettings {
     fn build_plugin(&self, registry: Option<&prometheus::Registry>) -> Fallible<BoxedPlugin> {
         let cfg = self.clone();
-        let plugin = CincinnatiGraphFetchPlugin::try_new(cfg.upstream, registry)?;
+        let plugin = CincinnatiGraphFetchPlugin::try_new(cfg.upstream, cfg.timeout, registry)?;
         Ok(new_plugin!(InternalPluginWrapper(plugin)))
     }
 }
@@ -68,6 +74,7 @@ impl CincinnatiGraphFetchPlugin {
 
     fn try_new(
         upstream: String,
+        timeout: u64,
         prometheus_registry: Option<&prometheus::Registry>,
     ) -> Fallible<Self> {
         let http_upstream_reqs = Counter::new(
@@ -87,7 +94,7 @@ impl CincinnatiGraphFetchPlugin {
 
         let client = reqwest::ClientBuilder::new()
             .gzip(true)
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(timeout))
             .build()
             .context("Building reqwest client")?;
 
@@ -173,7 +180,9 @@ mod tests {
                     .with_body($mock_body.to_string())
                     .create();
 
-                let plugin = CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), None)?;
+                let timeout: u64 = 30;
+                let plugin =
+                    CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), timeout, None)?;
                 let http_upstream_reqs = plugin.http_upstream_reqs.clone();
                 let http_upstream_errors_total = plugin.http_upstream_errors_total.clone();
 
@@ -238,7 +247,7 @@ mod tests {
                     .with_body($mock_body.to_string())
                     .create();
 
-                let plugin = CincinnatiGraphFetchPlugin::try_new($upstream.to_string(), None)?;
+                let plugin = CincinnatiGraphFetchPlugin::try_new($upstream.to_string(), 30, None)?;
                 let http_upstream_reqs = plugin.http_upstream_reqs.clone();
                 let http_upstream_errors_total = plugin.http_upstream_errors_total.clone();
 
@@ -301,7 +310,10 @@ mod tests {
             metrics_prefix.clone(),
         ))?));
 
-        let _ = CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), Some(registry))?;
+        let timeout: u64 = 30;
+
+        let _ =
+            CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), timeout, Some(registry))?;
 
         let metrics_call = metrics::serve::<metrics::RegistryWrapper>(actix_web::web::Data::new(
             RegistryWrapper(registry),

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -14,6 +14,7 @@ use failure::{Fallible, ResultExt};
 use prometheus::Counter;
 use reqwest;
 use reqwest::header::{HeaderValue, ACCEPT};
+use std::time::Duration;
 
 /// Default URL to upstream graph provider.
 pub static DEFAULT_UPSTREAM_URL: &str = "http://localhost:8080/v1/graph";
@@ -85,6 +86,8 @@ impl CincinnatiGraphFetchPlugin {
         };
 
         let client = reqwest::ClientBuilder::new()
+            .gzip(true)
+            .timeout(Duration::from_secs(30))
             .build()
             .context("Building reqwest client")?;
 

--- a/e2e/tests/slo.rs
+++ b/e2e/tests/slo.rs
@@ -9,11 +9,11 @@ use test_case::test_case;
 // No upstream errors
 #[test_case("max_over_time(cincinnati_pe_http_upstream_errors_total[1h])", "0")]
 #[test_case("max_over_time(cincinnati_gb_graph_upstream_errors_total[1h])", "0")]
-// Use clamp_min to bring up the minimal serve duration to 0.1 seconds
+// Use clamp_min to bring up the minimal serve duration to 500ms
 // If the quantile would produce a bigger result this test would fail
 #[test_case(
-    "clamp_min(histogram_quantile(0.90, sum(cincinnati_pe_v1_graph_serve_duration_seconds_bucket) by (le)), 0.1)",
-    "0.1"
+    "clamp_min(histogram_quantile(0.90, sum(cincinnati_pe_v1_graph_serve_duration_seconds_bucket) by (le)), 0.5)",
+    "0.5"
 )]
 // At least one scrape has been performed
 #[test_case("clamp_max(cincinnati_gb_graph_upstream_scrapes_total, 1)", "1")]

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use actix_web::{App, HttpServer};
+use actix_web::{middleware, App, HttpServer};
 use commons::metrics::{self, HasRegistry};
 use failure::{ensure, Error, Fallible, ResultExt};
 use graph_builder::{self, config, graph, status};
@@ -98,12 +98,14 @@ fn main() -> Result<(), Error> {
     let main_state = state;
     HttpServer::new(move || {
         App::new()
+            .wrap(middleware::Compress::default())
             .app_data(actix_web::web::Data::new(main_state.clone()))
             .service(
                 actix_web::web::resource(&format!("{}/v1/graph", app_prefix.clone()))
                     .route(actix_web::web::get().to(graph::index)),
             )
     })
+    .keep_alive(10)
     .bind(service_addr)?
     .run();
 

--- a/hack/load-testing.sh
+++ b/hack/load-testing.sh
@@ -13,7 +13,7 @@ TMP_DIR=$(mktemp -d)
 duration=30s
 
 for workers in 10 50 100; do
-  for rate in 10 100; do
+  for rate in 10 100 500 1000; do
     file="${TMP_DIR}/rate-${rate}-workers-${workers}.bin"
     echo "Testing workers ${workers}, rate ${rate} -> ${file}"
     sed "s,GRAPH_URL,${GRAPH_URL},g" vegeta.targets | \

--- a/hack/load-testing.sh
+++ b/hack/load-testing.sh
@@ -17,7 +17,7 @@ for workers in 10 50 100; do
     file="${TMP_DIR}/rate-${rate}-workers-${workers}.bin"
     echo "Testing workers ${workers}, rate ${rate} -> ${file}"
     sed "s,GRAPH_URL,${GRAPH_URL},g" vegeta.targets | \
-      vegeta attack -format http -workers=${workers} -rate=${rate} -duration ${duration} > ${file}
+      vegeta attack -format http -workers=${workers} -max-workers=${workers} -rate=${rate} -duration ${duration} > ${file}
     vegeta report -type=text ${file}
     # Sleep here to clear up connections cache in cincinnati
     sleep 30

--- a/policy-engine.log
+++ b/policy-engine.log
@@ -1,0 +1,1 @@
+   Compiling cincinnati v0.1.0 (/var/home/vrutkovs/src/github.com/openshift/cincinnati/cincinnati)

--- a/policy-engine.log
+++ b/policy-engine.log
@@ -1,1 +1,0 @@
-   Compiling cincinnati v0.1.0 (/var/home/vrutkovs/src/github.com/openshift/cincinnati/cincinnati)

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -25,7 +25,7 @@ mod config;
 mod graph;
 mod openapi;
 
-use actix_web::{App, HttpServer};
+use actix_web::{middleware, App, HttpServer};
 use cincinnati::plugins::BoxedPlugin;
 use commons::metrics::{self, RegistryWrapper};
 use failure::Error;
@@ -73,6 +73,7 @@ fn main() -> Result<(), Error> {
     registry.register(Box::new(BUILD_INFO.clone()))?;
     HttpServer::new(move || {
         App::new()
+            .wrap(middleware::Compress::default())
             .app_data(actix_web::web::Data::new(RegistryWrapper(registry)))
             .service(
                 actix_web::web::resource("/metrics")
@@ -103,6 +104,7 @@ fn main() -> Result<(), Error> {
                     .route(actix_web::web::get().to(openapi::index)),
             )
     })
+    .keep_alive(10)
     .bind((settings.address, settings.port))?
     .run();
 


### PR DESCRIPTION
Set `max-workers` == `workers` so that PE wouldn't get a large stream of additional connections.

This also adds the following improvements for PE/GB:

* Use gzip compression on GB side and enable using compressed connection on PE side
* Add timeouts to PE -> GB requests
* Enable keep-alive on GB and PE side

TODO:

* [x] Add a config option to `cincinnati-graph-fetch` plugin to configure -> GB client timeout 

Ref: https://issues.redhat.com/browse/OTA-105 to improve load-testing results