### PR TITLE
Follow HTTP redirects

### DIFF
--- a/hack/available-updates.sh
+++ b/hack/available-updates.sh
@@ -12,7 +12,7 @@ then
 fi
 
 URI="${UPSTREAM}?channel=${CHANNEL}&arch=${ARCH}"
-DATA="$(curl -sH Accept:application/json "${URI}")"
+DATA="$(curl -sHL Accept:application/json "${URI}")"
 if test -z "${DATA}"
 then
 	 echo "Failed to fetch data from ${URI}"


### PR DESCRIPTION
Without it fails like:
```bash
UPSTREAM=https://openshift-release.svc.ci.openshift.org/graph CHANNEL=stable-4.4 bash -x available-updates.sh 4.4.9
+ UPSTREAM=https://openshift-release.svc.ci.openshift.org/graph
+ CHANNEL=stable-4.4
+ ARCH=amd64
+ VERSION=4.4.9
+ test -z 4.4.9 -o 1 -ne 1
+ URI='https://openshift-release.svc.ci.openshift.org/graph?channel=stable-4.4&arch=amd64'
++ curl -sH Accept:application/json 'https://openshift-release.svc.ci.openshift.org/graph?channel=stable-4.4&arch=amd64'
+ DATA='<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.17.10</center>
</body>
'/html>
+ test -z '<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.17.10</center>
</body>
'/html>
+ echo '<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.17.10</center>
</body>
'/html>
+ jq -r '
  (.nodes | with_entries(.key |= tostring)) as $nodes_by_index |
  [
    .edges[] |
    select($nodes_by_index[(.[0] | tostring)].version == "4.4.9")[1] |
    tostring |
    $nodes_by_index[.]
  ] | sort_by(.version)[] |
  .version + "\t" + .payload + "\t" + (.metadata.url // "-")
'
parse error: Invalid numeric literal at line 1, column 7
```