### PR TITLE
hack/vegeta: use channels from production

### DIFF
--- a/hack/vegeta.targets
+++ b/hack/vegeta.targets
@@ -1,9 +1,9 @@
 # valid request
-GET GRAPH_URL?channel=a&arch=amd64
+GET GRAPH_URL?channel=stable-4.2&arch=amd64
 Accept: application/json
 
-GET GRAPH_URL?channel=b&arch=amd64
+GET GRAPH_URL?channel=stable-4.3&arch=amd64
 Accept: application/json
 
-GET GRAPH_URL?channel=test&arch=amd64
+GET GRAPH_URL?channel=fast-4.3&arch=amd64
 Accept: application/json


### PR DESCRIPTION

This updates channels used in load tests, as e2e is now configured to use
production data and thus shouldn't use "a", "b" and "test" channels