### PR TITLE
dist/openshift/cincinnati: Drop graph-builder pause to 5 minutes

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -266,7 +266,7 @@ parameters:
     displayName: "Policy-engine CPU request"
     description: "Requested amount of CPU (millicores) allowed for policy-engine (default: 350m)"
   - name: GB_PAUSE_SECS
-    value: "30"
+    value: "300"
     displayName: Seconds to pause between scrapes
   - name: GB_PORT
     value: "8080"

--- a/docs/user/graph-builder-configuration.md
+++ b/docs/user/graph-builder-configuration.md
@@ -20,6 +20,6 @@ TOML configuration currently supports the following sections and options:
    - `registry` (section): configuration for Docker-v2 registry provider.
      - `credentials_path` (string): path to file containing registry credentials, in "dockercfg" format. Default: unset.
      - `manifestref_key` (string): metadata key where to record the manifest-reference. Default: "io.openshift.upgrades.graph.release.manifestref".
-     - `pause_secs` (unsigned integer): pause between repository scrapes, in seconds. Default: 30.
+     - `pause_secs` (unsigned integer): pause between repository scrapes, in seconds. Default: 300.
      - `repository` (string): target image in the registry. Default: "openshift".
      - `url` (string): URL for the registry. Default: "http://localhost:5000". 

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -32,7 +32,7 @@ pub struct AppSettings {
     pub path_prefix: String,
 
     /// Pause (in seconds) between registry scrapes.
-    #[default(time::Duration::from_secs(30))]
+    #[default(time::Duration::from_secs(300))]
     pub pause_secs: time::Duration,
 
     /// Listening port for the main service.


### PR DESCRIPTION
The default seems to have lived in the 30s range since at least 517af6ee8f (#69).  But we can allow some latency here.  On the cluster-version operator (CVO) side:

* `cvo.New` [takes an argument][1] for the poll interval.
* That is fed by [`resyncPeriod(o.ResyncInterval)()`][2].
* `ResyncInterval` is [set from `minResyncPeriod`][3].
* `minResyncPeriod` is [2 minutes][4].
* `resyncPeriod` adds some jitter (returning [between 1x and 2x the input value][5]).

So should be uniformly distributed between 2 and 4 minutes.  That puts a floor on latency in getting this information out to clusters.

It's also not a problem to add latency above the CVO-enforced floor.  A delay in minutes in getting a new release out into a channel is not significant, because the biggest publication rush would be releasing a CVE fix into the stable channel.  And that's already delayed by needing to cook in the candidate and fast channels, and eventually having the push to stable being a phased rollout.

A delay in pulling an edge that has proven itself unstable is more serious, but we already have latencies in the minutes before alerts fire, and Telemetry/Insights that report issues to Red Hat add additional latencies in the minutes (Telemetry) to hours (Insights) range.  Delaying the edge pull by a few more minutes is not going to greatly increase overall cluster-breaks -> edge-pulled latency here.

[1]: https://github.com/openshift/cluster-version-operator/blob/12623332615a0657a5468fae27cff1998a70bfef/pkg/cvo/cvo.go#L165
[2]: https://github.com/openshift/cluster-version-operator/blob/12623332615a0657a5468fae27cff1998a70bfef/pkg/start/start.go#L341
[3]: https://github.com/openshift/cluster-version-operator/blob/12623332615a0657a5468fae27cff1998a70bfef/pkg/start/start.go#L93
[4]: https://github.com/openshift/cluster-version-operator/blob/12623332615a0657a5468fae27cff1998a70bfef/pkg/start/start.go#L43
[5]: https://github.com/openshift/cluster-version-operator/blob/12623332615a0657a5468fae27cff1998a70bfef/pkg/start/start.go#L250-L251