### PR TITLE
cargo_test: remove '--verify' kcov arg

### DIFF
--- a/dist/cargo_test.sh
+++ b/dist/cargo_test.sh
@@ -52,7 +52,6 @@ function run_tests() {
           find \"${CARGO_TARGET_DIR}\"/debug/ -maxdepth 1 -type f -executable -print0 | xargs -n1 -0 \
           kcov \
               --exclude-pattern=$HOME/.cargo \
-              --verify \
               ${CARGO_TARGET_DIR}/cov
         fi
       "


### PR DESCRIPTION
New kcov versions don't seem to support it anymore, breaking 
`cargo-test`