### PR TITLE
WIP Timeout initial scrape and retry without a pause until it succeeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "base64"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,7 +622,7 @@ dependencies = [
  "commons 0.1.0",
  "custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dkregistry 0.4.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=712f7dae50068948e8678af535ce90bb63afd878)",
+ "dkregistry 0.4.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=082c8b42cd41a109570fa5d27ab0578fb2cdb7fb)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -903,10 +908,10 @@ dependencies = [
 [[package]]
 name = "dkregistry"
 version = "0.4.0-alpha.0"
-source = "git+https://github.com/camallo/dkregistry-rs.git?rev=712f7dae50068948e8678af535ce90bb63afd878#712f7dae50068948e8678af535ce90bb63afd878"
+source = "git+https://github.com/camallo/dkregistry-rs.git?rev=082c8b42cd41a109570fa5d27ab0578fb2cdb7fb#082c8b42cd41a109570fa5d27ab0578fb2cdb7fb"
 dependencies = [
  "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3564,6 +3569,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -3608,7 +3614,7 @@ dependencies = [
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-"checksum dkregistry 0.4.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=712f7dae50068948e8678af535ce90bb63afd878)" = "<none>"
+"checksum dkregistry 0.4.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=082c8b42cd41a109570fa5d27ab0578fb2cdb7fb)" = "<none>"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = "^0.1"
 tempfile = "^3.1.0"
 flate2 = "^1.0.1"
 tar = "^0.4.16"
-dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "712f7dae50068948e8678af535ce90bb63afd878" }
+dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "082c8b42cd41a109570fa5d27ab0578fb2cdb7fb" }
 itertools = "^0.8.2"
 serde_yaml = "^0.8.11"
 prettydiff = { version = "0.3.1", optional = true }

--- a/cincinnati/src/plugins/internal/graph_builder/commons.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/commons.rs
@@ -11,11 +11,11 @@ pub mod tests {
         let _ = env_logger::try_init_from_env(env_logger::Env::default());
     }
 
