### PR TITLE
cincinnati/plugins: expose PLUGIN_NAME in trait

### DIFF
--- a/cincinnati/src/plugins/external/web.rs
+++ b/cincinnati/src/plugins/external/web.rs
@@ -37,6 +37,8 @@ mod tests {
 
     #[async_trait]
     impl ExternalPlugin for DummyWebClient {
+        const PLUGIN_NAME: &'static str = "dummy-web-client";
+
         async fn run_external(self: &Self, io: ExternalIO) -> Fallible<ExternalIO> {
             let input: interface::PluginExchange = io.try_into()?;
 

--- a/cincinnati/src/plugins/internal/arch_filter.rs
+++ b/cincinnati/src/plugins/internal/arch_filter.rs
@@ -86,6 +86,8 @@ lazy_static! {
 
 #[async_trait]
 impl InternalPlugin for ArchFilterPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, internal_io: InternalIO) -> Fallible<InternalIO> {
         let arch = infer_arch(
             internal_io.parameters.get("arch").map(|s| s.to_string()),

--- a/cincinnati/src/plugins/internal/channel_filter.rs
+++ b/cincinnati/src/plugins/internal/channel_filter.rs
@@ -53,6 +53,8 @@ lazy_static! {
 
 #[async_trait]
 impl InternalPlugin for ChannelFilterPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, internal_io: InternalIO) -> Fallible<InternalIO> {
         let channel = get_multiple_values!(internal_io.parameters, "channel")
             .map_err(|e| GraphError::MissingParams(vec![e.to_string()]))?

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -142,6 +142,8 @@ impl CincinnatiGraphFetchPlugin {
 
 #[async_trait]
 impl InternalPlugin for CincinnatiGraphFetchPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, io: InternalIO) -> Fallible<InternalIO> {
         self.do_run_internal(io)
             .map_err(move |e| {

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -24,6 +24,8 @@ pub struct EdgeAddRemovePlugin {
 
 #[async_trait]
 impl InternalPlugin for EdgeAddRemovePlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, io: InternalIO) -> Fallible<InternalIO> {
         let mut graph = io.graph;
         self.add_edges(&mut graph)?;

--- a/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
@@ -444,6 +444,8 @@ impl PluginSettings for GithubOpenshiftSecondaryMetadataScraperSettings {
 
 #[async_trait]
 impl InternalPlugin for GithubOpenshiftSecondaryMetadataScraperPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, mut io: InternalIO) -> Fallible<InternalIO> {
         io.parameters.insert(
             GRAPH_DATA_DIR_PARAM_KEY.to_string(),

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -471,6 +471,8 @@ impl OpenshiftSecondaryMetadataParserPlugin {
 
 #[async_trait]
 impl InternalPlugin for OpenshiftSecondaryMetadataParserPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, mut io: InternalIO) -> Fallible<InternalIO> {
         let data_dir = self.get_data_directory(&io);
 

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -133,6 +133,8 @@ impl ReleaseScrapeDockerv2Plugin {
 
 #[async_trait]
 impl InternalPlugin for ReleaseScrapeDockerv2Plugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, io: InternalIO) -> Fallible<InternalIO> {
         let releases = registry::fetch_releases(
             &self.registry,

--- a/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
+++ b/cincinnati/src/plugins/internal/metadata_fetch_quay.rs
@@ -98,6 +98,8 @@ impl QuayMetadataFetchPlugin {
 
 #[async_trait]
 impl InternalPlugin for QuayMetadataFetchPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, io: InternalIO) -> Fallible<InternalIO> {
         let (mut graph, parameters) = (io.graph, io.parameters);
 

--- a/cincinnati/src/plugins/internal/node_remove.rs
+++ b/cincinnati/src/plugins/internal/node_remove.rs
@@ -37,6 +37,8 @@ impl NodeRemovePlugin {
 
 #[async_trait]
 impl InternalPlugin for NodeRemovePlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
     async fn run_internal(self: &Self, io: InternalIO) -> Fallible<InternalIO> {
         let mut graph = io.graph;
         let key_suffix = "release.remove";


### PR DESCRIPTION
This enables use-cases like tracing the plugin execution to access the
plugin's name.

/cc @vrutkovs 