### PR TITLE
Dockerfile.e2e: remove duplicate yq install

### DIFF
--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -2,7 +2,6 @@ FROM quay.io/app-sre/cincinnati:builder AS rust_builder
 # build e2e tests
 COPY . .
 
-RUN yum -y install jq
 RUN hack/build_e2e.sh
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder


### PR DESCRIPTION

e2e image uses Dockerfile.build as a base, which already has jq installed.
Previously duplicate jq install was added to work around base image
caching - and now its no longer necessary.