-    pub fn common_init() -> (tokio::runtime::Runtime, registry::cache::Cache) {
+    pub fn common_init() -> (tokio::runtime::Runtime, registry::release_cache::Cache) {
         init_logger();
         (
             tokio::runtime::Runtime::new().unwrap(),
-            registry::cache::new(),
+            registry::release_cache::new(),
         )
     }
 

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use tar::Archive;
 
 /// Module for the release cache
-pub mod cache {
+pub mod release_cache {
     use super::cincinnati::plugins::internal::graph_builder::release::Release;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -44,6 +44,33 @@ pub mod cache {
 
     /// The values of the cache
     type Value = Option<Release>;
+
+    /// The sync cache to hold the `Release` cache
+    type CacheSync = HashMap<Key, Value>;
+
+    /// The async wrapper for `Cache`
+    type CacheAsync<T> = FuturesRwLock<T>;
+
+    /// The cache to hold the `Release` cache
+    pub type Cache = Arc<CacheAsync<CacheSync>>;
+
+    /// Instantiate a new cache
+    pub fn new() -> Cache {
+        Arc::new(CacheAsync::new(CacheSync::new()))
+    }
+}
+
+/// Module for registry cache
+pub mod registry_cache {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::RwLock as FuturesRwLock;
+
+    /// The key type of the cache - registry tag
+    type Key = String;
+
+    /// The values of the cache - manifestref and the manifest
+    type Value = (String, dkregistry::v2::manifest::Manifest);
 
     /// The sync cache to hold the `Release` cache
     type CacheSync = HashMap<Key, Value>;
@@ -195,7 +222,8 @@ pub async fn fetch_releases(
     repo: &str,
     username: Option<&str>,
     password: Option<&str>,
-    cache: cache::Cache,
+    release_cache: release_cache::Cache,
+    registry_cache: registry_cache::Cache,
     manifestref_key: &str,
     concurrency: usize,
 ) -> Result<Vec<cincinnati::plugins::internal::graph_builder::release::Release>, Error> {
@@ -223,13 +251,15 @@ pub async fn fetch_releases(
 
     tags.try_for_each_concurrent(concurrency, |tag| {
         let authenticated_client = authenticated_client.clone();
-        let cache = cache.clone();
+        let release_cache = release_cache.clone();
+        let registry_cache = registry_cache.clone();
         let releases = releases.clone();
 
         async move {
             trace!("[{}] Fetching release", tag);
             let (tag, manifest, manifestref) =
-                get_manifest_and_ref(tag, repo.to_owned(), &authenticated_client).await?;
+                get_manifest_and_ref(tag, repo.to_owned(), registry_cache, &authenticated_client)
+                    .await?;
 
             // Try to read the architecture from the manifest
             let arch = match manifest.architectures() {
@@ -271,7 +301,7 @@ pub async fn fetch_releases(
                 registry.host.to_owned().to_string(),
                 repo.to_owned(),
                 tag.to_owned(),
-                &cache,
+                &release_cache,
                 manifestref.clone(),
                 manifestref_key.to_string(),
                 arch,
@@ -318,7 +348,7 @@ async fn lookup_or_fetch(
     registry_host: String,
     repo: String,
     tag: String,
-    cache: &cache::Cache,
+    cache: &release_cache::Cache,
     manifestref: String,
     manifestref_key: String,
     arch: Option<String>,
@@ -384,16 +414,38 @@ async fn get_tags<'a, 'b: 'a>(
 async fn get_manifest_and_ref(
     tag: String,
     repo: String,
+    cache: registry_cache::Cache,
     authenticated_client: &dkregistry::v2::Client,
 ) -> Result<(String, dkregistry::v2::manifest::Manifest, String), failure::Error> {
+    let (tag, repo) = (tag.clone(), repo.clone());
     trace!("[{}] Processing {}", &tag, &repo);
-    let (manifest, manifestref) = authenticated_client
+
+    let manifestref = authenticated_client
+        .get_manifestref(&repo, &tag)
+        .map_err(|e| format_err!("{}", e))
+        .await?
+        .ok_or_else(|| format_err!("no manifestref found for {}:{}", &repo, &tag))?;
+
+    if let Some((cached_manifestref, manifest)) = cache.read().await.get(&tag) {
+        if cached_manifestref == &manifestref {
+            trace!(
+                "[{}] Using cached manifest metadata for manifestref {}",
+                &tag,
+                &manifestref
+            );
+            return Ok((tag, (*manifest).clone(), manifestref.clone()));
+        }
+    }
+
+    let (manifest, _) = authenticated_client
         .get_manifest_and_ref(&repo, &tag)
         .map_err(|e| format_err!("{}", e))
         .await?;
 
-    let manifestref =
-        manifestref.ok_or_else(|| format_err!("no manifestref found for {}:{}", &repo, &tag))?;
+    cache
+        .write()
+        .await
+        .insert(tag.clone(), (manifestref.clone(), manifest.clone()));
 
     Ok((tag, manifest, manifestref))
 }

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -377,7 +377,7 @@ where
 pub fn process_blocking<T>(
     plugins: T,
     initial_io: PluginIO,
-    timeout: Option<std::time::Duration>,
+    timeout: std::time::Duration,
 ) -> Fallible<InternalIO>
 where
     T: Iterator<Item = &'static BoxedPlugin>,
@@ -386,10 +386,6 @@ where
 {
     let mut runtime = tokio::runtime::Runtime::new()?;
 
-    let timeout = match timeout {
-        None => return runtime.block_on(process(plugins, initial_io)),
-        Some(timeout) => timeout,
-    };
     let deadline = timeout + (timeout / 100);
 
     let (tx, rx) = std::sync::mpsc::channel::<Fallible<InternalIO>>();
@@ -646,7 +642,7 @@ mod tests {
         let result_internalio = super::process_blocking(
             PLUGINS.iter(),
             PluginIO::InternalIO(initial_internalio),
-            Some(timeout),
+            timeout,
         );
         let process_duration = before_process.elapsed();
 
@@ -693,7 +689,7 @@ mod tests {
             let result_internalio = super::process_blocking(
                 PLUGINS.iter(),
                 PluginIO::InternalIO(initial_internalio.clone()),
-                Some(timeout),
+                timeout,
             );
             let process_duration = before_process.elapsed();
 

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -56,14 +56,14 @@ objects:
                 httpGet:
                   path: /liveness
                   port: ${{GB_STATUS_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 60
                 periodSeconds: 10
                 timeoutSeconds: 3
               readinessProbe:
                 httpGet:
                   path: /readiness
                   port: ${{GB_STATUS_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 60
                 periodSeconds: 10
                 timeoutSeconds: 3
               resources:
@@ -134,7 +134,7 @@ objects:
               livenessProbe:
                 tcpSocket:
                   port: ${{PE_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 60
                 periodSeconds: 10
                 timeoutSeconds: 3
               resources:

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -267,7 +267,7 @@ parameters:
     displayName: "Policy-engine CPU request"
     description: "Requested amount of CPU (millicores) allowed for policy-engine (default: 350m)"
   - name: GB_SCRAPE_TIMEOUT_SECS
-    value: "300"
+    value: "60"
     displayName: Graph-builder scrape timeout in seconds
   - name: GB_PAUSE_SECS
     value: "300"

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -36,7 +36,7 @@ pub struct AppSettings {
     pub pause_secs: time::Duration,
 
     /// Timeout (in seconds) per registry scrape.
-    pub scrape_timeout_secs: Option<time::Duration>,
+    pub scrape_timeout_secs: time::Duration,
 
     /// Listening port for the main service.
     #[default(8080)]

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -173,7 +173,8 @@ pub fn run(settings: &config::AppSettings, state: &State) -> ! {
 
     // Don't wait on the first iteration
     let mut first_iteration = true;
-    let mut first_success = true;
+    // Set first_success after initial scrape is done
+    let mut first_success = false;
 
     BUILD_INFO.inc();
 
@@ -185,7 +186,9 @@ pub fn run(settings: &config::AppSettings, state: &State) -> ! {
             *state.live.write() = true;
             first_iteration = false;
         } else {
-            thread::sleep(settings.pause_secs);
+            if first_success {
+                thread::sleep(settings.pause_secs);
+            }
         }
 
         debug!("graph update triggered");

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -173,8 +173,7 @@ pub fn run(settings: &config::AppSettings, state: &State) -> ! {
 
     // Don't wait on the first iteration
     let mut first_iteration = true;
-    // Set first_success after initial scrape is done
-    let mut first_success = false;
+    let mut first_success = true;
 
     BUILD_INFO.inc();
 
@@ -186,9 +185,7 @@ pub fn run(settings: &config::AppSettings, state: &State) -> ! {
             *state.live.write() = true;
             first_iteration = false;
         } else {
-            if first_success {
-                thread::sleep(settings.pause_secs);
-            }
+            thread::sleep(settings.pause_secs);
         }
 
         debug!("graph update triggered");


### PR DESCRIPTION
Timeout initial scrape and retry it without a timeout. This would ensure initial scrape doesn't hang up. Image metadata is cached in graph-builder, so the subsequent retries would finish sooner.

TODO:
* [ ] Cache manifests by digest to avoid re-pulling those
* [ ] Ensure partial graph is not served if initial scrape fails