### PR TITLE
dist/run_containerized_loadtesting: remove tty request

### DIFF
--- a/dist/run_containerized_loadtesting.sh
+++ b/dist/run_containerized_loadtesting.sh
@@ -13,4 +13,4 @@ docker run --rm \
   --env GRAPH_URL=${GRAPH_URL} \
   --workdir /tmp \
   --entrypoint=/usr/local/bin/load-testing.sh \
-  -ti "${VEGETA_IMAGE}"
+  -i "${VEGETA_IMAGE}"


### PR DESCRIPTION

Load testing container doesn't require a tty to run and its not available
on internal CI.

Fixes `the input device is not a TTY` during stage runs