### PR TITLE
Add rh-manifest-generator and dist/vendor script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-lock"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1088,11 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "flate2"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1322,24 @@ dependencies = [
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "twoway 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gumdrop"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2025,6 +2061,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2614,18 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rh-manifest-generator"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3104,7 @@ dependencies = [
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3704,6 +3762,7 @@ dependencies = [
 "checksum bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
 "checksum bytestring 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fc267467f58ef6cc8874064c62a0423eb0d099362c8a23edd1c6d044f46eead4"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum cargo-lock 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
@@ -3746,6 +3805,7 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+"checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -3769,6 +3829,8 @@ dependencies = [
 "checksum generic-array 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
+"checksum gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
+"checksum gumdrop_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -3843,6 +3905,7 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+"checksum petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 "checksum pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
 "checksum pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
 "checksum pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
 	"prometheus-query",
 	"quay",
 	"e2e",
+	"rh-manifest-generator",
 ]

--- a/dist/vendor.sh
+++ b/dist/vendor.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+set -ueo pipefail
+
+CARGO_CONFIG=".cargo/config.toml"
+FILES_TO_COMMIT=(
+  "${CARGO_CONFIG}"
+  "vendor"
+  "rh-manifest.txt"
+)
+
+# Don't overwrite any existing config
+[ ! -f "${CARGO_CONFIG}" ] || {
+  echo WARNING ${CARGO_CONFIG} exists, moving away..
+  mv --backup=existing ${CARGO_CONFIG}{,.prev}
+}
+
+set -x
+
+# generate the rh-manifest.txt
+cargo run --bin rh-manifest-generator
+
+mkdir -p "$(dirname ${CARGO_CONFIG})"
+cargo vendor > "${CARGO_CONFIG}"
+
+# some vendored files aren't world readable which has lead to issues in container builds when trying out the workflow
+find ./vendor -type f -exec chmod a+r {} \;
+
+git add --force "${FILES_TO_COMMIT[@]}"
+git diff --quiet --staged -- "${FILES_TO_COMMIT[@]}" || {
+  echo Files changed, committing...
+  git commit -m "Update vendored dependencies and rh-manifest.txt" -- "${FILES_TO_COMMIT[@]}"
+}

--- a/rh-manifest-generator/Cargo.toml
+++ b/rh-manifest-generator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rh-manifest-generator"
+version = "0.1.0"
+authors = ["Stefan Junker <mail@stefanjunker.de>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cargo-lock = "4.0"
+lazy_static = "1.4"
+reqwest = { version = "0.10", features = ["blocking"] }
+serde = "1.0"
+serde_json = "1.0"
+anyhow = "1.0"

--- a/rh-manifest-generator/src/main.rs
+++ b/rh-manifest-generator/src/main.rs
@@ -1,0 +1,75 @@
+//! This program reads a given Cargo.lock file and emits a manifest as desribed at
+//! https://mojo.redhat.com/docs/DOC-1195158#jive_content_id_NonGolang_dependencies
+
+use anyhow::{bail, Result};
+use cargo_lock::{Lockfile, Package};
+use std::io::Write;
+use std::sync::Arc;
+
+fn main() -> Result<()> {
+    let lockfile = Lockfile::load("Cargo.lock")?;
+    let mut rh_manifest = std::fs::File::create("rh-manifest.txt")?;
+
+    for package in lockfile.packages {
+        let url = match &package.source {
+            Some(_) => get_url(&package)?,
+            None => {
+                println!("{} doesn't have a source, skipping...", package.name);
+                continue;
+            }
+        };
+
+        let line = format!("{} {} {}\n", package.name, package.version, url);
+        rh_manifest.write_all(line.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+const CRATES_IO_INDEX_CONFIG_URL: &str =
+    "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/config.json";
+
+#[allow(dead_code)]
+#[derive(serde::Deserialize)]
+struct RegistryConfig {
+    dl: String,
+    api: String,
+}
+
+fn get_dl_url() -> Result<String> {
+    println!("Getting config from '{}'", CRATES_IO_INDEX_CONFIG_URL);
+    let config_json = reqwest::blocking::get(CRATES_IO_INDEX_CONFIG_URL)?;
+    let config: RegistryConfig = serde_json::from_str(&config_json.text()?)?;
+    Ok(config.dl)
+}
+
+lazy_static::lazy_static! {
+    static ref DEFAULT_REGISTRY_DL_URL: Arc<Result<String>> = {
+        Arc::new(get_dl_url())
+    };
+}
+
+fn get_url(package: &Package) -> Result<String> {
+    let source = match &package.source {
+        Some(source) => source,
+        None => bail!("{} doesn't have a source", package.name),
+    };
+
+    let url = if source.is_default_registry() {
+        format!(
+            "{}/{}/{}/download",
+            match &*DEFAULT_REGISTRY_DL_URL.clone() {
+                Ok(dl_url) => dl_url,
+                Err(e) => bail!("{}", e),
+            },
+            &package.name,
+            &package.version
+        )
+    } else if source.is_git() {
+        source.to_string()
+    } else {
+        bail!("unhandled source for package: {:?}", &package);
+    };
+
+    Ok(url)
+}


### PR DESCRIPTION
These tools can be used to prepare the source code for Red Hat's internal build system which works offline and expects a security manifest.

/cc @LalatenduMohanty @vrutkovs 