### PR TITLE
WIP: Use tag or sha256 digest for Cincinnati deployment

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -30,7 +30,7 @@ objects:
             deploymentconfig: cincinnati
         spec:
           containers:
-            - image: ${IMAGE}:${IMAGE_TAG}
+            - image: ${IMAGE}
               imagePullPolicy: Always
               name: cincinnati-graph-builder
               env:
@@ -80,7 +80,7 @@ objects:
                 - name: configs
                   mountPath: /etc/configs
                   readOnly: true
-            - image: ${IMAGE}:${IMAGE_TAG}
+            - image: ${IMAGE}
               name: cincinnati-policy-engine
               imagePullPolicy: Always
               env:
@@ -227,13 +227,9 @@ objects:
         ${GB_PLUGIN_SETTINGS}
 parameters:
   - name: IMAGE
-    value: "quay.io/app-sre/cincinnati"
-    displayName: cincinnati image
-    description: cincinnati docker image. Defaults to quay.io/app-sre/cincinnati
-  - name: IMAGE_TAG
-    value: "latest"
-    displayName: cincinnati version
-    description: cincinnati version which defaults to latest
+    value: "quay.io/app-sre/cincinnati:latest"
+    displayName: cincinnati image name with tag or digest
+    description: cincinnati docker image. Defaults to quay.io/app-sre/cincinnati@sha256:latest
   - name: GB_MEMORY_LIMIT
     value: "512Mi"
     displayName: "Graph-builder memory limit"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -19,8 +19,7 @@ else
   IMAGE_TAG="deploy"
 fi
 
-echo "IMAGE=${IMAGE}"
-echo "IMAGE_TAG=${IMAGE_TAG}"
+echo "IMAGE=${IMAGE}:${IMAGE_TAG}
 
 # Use defined PULL_SECRET or fall back to CI location
 PULL_SECRET=${PULL_SECRET:-/tmp/cluster/pull-secret}
@@ -63,7 +62,6 @@ export E2E_METADATA_REVISION
 # Apply oc template
 oc new-app -f dist/openshift/cincinnati.yaml \
   -p IMAGE="${IMAGE}" \
-  -p IMAGE_TAG="${IMAGE_TAG}" \
   -p GB_CPU_REQUEST=50m \
   -p PE_CPU_REQUEST=50m \
   -p RUST_BACKTRACE="1" \


### PR DESCRIPTION
If we just use ${IMAGE}, we can use both the digest and tag for the Cincinnati image.
```
quay.io/app-sre/cincinnati@sha256:a54195540164af7207db1ee9b52deeef2f6dac50284df55d14863f19d7afb0ae
```
Or
```
quay.io/app-sre/cincinnati:c1e2b4e
```

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>