### PR TITLE
hack/e2e: describe pods when failed

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -99,6 +99,7 @@ oc wait --for=condition=available --timeout=5m deploymentconfig/cincinnati || {
     oc get events
     oc describe deploymentconfig/cincinnati
     oc get configmap/cincinnati-configs -o yaml
+    oc describe pods --selector='app=cincinnati'
     oc logs --all-containers=true --timestamps=true --selector='app=cincinnati'
 
     exit $status


### PR DESCRIPTION
Describe status of the pods before listing logs - these might uncover failed healthchecks / OOMKills.

/cc @steveeJ 