### PR TITLE
Add scripts to manage test images and make e2e repository configurable

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -5,7 +5,7 @@ RUN yum -y install epel-release
 
 # build: system utilities and libraries
 RUN yum -y groupinstall 'Development Tools'
-RUN yum -y install openssl-devel protobuf-compiler jq
+RUN yum -y install openssl-devel protobuf-compiler jq skopeo buildah
 
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -19,6 +19,9 @@ RUN mkdir -p ${HOME}/bin && \
     curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
 ENV PATH="${PATH}:${HOME}/bin"
 
+# Install container tools
+RUN yum -y install skopeo buildah
+
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test
 COPY --from=rust_builder /opt/cincinnati/bin/slo /usr/bin/cincinnati-e2e-slo

--- a/dist/prepare_ci_images.sh
+++ b/dist/prepare_ci_images.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+pushd ./graph-builder/tests/images/
+
+export REPO_BASE="registry.svc.ci.openshift.org/cincinnati-ci/cincinnati"
+AUTHFILE="${CINCINNATI_CI_DOCKERJSON_PATH}" ./build-n-push-buildah.sh ./*private*
+
+export REPO_BASE="registry.svc.ci.openshift.org/cincinnati-ci-public/cincinnati"
+AUTHFILE="${CINCINNATI_CI_PUBLIC_DOCKERJSON_PATH}" ./build-n-push-buildah.sh ./*public*

--- a/dist/prepare_e2e_images.sh
+++ b/dist/prepare_e2e_images.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+skopeo sync --src docker --dest docker --src-no-creds --dest-authfile "${CINCINNATI_CI_PUBLIC_DOCKERJSON_PATH}" \
+  quay.io/openshift-release-dev/ocp-release \
+  registry.svc.ci.openshift.org/cincinnati-ci-public

--- a/graph-builder/tests/images/build-n-push-buildah.sh
+++ b/graph-builder/tests/images/build-n-push-buildah.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-set -xe
+set -e
 
 unused=${1:?"Please provide at least one target directory in the arguments"}
 
+set -x
+
 REPO_BASE="${REPO_BASE:-quay.io/redhat/openshift-cincinnati}"
+AUTHFILE="${AUTHFILE:-${HOME}/.docker.config.json}"
 
 for target in "${@}"; do
   arch_file="${target}/.arch"
@@ -22,5 +25,5 @@ for target in "${@}"; do
     buildah rm "${build_container}"
   fi
 
-  buildah push "${full_tag}"
+  buildah push --authfile "${AUTHFILE}" "${full_tag}"
 done

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -74,7 +74,8 @@ oc new-app -f dist/openshift/cincinnati.yaml \
   -p GB_PLUGIN_SETTINGS="$(cat <<-EOF
       [[plugin_settings]]
       name = "release-scrape-dockerv2"
-      repository = "openshift-release-dev/ocp-release"
+      registry = "${E2E_SCRAPE_REGISTRY:-quay.io}"
+      repository = "${E2E_SCRAPE_REPOSITORY:-openshift-release-dev/ocp-release}"
       fetch_concurrency = 128
 
       [[plugin_settings]]


### PR DESCRIPTION
This PR splits some changes from #308 in order support the configuration of CI independently from switching all the code to use the CI registry.