### PR TITLE
hack/load-testing: run using sh

### DIFF
--- a/hack/load-testing.sh
+++ b/hack/load-testing.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # This script is used to load test Cincinnati instance.
 # It uses vegeta - `go get -u github.com/tsenart/vegeta`


### PR DESCRIPTION
Image used in `dist/run_containerized_loadtesting.sh` doesn't have `bash`,
so we should be using plain shell instead, as no bash-specific tricks
are required to run the script wrapper.

Fixes `env: can't execute 'bash': No such file or directory` when running containerized load tests