### PR TITLE
dist/openshift/cincinnati: bump GB pod memory limit

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -235,7 +235,7 @@ parameters:
     displayName: cincinnati version
     description: cincinnati version which defaults to latest
   - name: GB_MEMORY_LIMIT
-    value: "512Mi"
+    value: "768Mi"
     displayName: "Graph-builder memory limit"
     description: "Maximum amount of memory (bytes) allowed for graph-builder (default: 523Mi)"
   - name: GB_CPU_LIMIT


### PR DESCRIPTION
Temporarily increase memory limit for graph-builder container. Too many releases cause the memory to grow rapidly, which causes graph-builder being killed