### PR TITLE
Change visibility of plugin classes

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -204,6 +204,9 @@ where
     Ok(t_vec)
 }
 
+pub static BLOCKED_EDGES_DIR: &str = "blocked-edges";
+pub static CHANNELS_DIR: &str = "channels";
+
 impl OpenshiftSecondaryMetadataParserPlugin {
     pub(crate) const PLUGIN_NAME: &'static str = "openshift-secondary-metadata-parse";
 
@@ -272,7 +275,7 @@ impl OpenshiftSecondaryMetadataParserPlugin {
         graph: &mut cincinnati::Graph,
         data_dir: &PathBuf,
     ) -> Fallible<()> {
-        let blocked_edges_dir = data_dir.join("blocked-edges");
+        let blocked_edges_dir = data_dir.join(BLOCKED_EDGES_DIR);
         let blocked_edges: Vec<graph_data_model::BlockedEdge> =
             deserialize_directory_files(&blocked_edges_dir, regex::Regex::new("ya+ml")?)
                 .await
@@ -377,7 +380,7 @@ impl OpenshiftSecondaryMetadataParserPlugin {
         graph: &mut cincinnati::Graph,
         data_dir: &PathBuf,
     ) -> Fallible<()> {
-        let channels_dir = data_dir.join("channels");
+        let channels_dir = data_dir.join(CHANNELS_DIR);
         let channels: Vec<graph_data_model::Channel> =
             deserialize_directory_files(&channels_dir, regex::Regex::new("ya+ml")?)
                 .await

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -6,7 +6,7 @@ use self::cincinnati::plugins::prelude_plugin_impl::*;
 
 pub static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
 
-mod graph_data_model {
+pub mod graph_data_model {
     //! This module contains the data types corresponding to the graph data files.
 
     use serde::de::Visitor;

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -148,7 +148,7 @@ impl PluginSettings for OpenshiftSecondaryMetadataParserSettings {
     }
 }
 
-async fn deserialize_directory_files<T>(
+pub async fn deserialize_directory_files<T>(
     path: &PathBuf,
     extension_re: regex::Regex,
 ) -> Fallible<Vec<T>>

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -24,30 +24,30 @@ pub static DEFAULT_FETCH_CONCURRENCY: usize = 16;
 #[serde(default)]
 pub struct ReleaseScrapeDockerv2Settings {
     #[default(DEFAULT_SCRAPE_REGISTRY.to_string())]
-    registry: String,
+    pub registry: String,
 
     #[default(DEFAULT_SCRAPE_REPOSITORY.to_string())]
-    repository: String,
+    pub repository: String,
 
     /// Metadata key where to record the manifest-reference.
     #[default(DEFAULT_MANIFESTREF_KEY.to_string())]
-    manifestref_key: String,
+    pub manifestref_key: String,
 
     #[default(DEFAULT_FETCH_CONCURRENCY)]
-    fetch_concurrency: usize,
+    pub fetch_concurrency: usize,
 
     /// Username for authenticating with the registry
     #[default(Option::None)]
-    username: Option<String>,
+    pub username: Option<String>,
 
     /// Password for authenticating with the registry
     #[default(Option::None)]
-    password: Option<String>,
+    pub password: Option<String>,
 
     /// File containing the credentials for authenticating with the registry.
     /// Takes precedence over username and password
     #[default(Option::None)]
-    credentials_path: Option<PathBuf>,
+    pub credentials_path: Option<PathBuf>,
 }
 
 impl PluginSettings for ReleaseScrapeDockerv2Settings {


### PR DESCRIPTION
This exposes some modules, functions and class variables so that cincinnati-graph-data CI could re-use Cincinnati models.

* `graph_data_model` is made public so that CI tool could import `BlockedEdge` and `Channel` classes
* `deserialize_directory_files` function is public so that CI tool could convert YAMLs into `BlockedEdge`/`Channel` instances
* `BLOCKED_EDGES_DIR`/`CHANNELS_DIR` const made public to avoid hardcoding those in CI tool
* `ReleaseScrapeDockerv2Settings` made public so that CI tool could reuse registry configuration and verify all blocked-edge/channel release are uploaded to Quay