### PR TITLE
hack/available-updates: Mock up an update-target lister

### DIFF
--- a/hack/available-updates.sh
+++ b/hack/available-updates.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+UPSTREAM="${UPSTREAM:-https://api.openshift.com/api/upgrades_info/v1/graph}"
+CHANNEL="${CHANNEL:-stable-4.3}"
+ARCH="${ARCH:-amd64}"
+VERSION="$1"
+
+if test -z "${VERSION}" -o "$#" -ne 1
+then
+	printf 'usage: %s VERSION\n\nOptional environment variables:\n\nUPSTREAM: Cincinnati upstream (default %s)\nCHANNEL: Graph channel (default %s)\nARCH: Cluster architecture (default %s)\n' "$0" "${UPSTREAM}" "${CHANNEL}" "${ARCH}" >&2
+	exit 1
+fi
+
+URI="${UPSTREAM}?channel=${CHANNEL}&arch=${ARCH}"
+DATA="$(curl -sH Accept:application/json "${URI}")"
+if test -z "${DATA}"
+then
+	 echo "Failed to fetch data from ${URI}"
+fi
+
+echo "${DATA}" | jq -r "
+  (.nodes | with_entries(.key |= tostring)) as \$nodes_by_index |
+  [
+    .edges[] |
+    select(\$nodes_by_index[(.[0] | tostring)].version == \"${VERSION}\")[1] |
+    tostring |
+    \$nodes_by_index[.]
+  ] | sort_by(.version)[] |
+  .version + \"\\t\" + .payload + \"\\t\" + (.metadata.url // \"-\")
+"


### PR DESCRIPTION
For folks running clusters in a restricted network, to make it easier to figure out what can be mirrored in.  For example:

```console
$ CHANNEL=stable-4.2 ~/src/openshift/cincinnati/hack/available-updates.sh 4.2.12
4.2.13  quay.io/openshift-release-dev/ocp-release@sha256:782b41750f3284f3c8ee2c1f8cb896896da074e362cf8a472846356d1617752d  https://access.redhat.com/errata/RHBA-2020:0014
4.2.14  quay.io/openshift-release-dev/ocp-release@sha256:3fabe939da31f9a31f509251b9f73d321e367aba2d09ff392c2f452f6433a95a  https://access.redhat.com/errata/RHBA-2020:0066
4.2.16  quay.io/openshift-release-dev/ocp-release@sha256:e5a6e348721c38a78d9299284fbb5c60fb340135a86b674b038500bf190ad514  https://access.redhat.com/errata/RHBA-2020:0107
4.2.18  quay.io/openshift-release-dev/ocp-release@sha256:283a1625e18e0b6d7f354b1b022a0aeaab5598f2144ec484faf89e1ecb5c7498  https://access.redhat.com/errata/RHBA-2020:0395
4.2.19  quay.io/openshift-release-dev/ocp-release@sha256:b51a0c316bb0c11686e6b038ec7c9f7ff96763f47a53c3443ac82e8c054bc035  https://access.redhat.com/errata/RHBA-2020:0460
4.2.20  quay.io/openshift-release-dev/ocp-release@sha256:bd8aa8e0ce08002d4f8e73d6a2f9de5ae535a6a961ff6b8fdf2c52e4a14cc787  https://access.redhat.com/errata/RHBA-2020:0523
4.2.21  quay.io/openshift-release-dev/ocp-release@sha256:6c57b48ec03382d9d63c529d4665d133969573966400515777f36dd592ad834a  https://access.redhat.com/errata/RHBA-2020:0614
```