### PR TITLE
Replace failure crate with anyhow+thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -365,7 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -375,7 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -619,7 +619,6 @@ dependencies = [
  "daggy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dkregistry 0.4.0-alpha.0 (git+https://github.com/camallo/dkregistry-rs.git?rev=712f7dae50068948e8678af535ce90bb63afd878)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-locks 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,8 +686,8 @@ name = "commons"
 version = "0.1.0"
 dependencies = [
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -696,6 +695,7 @@ dependencies = [
  "prometheus 0.7.0 (git+https://github.com/pingcap/rust-prometheus.git?rev=6a02b0d2943f8fffce672e236e22c6f925184d93)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "twoway 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -845,7 +845,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -976,7 +976,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1245,7 +1245,6 @@ dependencies = [
  "commons 0.1.0",
  "custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1964,7 +1963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1993,7 +1992,6 @@ dependencies = [
  "commons 0.1.0",
  "custom_debug_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2060,7 +2058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2101,10 +2099,10 @@ dependencies = [
 name = "prometheus-query"
 version = "0.0.0-dev"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "commons 0.1.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2164,9 +2162,9 @@ dependencies = [
 name = "quay"
 version = "0.0.0-dev"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2583,7 +2581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2762,7 +2760,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2777,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.5"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2850,7 +2848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2860,6 +2858,24 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3346,7 +3362,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3377,7 +3393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3397,7 +3413,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3798,7 +3814,7 @@ dependencies = [
 "checksum strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "572a2f4e53dd4c3483fd79e5cc10ddd773a3acb1169bbfe8762365e107110579"
 "checksum strum_macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
@@ -3807,6 +3823,8 @@ dependencies = [
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum test-case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "199464148b42bcf3da8b2a56f6ee87ca68f47402496d1268849291ec9fb463c8"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+"checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -10,7 +10,6 @@ commons = { path = "../commons" }
 custom_debug_derive = "^0.1.7"
 daggy = { version = "^0.6.0", features = [ "serde-1" ] }
 env_logger = "^0.6.0"
-failure = "^0.1.1"
 futures = "0.3"
 futures-locks = "0.5.0"
 lazy_static = "^1.2.0"

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -13,17 +13,14 @@
 // limitations under the License.
 
 #[macro_use]
-extern crate failure;
-
-#[macro_use]
 extern crate serde_derive;
 
 #[macro_use]
 pub mod plugins;
 
+use commons::prelude_errors::*;
 use daggy::petgraph::visit::{IntoNodeReferences, NodeRef};
 use daggy::{Dag, EdgeIndex, Walker};
-use failure::{Error, Fallible};
 use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::{collections, fmt};
@@ -154,9 +151,11 @@ pub struct Empty;
 
 /// Errors that can be returned by the methods in this library
 pub mod errors {
+    use commons::prelude_errors::*;
+
     /// Edge already exists
     #[derive(Debug, Fail, Eq, PartialEq)]
-    #[fail(display = "edge from {:?} to {:?} already exists", from, to)]
+    #[error("edge from {:?} to {:?} already exists", from, to)]
     pub struct EdgeAlreadyExists {
         pub(crate) from: String,
         pub(crate) to: String,
@@ -164,7 +163,7 @@ pub mod errors {
 
     /// Edge doesn't exist
     #[derive(Debug, Fail, Eq, PartialEq)]
-    #[fail(display = "edge from '{:?}' to '{:?}' doesn't exist", from, to)]
+    #[error("edge from '{:?}' to '{:?}' doesn't exist", from, to)]
     pub struct EdgeDoesntExist {
         pub(crate) from: String,
         pub(crate) to: String,
@@ -172,7 +171,7 @@ pub mod errors {
 
     /// Missing node weight
     #[derive(Debug, Fail, Eq, PartialEq)]
-    #[fail(display = "NodeWeight with index {} is missing", 0)]
+    #[error("NodeWeight with index {} is missing", 0)]
     pub struct NodeWeightMissing(pub(crate) usize);
 }
 

--- a/cincinnati/src/plugins/catalog.rs
+++ b/cincinnati/src/plugins/catalog.rs
@@ -22,7 +22,7 @@ use super::internal::openshift_secondary_metadata_parser::{
 use super::internal::release_scrape_dockerv2::{
     ReleaseScrapeDockerv2Plugin, ReleaseScrapeDockerv2Settings,
 };
-use failure::{bail, format_err, Fallible};
+use commons::prelude_errors::*;
 use std::fmt::Debug;
 
 /// Key used to look up plugin-type in a configuration entry.

--- a/cincinnati/src/plugins/external/web.rs
+++ b/cincinnati/src/plugins/external/web.rs
@@ -20,8 +20,8 @@ mod tests {
     use async_trait::async_trait;
     use cincinnati::plugins::{interface, ExternalIO, ExternalPlugin, InternalIO, PluginResult};
     use cincinnati::testing::generate_graph;
+    use commons::prelude_errors::*;
     use commons::testing::init_runtime;
-    use failure::Fallible;
     use log::trace;
     use std::convert::TryInto;
 

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -9,8 +9,8 @@ use self::cincinnati::plugins::prelude::*;
 use self::cincinnati::plugins::prelude_plugin_impl::*;
 use self::cincinnati::CONTENT_TYPE;
 
+use commons::prelude_errors::*;
 use commons::GraphError;
-use failure::{Fallible, ResultExt};
 use prometheus::Counter;
 use reqwest;
 use reqwest::header::{HeaderValue, ACCEPT};
@@ -158,8 +158,8 @@ mod tests {
     use super::*;
     use cincinnati::testing::generate_custom_graph;
     use commons::metrics::{self, RegistryWrapper};
+    use commons::prelude_errors::*;
     use commons::testing::{self, init_runtime};
-    use failure::{bail, Fallible};
     use prometheus::Registry;
 
     macro_rules! fetch_upstream_success_test {
@@ -318,7 +318,7 @@ mod tests {
         let metrics_call = metrics::serve::<metrics::RegistryWrapper>(actix_web::web::Data::new(
             RegistryWrapper(registry),
         ));
-        let resp = rt.block_on(metrics_call)?;
+        let resp = rt.block_on(metrics_call);
 
         assert_eq!(resp.status(), 200);
         if let actix_web::body::ResponseBody::Body(body) = resp.body() {

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -333,7 +333,6 @@ mod tests {
     use cincinnati::testing::generate_custom_graph;
     use cincinnati::MapImpl;
     use commons::testing::init_runtime;
-    use failure::ResultExt;
 
     static KEY_PREFIX: &str = "test_key";
 

--- a/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
@@ -44,7 +44,7 @@ impl Reference {
 }
 
 impl TryFrom<(Option<&String>, Option<&String>)> for Reference {
-    type Error = failure::Error;
+    type Error = Error;
 
     fn try_from(options: (Option<&String>, Option<&String>)) -> Fallible<Self> {
         let reference = match (options.0, options.1) {
@@ -194,7 +194,7 @@ impl GithubOpenshiftSecondaryMetadataScraperPlugin {
             reference: settings
                 .reference
                 .clone()
-                .ok_or_else(|| failure::err_msg("settings don't contain a 'reference'"))?,
+                .ok_or_else(|| format_err!("settings don't contain a 'reference'"))?,
             settings,
             output_whitelist,
             oauth_token,
@@ -248,7 +248,7 @@ impl GithubOpenshiftSecondaryMetadataScraperPlugin {
             })
             .nth(0)
             .ok_or_else(|| {
-                failure::err_msg(format!(
+                format_err!(format!(
                     "{}/{} does not have branch {}: {:#?}",
                     &self.settings.github_org,
                     &self.settings.github_repo,
@@ -304,7 +304,7 @@ impl GithubOpenshiftSecondaryMetadataScraperPlugin {
             state
                 .commit_wanted
                 .clone()
-                .ok_or_else(|| failure::err_msg("commit_wanted unset"))?
+                .ok_or_else(|| format_err!("commit_wanted unset"))?
         };
 
         let url = github_v3::tarball_url(
@@ -371,7 +371,7 @@ impl GithubOpenshiftSecondaryMetadataScraperPlugin {
                                 &entry.header().clone().path().unwrap_or_default()
                             ))?
                             .to_str()
-                            .ok_or_else(|| failure::err_msg("Could not get string from entry"))?
+                            .ok_or_else(|| format_err!("Could not get string from entry"))?
                             .to_owned();
                         trace!("Processing entry with path {:?}", &path);
 
@@ -450,7 +450,7 @@ impl InternalPlugin for GithubOpenshiftSecondaryMetadataScraperPlugin {
             self.data_dir
                 .path()
                 .to_str()
-                .ok_or_else(|| failure::err_msg("data_dir cannot be converted to str"))?
+                .ok_or_else(|| format_err!("data_dir cannot be converted to str"))?
                 .to_string(),
         );
 

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -492,7 +492,7 @@ mod tests {
     use self::cincinnati::plugins::InternalPlugin;
     use self::cincinnati::testing::compare_graphs_verbose;
 
-    use failure::{Fallible, ResultExt};
+    use commons::prelude_errors::*;
     use std::path::PathBuf;
     use std::str::FromStr;
     use test_case::test_case;

--- a/cincinnati/src/plugins/internal/graph_builder/release.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release.rs
@@ -16,7 +16,7 @@ use crate as cincinnati;
 
 use self::cincinnati::MapImpl;
 
-use failure::Fallible;
+use commons::prelude_errors::*;
 use itertools::Itertools;
 use log::{trace, warn};
 use semver::Version;
@@ -75,7 +75,7 @@ pub enum MetadataKind {
 ///
 /// When processing previous/next release metadata it is assumed that the edge
 /// destination has the same build type as the origin.
-pub fn create_graph(releases: Vec<Release>) -> Result<cincinnati::Graph, failure::Error> {
+pub fn create_graph(releases: Vec<Release>) -> Result<cincinnati::Graph, Error> {
     let mut graph = cincinnati::Graph::default();
 
     releases
@@ -146,7 +146,7 @@ pub fn create_graph(releases: Vec<Release>) -> Result<cincinnati::Graph, failure
                     if let Err(e) = graph.add_edge(&&current, &next) {
                         if let Some(eae) = e.downcast_ref::<cincinnati::errors::EdgeAlreadyExists>()
                         {
-                            warn!("{}", eae);
+                            warn!("{:?}", eae);
                         } else {
                             return Err(e);
                         }

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -98,7 +98,7 @@ impl ReleaseScrapeDockerv2Plugin {
         mut settings: ReleaseScrapeDockerv2Settings,
         cache: Option<registry::cache::Cache>,
         prometheus_registry: Option<&prometheus::Registry>,
-    ) -> failure::Fallible<Self> {
+    ) -> Fallible<Self> {
         use prometheus::IntGauge;
         let graph_upstream_raw_releases: IntGauge = IntGauge::new(
             "graph_upstream_raw_releases",
@@ -173,7 +173,7 @@ mod network_tests {
 
     use cincinnati::plugins::internal::graph_builder::commons::tests::common_init;
     use cincinnati::testing::{TestGraphBuilder, TestMetadata};
-    use failure::{Fallible, ResultExt};
+    use commons::prelude_errors::*;
     use std::collections::HashSet;
 
     #[test]

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -15,8 +15,8 @@
 use crate as cincinnati;
 
 use self::cincinnati::plugins::internal::graph_builder::release::Metadata;
+use self::cincinnati::plugins::prelude_plugin_impl::*;
 
-use failure::{bail, ensure, format_err, Error, Fallible, ResultExt};
 use flate2::read::GzDecoder;
 use futures::lock::Mutex as FuturesMutex;
 use futures::prelude::*;
@@ -385,7 +385,7 @@ async fn get_manifest_and_ref(
     tag: String,
     repo: String,
     authenticated_client: &dkregistry::v2::Client,
-) -> Result<(String, dkregistry::v2::manifest::Manifest, String), failure::Error> {
+) -> Result<(String, dkregistry::v2::manifest::Manifest, String), Error> {
     trace!("[{}] Processing {}", &tag, &repo);
     let (manifest, manifestref) = authenticated_client
         .get_manifest_and_ref(&repo, &tag)

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/network_tests.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/network_tests.rs
@@ -11,7 +11,7 @@ use cincinnati::plugins::internal::graph_builder::release_scrape_dockerv2::regis
 };
 use cincinnati::plugins::internal::metadata_fetch_quay::DEFAULT_QUAY_MANIFESTREF_KEY as MANIFESTREF_KEY;
 use cincinnati::{Empty, MapImpl, WouldCycle};
-use failure::{bail, ensure, Fallible};
+use commons::prelude_errors::*;
 use itertools::Itertools;
 use semver::Version;
 use std::collections::HashMap;

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -71,7 +71,6 @@ mod tests {
     use super::*;
     use cincinnati::testing::{generate_custom_graph, TestMetadata};
     use commons::testing::init_runtime;
-    use failure::ResultExt;
 
     #[test]
     fn ensure_release_remove() -> Fallible<()> {

--- a/cincinnati/src/plugins/macros.rs
+++ b/cincinnati/src/plugins/macros.rs
@@ -9,7 +9,7 @@ macro_rules! get_multiple_values {
                     if let Some(value) = $map.get($key) {
                         value
                     } else {
-                        failure::bail!("{}", $key)
+                        return Err(Box::new(format!("{}", $key)));
                     },
                 )
             };
@@ -25,7 +25,7 @@ macro_rules! get_multiple_values {
                             if let Some(value) = $map.get($key) {
                                 value
                             } else {
-                                failure::bail!("{}", $key)
+                                return Err(Box::new(format!("{}", $key)));
                             },
                         )*
                     )

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 [dependencies]
 actix-web = "^2.0"
 env_logger = "^0.6.0"
-failure = "^0.1.5"
+anyhow = "1.0"
+thiserror = "1.0"
 lazy_static = "^1.2.0"
 log = "^0.4.6"
 prometheus = { git = "https://github.com/pingcap/rust-prometheus.git", rev = "6a02b0d2943f8fffce672e236e22c6f925184d93"}

--- a/commons/src/config.rs
+++ b/commons/src/config.rs
@@ -20,5 +20,5 @@ macro_rules! assign_if_some {
 /// leaving unset ones preserved as-is from existing settings.
 pub trait MergeOptions<T> {
     /// MergeOptions values from `options` into current settings.
-    fn try_merge(&mut self, options: T) -> failure::Fallible<()>;
+    fn try_merge(&mut self, options: T) -> crate::Fallible<()>;
 }

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -1,7 +1,20 @@
 use actix_web::http;
 use actix_web::HttpResponse;
-use failure::Fallible;
 use prometheus::{IntCounterVec, Opts, Registry};
+use thiserror::Error;
+
+pub mod prelude {
+    pub use anyhow::anyhow as format_err;
+    pub use anyhow::bail;
+    pub use anyhow::ensure;
+    pub use anyhow::Context;
+    pub use anyhow::Error;
+    pub use anyhow::Result as Fallible;
+
+    // Macro imports
+    pub use thiserror::Error as Fail;
+}
+pub use prelude::*;
 
 lazy_static! {
     static ref V1_GRAPH_ERRORS: IntCounterVec = IntCounterVec::new(
@@ -25,43 +38,43 @@ pub fn register_metrics(registry: &Registry) -> Fallible<()> {
     Ok(())
 }
 
-#[derive(Debug, Fail, Eq, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
 /// Error that can be returned by `/v1/graph` endpoint.
 pub enum GraphError {
     /// Failed to deserialize JSON.
-    #[fail(display = "failed to deserialize JSON: {}", _0)]
+    #[error("failed to deserialize JSON: {}", _0)]
     FailedJsonIn(String),
 
     /// Failed to serialize JSON.
-    #[fail(display = "failed to serialize JSON: {}", _0)]
+    #[error("failed to serialize JSON: {}", _0)]
     FailedJsonOut(String),
 
     /// Error response from upstream.
-    #[fail(display = "failed to fetch upstream graph: {}", _0)]
+    #[error("failed to fetch upstream graph: {}", _0)]
     FailedUpstreamFetch(String),
 
     /// Plugin failure.
-    #[fail(display = "failed to execute plugins: {}", _0)]
+    #[error("failed to execute plugins: {}", _0)]
     FailedPluginExecution(String),
 
     /// Error while reaching upstream.
-    #[fail(display = "failed to assemble upstream request")]
+    #[error("failed to assemble upstream request")]
     FailedUpstreamRequest(String),
 
     /// Requested invalid mediatype.
-    #[fail(display = "invalid Content-Type requested")]
+    #[error("invalid Content-Type requested")]
     InvalidContentType,
 
     /// Missing client parameters.
-    #[fail(display = "mandatory client parameters missing")]
+    #[error("mandatory client parameters missing")]
     MissingParams(Vec<String>),
 
     /// Invalid client parameters.
-    #[fail(display = "invalid client parameters: {}", _0)]
+    #[error("invalid client parameters: {}", _0)]
     InvalidParams(String),
 
     /// Failed to parse as Semantic Version
-    #[fail(display = "failed to process version: {}", _0)]
+    #[error("failed to process version: {}", _0)]
     ArchVersionError(String),
 }
 

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -4,8 +4,6 @@
 
 extern crate actix_web;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate serde_json;
@@ -18,7 +16,12 @@ pub mod metrics;
 pub mod testing;
 
 mod errors;
-pub use errors::{register_metrics, GraphError, MISSING_APPSTATE_PANIC_MSG};
+pub use errors::{register_metrics, Fallible, GraphError, MISSING_APPSTATE_PANIC_MSG};
+
+/// Commonly used imports for error handling.
+pub mod prelude_errors {
+    pub use crate::errors::prelude::*;
+}
 
 use actix_web::http::header;
 use std::collections::HashSet;

--- a/commons/src/testing.rs
+++ b/commons/src/testing.rs
@@ -1,6 +1,6 @@
 //! Test helpers.
 
-use failure::Fallible;
+use crate::prelude_errors::*;
 use tokio::runtime::Runtime;
 
 /// Initialize logging.
@@ -12,7 +12,7 @@ pub fn init_logger() -> Fallible<()> {
 /// Initialize a tokio runtime for tests, with logging.
 pub fn init_runtime() -> Fallible<Runtime> {
     let _ = init_logger();
-    Runtime::new().map_err(failure::Error::from)
+    Runtime::new().map_err(Error::from)
 }
 
 /// Register a dummy gauge, with given value.

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use commons::prelude_errors::*;
 use reqwest::header::{HeaderValue, ACCEPT};
 use std::env;
 use test_case::test_case;

--- a/e2e/tests/prometheus_query.rs
+++ b/e2e/tests/prometheus_query.rs
@@ -1,4 +1,4 @@
-use failure::{Fallible, ResultExt};
+use commons::prelude_errors::*;
 use prometheus_query::v1::queries::{QueryData, QueryResult, VectorResult};
 use prometheus_query::v1::Client;
 

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -12,7 +12,6 @@ chrono = "^0.4.7"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
 env_logger = "^0.6.0"
-failure = "^0.1.1"
 flate2 = "^1.0.1"
 futures = "0.3"
 itertools = "^0.8.2"

--- a/graph-builder/src/config/cli.rs
+++ b/graph-builder/src/config/cli.rs
@@ -2,8 +2,8 @@
 
 use super::options;
 use super::AppSettings;
+use commons::prelude_errors::*;
 use commons::MergeOptions;
-use failure::Fallible;
 
 /// CLI configuration flags, top-level.
 #[derive(Debug, StructOpt)]

--- a/graph-builder/src/config/file.rs
+++ b/graph-builder/src/config/file.rs
@@ -3,8 +3,8 @@
 use super::options;
 use super::AppSettings;
 use commons::de::de_loglevel;
+use commons::prelude_errors::*;
 use commons::MergeOptions;
-use failure::{Fallible, ResultExt};
 use std::io::Read;
 use std::{fs, io, path};
 

--- a/graph-builder/src/config/options.rs
+++ b/graph-builder/src/config/options.rs
@@ -1,8 +1,8 @@
 //! Options shared by CLI and TOML.
 
 use super::AppSettings;
+use commons::prelude_errors::*;
 use commons::{de_path_prefix, parse_params_set, parse_path_prefix, MergeOptions};
-use failure::Fallible;
 use std::collections::HashSet;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -138,7 +138,7 @@ where
     Ok(Some(Duration::from_secs(secs)))
 }
 
-pub fn duration_from_secs<S>(num: S) -> failure::Fallible<Duration>
+pub fn duration_from_secs<S>(num: S) -> Fallible<Duration>
 where
     S: AsRef<str>,
 {

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -3,8 +3,8 @@
 use super::{cli, file};
 use cincinnati::plugins::catalog::{build_plugins, PluginSettings};
 use cincinnati::plugins::BoxedPlugin;
+use commons::prelude_errors::*;
 use commons::MergeOptions;
-use failure::Fallible;
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
@@ -125,8 +125,6 @@ impl AppSettings {
     }
 
     fn default_openshift_plugin_settings(&self) -> Fallible<Vec<Box<dyn PluginSettings>>> {
-        use failure::ResultExt;
-
         use cincinnati::plugins::internal::github_openshift_secondary_metadata_scraper::GITHUB_SCRAPER_TOKEN_PATH_ENV;
         use cincinnati::plugins::prelude::*;
 

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -18,8 +18,7 @@ use actix_web::{HttpRequest, HttpResponse};
 use cincinnati::plugins::prelude::*;
 use cincinnati::CONTENT_TYPE;
 use commons::metrics::HasRegistry;
-use commons::GraphError;
-use failure::Fallible;
+use commons::{Fallible, GraphError};
 use lazy_static;
 pub use parking_lot::RwLock;
 use prometheus::{self, histogram_opts, labels, opts, Counter, Gauge, Histogram, IntGauge};
@@ -207,7 +206,7 @@ pub fn run(settings: &config::AppSettings, state: &State) -> ! {
             Ok(internal_io) => internal_io,
             Err(err) => {
                 UPSTREAM_ERRORS.inc();
-                err.iter_chain().for_each(|cause| error!("{}", cause));
+                err.chain().for_each(|cause| error!("{}", cause));
                 continue;
             }
         };

--- a/graph-builder/src/lib.rs
+++ b/graph-builder/src/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate commons;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -14,7 +14,7 @@
 
 use actix_web::{middleware, App, HttpServer};
 use commons::metrics::{self, HasRegistry};
-use failure::{ensure, Error, Fallible, ResultExt};
+use commons::prelude_errors::*;
 use graph_builder::{self, config, graph, status};
 use log::debug;
 use parking_lot::RwLock;
@@ -145,7 +145,6 @@ mod tests {
     use commons::metrics::HasRegistry;
     use commons::metrics::RegistryWrapper;
     use commons::testing;
-    use failure::{bail, Fallible};
     use parking_lot::RwLock;
     use prometheus::Registry;
     use std::collections::HashSet;
@@ -175,7 +174,7 @@ mod tests {
 
         let metrics_call =
             metrics::serve::<RegistryWrapper>(actix_web::web::Data::new(RegistryWrapper(registry)));
-        let resp = rt.block_on(metrics_call)?;
+        let resp = rt.block_on(metrics_call);
 
         assert_eq!(resp.status(), 200);
         if let actix_web::body::ResponseBody::Body(body) = resp.body() {

--- a/graph-builder/src/status.rs
+++ b/graph-builder/src/status.rs
@@ -2,21 +2,18 @@
 
 use crate::graph::State;
 use actix_web::HttpResponse;
-use failure::Fallible;
 
 /// Expose liveness status.
 ///
 /// Status:
 ///  * Live (200 code): The upstream scrape loop thread is running
 ///  * Not Live (503 code): everything else.
-pub async fn serve_liveness(app_data: actix_web::web::Data<State>) -> Fallible<HttpResponse> {
-    let resp = if app_data.is_live() {
+pub async fn serve_liveness(app_data: actix_web::web::Data<State>) -> HttpResponse {
+    if app_data.is_live() {
         HttpResponse::Ok().finish()
     } else {
         HttpResponse::ServiceUnavailable().finish()
-    };
-
-    Ok(resp)
+    }
 }
 
 /// Expose readiness status.
@@ -24,12 +21,10 @@ pub async fn serve_liveness(app_data: actix_web::web::Data<State>) -> Fallible<H
 /// Status:
 ///  * Ready (200 code): a JSON graph as the result of a successful scrape is available.
 ///  * Not Ready (503 code): no JSON graph available yet.
-pub async fn serve_readiness(app_data: actix_web::web::Data<State>) -> Fallible<HttpResponse> {
-    let resp = if app_data.is_ready() {
+pub async fn serve_readiness(app_data: actix_web::web::Data<State>) -> HttpResponse {
+    if app_data.is_ready() {
         HttpResponse::Ok().finish()
     } else {
         HttpResponse::ServiceUnavailable().finish()
-    };
-
-    Ok(resp)
+    }
 }

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -11,7 +11,6 @@ actix-web = "^2.0"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
 env_logger = "^0.6.0"
-failure = "^0.1.1"
 futures = "^0.3"
 hyper = "^0.13"
 lazy_static = "^1.2.0"

--- a/policy-engine/src/config/cli.rs
+++ b/policy-engine/src/config/cli.rs
@@ -2,8 +2,8 @@
 
 use super::options;
 use super::AppSettings;
+use commons::prelude_errors::*;
 use commons::MergeOptions;
-use failure::Fallible;
 
 /// CLI configuration flags, top-level.
 #[derive(Debug, StructOpt)]

--- a/policy-engine/src/config/file.rs
+++ b/policy-engine/src/config/file.rs
@@ -3,8 +3,8 @@
 use super::options;
 use super::AppSettings;
 use commons::de::de_loglevel;
+use commons::prelude_errors::*;
 use commons::MergeOptions;
-use failure::{Fallible, ResultExt};
 use std::io::Read;
 use std::{fs, io, path};
 
@@ -53,7 +53,7 @@ impl FileOptions {
 }
 
 impl MergeOptions<Option<FileOptions>> for AppSettings {
-    fn try_merge(&mut self, opts: Option<FileOptions>) -> failure::Fallible<()> {
+    fn try_merge(&mut self, opts: Option<FileOptions>) -> Fallible<()> {
         if let Some(file) = opts {
             assign_if_some!(self.verbosity, file.verbosity);
             self.try_merge(file.policy)?;

--- a/policy-engine/src/config/options.rs
+++ b/policy-engine/src/config/options.rs
@@ -1,8 +1,8 @@
 //! Options shared by CLI and TOML.
 
 use super::AppSettings;
+use commons::prelude_errors::*;
 use commons::{de_path_prefix, parse_params_set, parse_path_prefix, MergeOptions};
-use failure::Fallible;
 use std::collections::HashSet;
 use std::net::IpAddr;
 
@@ -85,7 +85,7 @@ impl MergeOptions<Option<UpCincinnatiOptions>> for AppSettings {
 }
 
 /// Parse a URI from a string.
-pub fn uri_from_str<S>(input: S) -> failure::Fallible<hyper::Uri>
+pub fn uri_from_str<S>(input: S) -> Fallible<hyper::Uri>
 where
     S: AsRef<str>,
 {

--- a/policy-engine/src/config/settings.rs
+++ b/policy-engine/src/config/settings.rs
@@ -3,7 +3,7 @@
 use super::{cli, file};
 use cincinnati::plugins::catalog::{self, PluginSettings};
 use cincinnati::plugins::BoxedPlugin;
-use failure::Fallible;
+use commons::prelude_errors::*;
 use hyper::Uri;
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -7,8 +7,6 @@ extern crate cincinnati;
 #[macro_use]
 extern crate commons;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
@@ -28,7 +26,7 @@ mod openapi;
 use actix_web::{middleware, App, HttpServer};
 use cincinnati::plugins::BoxedPlugin;
 use commons::metrics::{self, RegistryWrapper};
-use failure::Error;
+use commons::prelude_errors::*;
 use prometheus::{labels, opts, Counter, Registry};
 use std::collections::HashSet;
 

--- a/prometheus-query/Cargo.toml
+++ b/prometheus-query/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 commons = { path = "../commons" }
-failure = "^0.1.5"
+anyhow = "^1.0"
 futures = "^0.3"
 reqwest = "^0.9.8"
 serde = { version = "^1.0.84", features = ["derive"] }

--- a/prometheus-query/src/lib.rs
+++ b/prometheus-query/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! See https://github.com/prometheus/prometheus/blob/9de0ab3c8a32f8e09ab68f793dab0c76ec3e93d0/docs/querying/api.md#http-api
 
-#[macro_use]
-extern crate failure;
 extern crate futures;
 extern crate reqwest;
 extern crate serde;

--- a/prometheus-query/src/v1/mod.rs
+++ b/prometheus-query/src/v1/mod.rs
@@ -1,6 +1,6 @@
 //! Asynchronous Prometheus HTTP API Client /v1 implementation
 
-use failure::Fallible;
+use anyhow::{bail, Result as Fallible};
 use reqwest;
 
 pub mod queries;

--- a/prometheus-query/src/v1/queries/instant.rs
+++ b/prometheus-query/src/v1/queries/instant.rs
@@ -1,7 +1,7 @@
 //! Impelement instant queries
 
 use super::*;
-use failure::Fallible;
+use anyhow::Result as Fallible;
 use reqwest;
 use std::time::Duration;
 

--- a/prometheus-query/src/v1/queries/mod.rs
+++ b/prometheus-query/src/v1/queries/mod.rs
@@ -63,7 +63,7 @@ impl VectorResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use failure::Fallible;
+    use anyhow::{bail, Result as Fallible};
 
     #[test]
     fn deserialize_queryresult() -> Fallible<()> {

--- a/quay/Cargo.toml
+++ b/quay/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = "^0.1.5"
+anyhow = "1.0"
 futures = "^0.3"
 reqwest = { version = "^0.10", features = ["json"] }
 serde = "^1.0.84"

--- a/quay/src/lib.rs
+++ b/quay/src/lib.rs
@@ -1,12 +1,9 @@
 //! Asynchronous client for quay.io v1 API.
 
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate serde_derive;
 
-use failure::Fallible;
-use failure::ResultExt;
+use anyhow::{bail, format_err, Context, Result as Fallible};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;

--- a/quay/src/v1/manifest.rs
+++ b/quay/src/v1/manifest.rs
@@ -1,7 +1,7 @@
 //! Manifest API.
 
 use super::Client;
-use failure::Error;
+use anyhow::Error;
 use reqwest::Method;
 
 /// API result with all labels.

--- a/quay/src/v1/mod.rs
+++ b/quay/src/v1/mod.rs
@@ -1,4 +1,4 @@
-use failure::Fallible;
+use anyhow::Result as Fallible;
 use reqwest;
 
 mod manifest;

--- a/quay/src/v1/tag.rs
+++ b/quay/src/v1/tag.rs
@@ -1,8 +1,8 @@
 //! Tag API.
 
 use super::Client;
+use anyhow::Result as Fallible;
 use async_stream::stream;
-use failure::Fallible;
 use futures::Stream;
 use reqwest::Method;
 

--- a/quay/tests/net/private.rs
+++ b/quay/tests/net/private.rs
@@ -1,3 +1,4 @@
+use anyhow::Error;
 use futures::StreamExt;
 use tokio::runtime::Runtime;
 
@@ -24,7 +25,7 @@ fn test_wrong_auth() {
             .stream_tags(repo, true)
             .await
             .map(Result::unwrap_err)
-            .collect::<Vec<failure::Error>>()
+            .collect::<Vec<Error>>()
             .await
     };
     rt.block_on(fetch_tags);


### PR DESCRIPTION
Failure was [deprecated][0] and suggests anyhow+thiserror to replace
itself in dependent projects.

[0]: https://github.com/rust-lang-nursery/failure/pull/347