### PR TITLE
e2e: deref copied kubeconfig

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -27,7 +27,9 @@ PULL_SECRET=${PULL_SECRET:-/tmp/cluster/pull-secret}
 
 set -euo pipefail
 # Copy KUBECONFIG so that it can be mutated
-cp -rvf $KUBECONFIG /tmp/kubeconfig
+cp -Lrvf $KUBECONFIG /tmp/kubeconfig
+ls -la /tmp/kubeconfig
+cat /tmp/kubeconfig
 export KUBECONFIG=/tmp/kubeconfig
 
 # Create a new project

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -23,13 +23,11 @@ echo "IMAGE=${IMAGE}"
 echo "IMAGE_TAG=${IMAGE_TAG}"
 
 # Use defined PULL_SECRET or fall back to CI location
-PULL_SECRET=${PULL_SECRET:-/tmp/cluster/pull-secret}
+PULL_SECRET=${PULL_SECRET:-/var/run/secrets/ci.openshift.io/cluster-profile/pull-secret}
 
 set -euo pipefail
 # Copy KUBECONFIG so that it can be mutated
 cp -Lrvf $KUBECONFIG /tmp/kubeconfig
-ls -la /tmp/kubeconfig
-cat /tmp/kubeconfig
 export KUBECONFIG=/tmp/kubeconfig
 
 # Create a new project


### PR DESCRIPTION
In multistage test kubeconfig is mounted from a secret, so its a reference to `../data/kubeconfig`.
Copy kubeconfig with `-L` so that `/tmp/kubeconfig` would be a plain file.

This also updates the location for pull-secret

--

Closes #310 