### PR TITLE
WIP: hack/e2e: Debug kubeconfig loading error

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -28,10 +28,13 @@ PULL_SECRET=${PULL_SECRET:-/tmp/cluster/pull-secret}
 set -euo pipefail
 # Copy KUBECONFIG so that it can be mutated
 cp -rvf $KUBECONFIG /tmp/kubeconfig
+ls -l "${KUBECONFIG}" /tmp
 export KUBECONFIG=/tmp/kubeconfig
+grep '^[^ ]' "${KUBECONFIG}"
+ls -l "${KUBECONFIG}"
 
 # Create a new project
-oc new-project cincinnati-e2e
+oc --v=8 new-project cincinnati-e2e
 oc project cincinnati-e2e
 
 # Create a dummy secret as a workaround to not having real secrets in e2e


### PR DESCRIPTION
Help [debug][1]:

```
'/var/run/secrets/ci.openshift.io/multi-stage/kubeconfig' -> '/tmp/kubeconfig'
W0928 07:25:20.032259      16 loader.go:223] Config not found: /tmp/kubeconfig
```

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati/309/pull-ci-openshift-cincinnati-master-e2e/1310469970529882112