### PR TITLE
graph-builder: add scrape timeout flag and set to 300s by default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -139,6 +139,7 @@ run-graph-builder:
 		verbosity = "vvv"
 
 		[service]
+		scrape_timeout_secs = 300
 		pause_secs = {{pause_secs}}
 		address = "127.0.0.1"
 		port = 8080

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0.70"
 serde_derive = "1.0.70"
 serde_json = "^1.0.22"
 smart-default = "^0.5.2"
-tokio = { version = "0.2.11", features = [ "fs", "stream" ] }
+tokio = { version = "0.2.11", features = [ "time", "fs", "stream" ] }
 toml = "^0.4.10"
 url = "^1.7.2"
 semver = { version = "^0.9.0", features = [ "serde" ] }

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -215,6 +215,7 @@ objects:
         verbosity = "${GB_LOG_VERBOSITY}"
 
         [service]
+        scrape_timeout_secs = ${GB_SCRAPE_TIMEOUT_SECS}
         pause_secs = ${GB_PAUSE_SECS}
         address = "${GB_ADDRESS}"
         port = ${GB_PORT}
@@ -265,6 +266,9 @@ parameters:
     value: "350m"
     displayName: "Policy-engine CPU request"
     description: "Requested amount of CPU (millicores) allowed for policy-engine (default: 350m)"
+  - name: GB_SCRAPE_TIMEOUT_SECS
+    value: "300"
+    displayName: Graph-builder scrape timeout in seconds
   - name: GB_PAUSE_SECS
     value: "300"
     displayName: Seconds to pause between scrapes

--- a/graph-builder/src/config/options.rs
+++ b/graph-builder/src/config/options.rs
@@ -34,6 +34,14 @@ pub struct ServiceOptions {
     #[serde(default = "Option::default", deserialize_with = "de_duration_secs")]
     pub pause_secs: Option<Duration>,
 
+    /// Timeout for a single scrape in seconds
+    #[structopt(
+        long = "service.scrape_timeout",
+        parse(try_from_str = "duration_from_secs")
+    )]
+    #[serde(default = "Option::default", deserialize_with = "de_duration_secs")]
+    pub scrape_timeout_secs: Option<Duration>,
+
     /// Address on which the server will listen
     #[structopt(name = "service_address", long = "service.address", alias = "address")]
     pub address: Option<IpAddr>,
@@ -86,6 +94,7 @@ impl MergeOptions<Option<ServiceOptions>> for AppSettings {
     fn try_merge(&mut self, opts: Option<ServiceOptions>) -> Fallible<()> {
         if let Some(service) = opts {
             assign_if_some!(self.pause_secs, service.pause_secs);
+            assign_if_some!(self.scrape_timeout_secs, service.scrape_timeout_secs);
             assign_if_some!(self.address, service.address);
             assign_if_some!(self.port, service.port);
             assign_if_some!(self.path_prefix, service.path_prefix);

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -35,6 +35,9 @@ pub struct AppSettings {
     #[default(time::Duration::from_secs(300))]
     pub pause_secs: time::Duration,
 
+    /// Timeout (in seconds) per registry scrape.
+    pub scrape_timeout_secs: Option<time::Duration>,
+
     /// Listening port for the main service.
     #[default(8080)]
     pub port: u16,

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -65,10 +65,10 @@ fn main() -> Result<(), Error> {
 
     // Graph scraper
     {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-
         let graph_state = state.clone();
-        thread::spawn(move || runtime.block_on(graph::run(&settings, &graph_state)));
+        thread::spawn(move || {
+            graph::run(&settings, &graph_state);
+        });
     }
 
     // Status service.


### PR DESCRIPTION
The timeout case looks like this in the log:

```
(...)
[2020-04-06T15:27:38Z TRACE cincinnati::plugins::internal::graph_builder::release_scrape_dockerv2::registry] [4.2.7] Downloading layer sha256:de05399aafa027d3bddcff8d4aa011c57689fec00fde83fc744face6af919037
[2020-04-06T15:27:38Z TRACE cincinnati::plugins::internal::graph_builder::release_scrape_dockerv2::registry] [4.2.8] Downloading layer sha256:d08d07c970bc38298f26257215ba27c01be86760228264c0751ed7a3be4eaf5b
[2020-04-06T15:27:38Z ERROR graph_builder::graph] Exceeded timeout of 10s
(... possibly more output of the leaked threads)
```