### PR TITLE
dist/openshift: omit 'data_directory' for metadata parser plugin

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -165,7 +165,6 @@ run-graph-builder:
 
 		[[plugin_settings]]
 		name = "openshift-secondary-metadata-parse"
-		data_directory = "${TMPDIR}"
 
 		[[plugin_settings]]
 		name = "edge-add-remove"

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -327,7 +327,6 @@ parameters:
 
       [[plugin_settings]]
       name = "openshift-secondary-metadata-parse"
-      data_directory = "/tmp/cincinnati/graph-data"
 
       [[plugin_settings]]
       name = "edge-add-remove"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -82,7 +82,6 @@ oc new-app -f dist/openshift/cincinnati.yaml \
 
       [[plugin_settings]]
       name = "openshift-secondary-metadata-parse"
-      data_directory = "/tmp/cincinnati-graph-data"
 
       [[plugin_settings]]
       name = "edge-add-remove"


### PR DESCRIPTION
f49909ad27f529f9a49f33fd9120bbb37e8588bf implemented a mechanism which
makes this configuration option obsolete, by having the scraper plugin
insert this path into the plugin parameters.