### PR TITLE
Run 2 Cincinnati pods during e2e

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -11,7 +11,7 @@ objects:
         app: cincinnati
       name: cincinnati
     spec:
-      replicas: 1
+      replicas: ${{REPLICAS}}
       selector:
         app: cincinnati
         deploymentconfig: cincinnati
@@ -341,3 +341,5 @@ parameters:
     value: "/etc/configs/gb.toml"
   - name: ENVIRONMENT_SECRETS
     value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
+  - name: REPLICAS
+    value: "1"

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -29,6 +29,18 @@ objects:
             app: cincinnati
             deploymentconfig: cincinnati
         spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - cincinnati
+                    topologyKey: kubernetes.io/hostname
           containers:
             - image: ${IMAGE}:${IMAGE_TAG}
               imagePullPolicy: Always

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -201,6 +201,15 @@ objects:
           targetPort: ${{PE_STATUS_PORT}}
       selector:
         deploymentconfig: cincinnati
+  - apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      name: cincinnati-pdb
+      namespace: cincinnati
+    spec:
+      minAvailable: 1
+    selector:
+      app: cincinnati
   - apiVersion: v1
     kind: ConfigMap
     metadata:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -88,6 +88,7 @@ oc new-app -f dist/openshift/cincinnati.yaml \
 EOF
 )" \
   -p ENVIRONMENT_SECRETS="{}" \
+  -p REPLICAS="2" \
   ;
 
 # Wait for dc to rollout

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -92,7 +92,7 @@ EOF
   ;
 
 # Wait for dc to rollout
-oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati || {
+oc wait --for=condition=available --timeout=10m deploymentconfig/cincinnati || {
     status=$?
     set +e -x
 


### PR DESCRIPTION
This PR updates the deployment template:

* support specifying replicas number (default - 1)
* add anti-affinity rule so that Cincinnati pods would be placed on different nodes. This ensures cincinnati pods are not distrupted on node reboots / cluster updates
* add PodDistruptionBudget to ensure at least one Cincinnati pod is running during pod eviction.

Note that pods are not synced in any way, so amount of Github / Quay requests would increase proportionally to replicas. As a result `e2e` script now waits for 10 mins (instead of 5) to make sure initial scrape succeeds on both pods.

2 replica deployment seems to improve response latency - 34.96% of requests handled in 50ms in master now vs. 58.04% with this patch

Ref: OTA-148