### PR TITLE
hack/e2e: increase the timeout when waiting for initial scrape

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -20,7 +20,7 @@ objects:
           intervalSeconds: 1
           maxSurge: 25%
           maxUnavailable: 25%
-          timeoutSeconds: 600
+          timeoutSeconds: 900
           updatePeriodSeconds: 1
         type: Rolling
       template:

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -56,14 +56,14 @@ objects:
                 httpGet:
                   path: /liveness
                   port: ${{GB_STATUS_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 60
                 periodSeconds: 10
                 timeoutSeconds: 3
               readinessProbe:
                 httpGet:
                   path: /readiness
                   port: ${{GB_STATUS_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 60
                 periodSeconds: 10
                 timeoutSeconds: 3
               resources:
@@ -134,7 +134,7 @@ objects:
               livenessProbe:
                 tcpSocket:
                   port: ${{PE_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 60
                 periodSeconds: 10
                 timeoutSeconds: 3
               resources:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -91,7 +91,7 @@ EOF
   ;
 
 # Wait for dc to rollout
-oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati || {
+oc wait --for=condition=available --timeout=15m deploymentconfig/cincinnati || {
     status=$?
     set +e -x
 


### PR DESCRIPTION
Initial registry scrape doesn't complete in 5 minutes anymore. Local
tests show its 330s now. This commit would increase the timeout to 15
minutes.

/cc @steveeJ 