### PR TITLE
hack/e2e: copy kubeconfig to /tmp so that it can be mutated

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -26,6 +26,10 @@ echo "IMAGE_TAG=${IMAGE_TAG}"
 PULL_SECRET=${PULL_SECRET:-/tmp/cluster/pull-secret}
 
 set -euo pipefail
+# Copy KUBECONFIG so that it can be mutated
+cp -rvf $KUBECONFIG /tmp/kubeconfig
+export KUBECONFIG=/tmp/kubeconfig
+
 # Create a new project
 oc new-project cincinnati-e2e
 oc project cincinnati-e2e


### PR DESCRIPTION
Switching projects mutates kubeconfig, which can be mounted as read-only. e2e script should copy it to writable location.

See https://github.com/openshift/release/pull/11904, which fails with
```
error: open /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig: read-only file system
error: failed to execute wrapped command: exit status 1 
```