### PR TITLE
dist/run_containerized_loadtesting: create a script to run load-testing in a container

### DIFF
--- a/dist/run_containerized_loadtesting.sh
+++ b/dist/run_containerized_loadtesting.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Pull vegeta container, mount load testing script and run it against GRAPH_URL
+# This is a wrapper around hack/load-testing.sh which we run after stage deployment is complete
+
+set -ex
+
+VEGETA_IMAGE="docker.io/peterevans/vegeta:6.8"
+
+docker run --rm \
+  --volume hack/load-testing.sh:/usr/local/bin/load-testing.sh \
+  --volume hack/vegeta.targets:/tmp/vegeta.targets \
+  --env GRAPH_URL=${GRAPH_URL} \
+  --workdir /tmp \
+  --entrypoint=/usr/local/bin/load-testing.sh \
+  -ti "${VEGETA_IMAGE}"


### PR DESCRIPTION
This PR adds a script, which runs load-testing in a dedicated container. In order to run post-build actions on stage we can't reuse `hack/e2e.sh` and should mount targets and wrapper script into a vegeta container.

The followup PRs would add a detailed documentation.

Ref: https://issues.redhat.com/browse/OTA-105