### PR TITLE
plugins/release_scrape_dockerv2: include port in release source

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -8,7 +8,7 @@ use self::cincinnati::plugins::prelude_plugin_impl::*;
 use std::convert::TryInto;
 
 /// Default registry to scrape.
-pub static DEFAULT_SCRAPE_REGISTRY: &str = "https://quay.io";
+pub static DEFAULT_SCRAPE_REGISTRY: &str = "quay.io";
 
 /// Default repository to scrape.
 pub static DEFAULT_SCRAPE_REPOSITORY: &str = "openshift-release-dev/ocp-release";
@@ -182,7 +182,7 @@ mod network_tests {
     fn scrape_public_multiarch_manual_succeeds() -> Fallible<()> {
         let (mut runtime, _) = common_init();
 
-        let registry = "https://quay.io";
+        let registry = DEFAULT_SCRAPE_REGISTRY;
         let repo = "redhat/openshift-cincinnati-test-public-multiarch-manual";
 
         let plugin = Box::new(ReleaseScrapeDockerv2Plugin::try_new(
@@ -302,7 +302,7 @@ mod network_tests {
             ];
 
             TestGraphBuilder::new()
-                .with_image(&format!("quay.io/{}", repo))
+                .with_image(&format!("{}/{}", DEFAULT_SCRAPE_REGISTRY, repo))
                 .with_metadata(input_metadata)
                 .with_edges(input_edges)
                 .with_version_template("0.0.{{i}}")

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/network_tests.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/network_tests.rs
@@ -250,7 +250,7 @@ fn fetch_release_public_with_first_empty_tag_must_succeed() {
 }
 
 #[test]
-fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
+fn fetch_release_public_must_succeed_with_various_registry_urls() {
     let (mut runtime, cache) = common_init();
 
     let test = |registry: Registry| {
@@ -296,9 +296,9 @@ fn fetch_release_public_must_succeed_with_schemes_missing_http_https() {
 
     [
         "quay.io",
+        "quay.io:443",
         // TODO: enable this when the dkregistry-rs migration to reqwest is complete
         //"http://quay.io",
-        "https://quay.io",
     ]
     .iter()
     .map(|url| registry::Registry::try_from_str(url).unwrap())
@@ -343,7 +343,7 @@ fn fetch_release_with_cyclic_metadata_fails() -> Fallible<()> {
 fn fetch_releases_public_multiarch_manual_succeeds() -> Fallible<()> {
     let (mut runtime, cache) = common_init();
 
-    let registry = registry::Registry::try_from_str("https://quay.io")?;
+    let registry = registry::Registry::try_from_str("quay.io")?;
     let repo = "redhat/openshift-cincinnati-test-public-multiarch-manual";
     let (username, password) = (None, None);
     let releases = runtime


### PR DESCRIPTION
This fixes ReleaseScrapeDockerv2Plugin implementation to include the
port in the source url for each release.
In order to achieve this a few actions were taken:

* Pass the a `Registry` instance all the way down to `lookup_or_fetch`
  to have the methods available instead of just the Strings.

* Extend the tests to check for the port exposure

* Cache: store `Metadata` instead of `Release`, since the former does
  not store the source. For situations where the cache is used throughout
  calls given different registries (as is the case in some tests) it seems
  more elegant to assemble a new `Release` with the correct source,
  instead of overwriting the source of a previously cached release.

In addition this prepares for removing the scheme handling from the
registry URL, because this is not valid according to Docker and podman.
