### PR TITLE
dist/run_containerized_loadtesting: fix mounting vegeta targets and wrapper scripts

### DIFF
--- a/dist/run_containerized_loadtesting.sh
+++ b/dist/run_containerized_loadtesting.sh
@@ -8,8 +8,8 @@ set -ex
 VEGETA_IMAGE="docker.io/peterevans/vegeta:6.8"
 
 docker run --rm \
-  --volume hack/load-testing.sh:/usr/local/bin/load-testing.sh \
-  --volume hack/vegeta.targets:/tmp/vegeta.targets \
+  --volume $(pwd)/hack/load-testing.sh:/usr/local/bin/load-testing.sh \
+  --volume $(pwd)/hack/vegeta.targets:/tmp/vegeta.targets \
   --env GRAPH_URL=${GRAPH_URL} \
   --workdir /tmp \
   --entrypoint=/usr/local/bin/load-testing.sh \


### PR DESCRIPTION
Docker assumes local paths to be volume names by default. Use absolute path
(using `$(pwd)`) to mount vegeta targets and wrapper script.

Fixes the following error on stage:
```
docker: Error response from daemon: create hack/vegeta.targets: "hack/vegeta.targets" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```