### PR TITLE
dist/openshift/cincinnati: fix indent in PDB spec

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -208,8 +208,8 @@ objects:
       namespace: cincinnati
     spec:
       minAvailable: 1
-    selector:
-      app: cincinnati
+      selector:
+        app: cincinnati
   - apiVersion: v1
     kind: ConfigMap
     metadata:


### PR DESCRIPTION

According to https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#poddisruptionbudgetspec-v1beta1-policy
`selector` should be nested under `spec`