### PR TITLE
cincinnati/plugins: add DkrV2OpenshiftSecondaryMetadataScraperPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ dependencies = [
  "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3148,6 +3149,16 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3994,6 +4005,7 @@ dependencies = [
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 "checksum tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
+"checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 "checksum tokio-reactor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 "checksum tokio-sync 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 "checksum tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -38,12 +38,12 @@ prettydiff = { version = "0.3.1", optional = true }
 opentelemetry = "0.4.0"
 strum = "^0.19.2"
 strum_macros = "^0.19.2"
+walkdir = "2.3.1"
 
 [dev-dependencies]
 mockito = "^0.20.0"
 serde_json = "1.0.22"
 twoway = "^0.2"
-walkdir = "2.3.1"
 pretty_assertions = "0.6.1"
 test-case = "1.0.0"
 prettydiff = "0.3.1"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0.70"
 serde_derive = "1.0.70"
 serde_json = "^1.0.22"
 smart-default = "^0.5.2"
-tokio = { version = "0.2.11", features = [ "time", "fs", "stream" ] }
+tokio = { version = "0.2.11", features = [ "time", "fs", "stream", "rt-threaded", "blocking", "macros" ] }
 toml = "^0.4.10"
 url = "^2.1.1"
 semver = { version = "^0.9.0", features = [ "serde" ] }

--- a/cincinnati/src/plugins/catalog.rs
+++ b/cincinnati/src/plugins/catalog.rs
@@ -10,6 +10,9 @@ use self::cincinnati::plugins::BoxedPlugin;
 use super::internal::arch_filter::ArchFilterPlugin;
 use super::internal::channel_filter::ChannelFilterPlugin;
 use super::internal::cincinnati_graph_fetch::CincinnatiGraphFetchPlugin;
+use super::internal::dkrv2_openshift_secondary_metadata_scraper::{
+    DkrV2OpenshiftSecondaryMetadataScraperPlugin, DkrV2OpenshiftSecondaryMetadataScraperSettings,
+};
 use super::internal::edge_add_remove::EdgeAddRemovePlugin;
 use super::internal::github_openshift_secondary_metadata_scraper::{
     GithubOpenshiftSecondaryMetadataScraperPlugin, GithubOpenshiftSecondaryMetadataScraperSettings,
@@ -60,6 +63,9 @@ pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<dyn PluginSettings>>
         }
         OpenshiftSecondaryMetadataParserPlugin::PLUGIN_NAME => {
             OpenshiftSecondaryMetadataParserSettings::deserialize_config(cfg)
+        }
+        DkrV2OpenshiftSecondaryMetadataScraperPlugin::PLUGIN_NAME => {
+            DkrV2OpenshiftSecondaryMetadataScraperSettings::deserialize_config(cfg)
         }
         x => bail!("unknown plugin '{}'", x),
     }

--- a/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/mod.rs
@@ -1,0 +1,11 @@
+//! This plugin downloads repository content and extracts it to a given output directory.
+//!
+//! It is meant to be included in the plugin chain, preceding other plugins who
+//! rely on the data being in the output directory.
+//! The plugin will only download a tarball if detects a change of revision or on first run.
+
+pub mod plugin;
+
+pub use plugin::{
+    DkrV2OpenshiftSecondaryMetadataScraperPlugin, DkrV2OpenshiftSecondaryMetadataScraperSettings,
+};

--- a/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/plugin.rs
@@ -1,0 +1,449 @@
+use crate as cincinnati;
+use crate::plugins::internal::release_scrape_dockerv2::registry;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+use self::cincinnati::plugins::prelude::*;
+use self::cincinnati::plugins::prelude_plugin_impl::*;
+
+use tokio::sync::Mutex as FuturesMutex;
+
+pub static DEFAULT_OUTPUT_WHITELIST: &[&str] = &[
+    "channels/.+\\.ya+ml",
+    "blocked-edges/.+\\.ya+ml",
+    "raw/metadata.json",
+    "version",
+];
+
+pub static DEFAULT_METADATA_IMAGE_REGISTRY: &str = "";
+pub static DEFAULT_METADATA_IMAGE_REPOSITORY: &str = "";
+pub static DEFAULT_METADATA_IMAGE_TAG: &str = "latest";
+
+// Defines the key for placing the data directory path in the IO parameters
+pub static GRAPH_DATA_DIR_PARAM_KEY: &str = "io.openshift.upgrades.secondary_metadata.directory";
+
+/// Plugin settings.
+#[derive(Debug, SmartDefault, Clone, Deserialize)]
+#[serde(default)]
+pub struct DkrV2OpenshiftSecondaryMetadataScraperSettings {
+    /// Directory where the image will be unpacked. Will be created if it doesn't exist.
+    output_directory: PathBuf,
+
+    /// Vector of regular expressions used as a positive output filter.
+    /// An empty vector is regarded as a configuration error.
+    #[default(DEFAULT_OUTPUT_WHITELIST.iter().map(|s| (*s).to_string()).collect())]
+    output_allowlist: Vec<String>,
+
+    /// The image registry.
+    #[default(DEFAULT_METADATA_IMAGE_REGISTRY.to_string())]
+    registry: String,
+
+    /// The image repository.
+    #[default(DEFAULT_METADATA_IMAGE_REPOSITORY.to_string())]
+    repository: String,
+
+    /// The image tag.
+    #[default(DEFAULT_METADATA_IMAGE_TAG.to_string())]
+    tag: String,
+
+    /// Username for authenticating with the registry
+    #[default(Option::None)]
+    username: Option<String>,
+
+    /// Password for authenticating with the registry
+    #[default(Option::None)]
+    password: Option<String>,
+
+    /// File containing the credentials for authenticating with the registry.
+    /// Takes precedence over username and password
+    #[default(Option::None)]
+    credentials_path: Option<PathBuf>,
+}
+
+impl DkrV2OpenshiftSecondaryMetadataScraperSettings {
+    /// Validate plugin configuration and fill in defaults.
+    pub fn deserialize_config(cfg: toml::Value) -> Fallible<Box<dyn PluginSettings>> {
+        let mut settings: Self = cfg
+            .clone()
+            .try_into()
+            .context(format!("Deserializing {:#?}", &cfg))?;
+
+        ensure!(
+            !settings
+                .output_directory
+                .to_str()
+                .unwrap_or_default()
+                .is_empty(),
+            "empty output_directory"
+        );
+
+        ensure!(
+            !settings.output_allowlist.is_empty(),
+            "empty output_allowlist"
+        );
+
+        ensure!(!settings.registry.is_empty(), "empty registry");
+        ensure!(!settings.repository.is_empty(), "empty repository");
+        ensure!(!settings.tag.is_empty(), "empty tag");
+
+        if let Some(credentials_path) = &settings.credentials_path {
+            if credentials_path == &PathBuf::from("") {
+                warn!("Settings contain an empty credentials path, setting to None");
+                settings.credentials_path = None;
+            }
+        }
+
+        Ok(Box::new(settings))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct State {
+    cached_layers: Option<Vec<String>>,
+    cached_data_dir: Option<TempDir>,
+}
+
+/// This plugin implements downloading the secondary metadata container image
+/// from a given registry/repository location that is compatible with the Docker
+/// V2 protocol.
+#[derive(Debug)]
+pub struct DkrV2OpenshiftSecondaryMetadataScraperPlugin {
+    settings: DkrV2OpenshiftSecondaryMetadataScraperSettings,
+    output_allowlist: Vec<regex::Regex>,
+    data_dir: TempDir,
+    state: FuturesMutex<State>,
+
+    registry: registry::Registry,
+}
+
+impl DkrV2OpenshiftSecondaryMetadataScraperPlugin {
+    pub(crate) const PLUGIN_NAME: &'static str = "dkrv2-secondary-metadata-scrape";
+
+    /// Instantiate a new instance of `Self`.
+    pub fn try_new(mut settings: DkrV2OpenshiftSecondaryMetadataScraperSettings) -> Fallible<Self> {
+        let output_allowlist: Vec<regex::Regex> = settings
+            .output_allowlist
+            .iter()
+            .try_fold(
+                Vec::with_capacity(settings.output_allowlist.len()),
+                |mut acc, cur| -> Fallible<_> {
+                    let re = regex::Regex::new(cur)?;
+                    acc.push(re);
+                    Ok(acc)
+                },
+            )
+            .context("Parsing output allowlist strings as regex")?;
+
+        // Create the output directory if it doesn't exist
+        std::fs::create_dir_all(&settings.output_directory).context(format!(
+            "Creating directory {:?}",
+            &settings.output_directory
+        ))?;
+
+        let data_dir = tempfile::tempdir_in(&settings.output_directory)?;
+
+        let registry = registry::Registry::try_from_str(&settings.registry)
+            .context(format!("Parsing {} as Registry", &settings.registry))?;
+
+        if let Some(credentials_path) = &settings.credentials_path {
+            let (username, password) =
+                registry::read_credentials(Some(&credentials_path), &registry.host_port_string())
+                    .context(format!(
+                    "Reading registry credentials from {:?}",
+                    credentials_path
+                ))?;
+
+            settings.username = username;
+            settings.password = password;
+        }
+
+        Ok(Self {
+            settings,
+            output_allowlist,
+            data_dir,
+
+            registry,
+            state: FuturesMutex::new(State::default()),
+        })
+    }
+}
+
+impl PluginSettings for DkrV2OpenshiftSecondaryMetadataScraperSettings {
+    fn build_plugin(&self, _: Option<&prometheus::Registry>) -> Fallible<BoxedPlugin> {
+        let plugin = DkrV2OpenshiftSecondaryMetadataScraperPlugin::try_new(self.clone())?;
+        Ok(new_plugin!(InternalPluginWrapper(plugin)))
+    }
+}
+
+#[async_trait]
+impl InternalPlugin for DkrV2OpenshiftSecondaryMetadataScraperPlugin {
+    const PLUGIN_NAME: &'static str = Self::PLUGIN_NAME;
+
+    async fn run_internal(self: &Self, mut io: InternalIO) -> Fallible<InternalIO> {
+        let registry_client = registry::new_registry_client(
+            &self.registry,
+            &self.settings.repository,
+            self.settings.username.as_deref(),
+            self.settings.password.as_deref(),
+        )
+        .await?;
+
+        let (manifest, reference) = registry_client
+            .get_manifest_and_ref(&self.settings.repository, &self.settings.tag)
+            .await?;
+        trace!("manifest: {:?}, reference: {:?}", manifest, reference);
+
+        // TODO: download signature and verify the manifest. yield an error if either step fails.
+
+        let layers = manifest.layers_digests(None)?;
+        trace!("layers: {:?}", &layers);
+
+        if self.are_layers_cached(&layers, &mut io).await? {
+            return Ok(io);
+        }
+
+        let layers_blobs = {
+            use futures::TryStreamExt;
+            layers
+                .iter()
+                .map(|layer| registry_client.get_blob(&self.settings.repository, &layer))
+                .collect::<futures::stream::FuturesOrdered<_>>()
+                .try_collect::<Vec<_>>()
+                .await?
+        };
+
+        // wrap the blocking filesystem operations so that they don't block the runtime
+        let data_dir = tokio::task::block_in_place(|| async {
+            let data_dir = self.create_data_dir(&mut io)?;
+            self.unpack_layers(layers_blobs.as_slice(), &data_dir)?;
+            self.remove_disallowed_files(&data_dir)?;
+
+            Result::<_, Error>::Ok(data_dir)
+        })
+        .await?;
+
+        self.update_cache_state(layers, data_dir).await;
+
+        Ok(io)
+    }
+}
+
+impl DkrV2OpenshiftSecondaryMetadataScraperPlugin {
+    async fn are_layers_cached(&self, layers: &[String], io: &mut InternalIO) -> Fallible<bool> {
+        let state = self.state.lock().await;
+        match (&state.cached_layers, &state.cached_data_dir) {
+            (Some(cached_layers), Some(cached_data_dir)) if cached_layers.as_slice() == layers => {
+                trace!("Using cached data directory for tag {}", self.settings.tag);
+                io.parameters.insert(
+                    GRAPH_DATA_DIR_PARAM_KEY.to_string(),
+                    cached_data_dir
+                        .path()
+                        .to_str()
+                        .ok_or_else(|| format_err!("data_dir cannot be converted to str"))?
+                        .to_string(),
+                );
+                Ok(true)
+            }
+
+            _ => Ok(false),
+        }
+    }
+
+    fn create_data_dir(&self, io: &mut InternalIO) -> Fallible<TempDir> {
+        let data_dir = tempfile::tempdir_in(self.data_dir.path())?;
+
+        io.parameters.insert(
+            GRAPH_DATA_DIR_PARAM_KEY.to_string(),
+            data_dir
+                .path()
+                .to_str()
+                .ok_or_else(|| format_err!("data_dir cannot be converted to str"))?
+                .to_string(),
+        );
+
+        trace!(
+            "Using data directory {:?} for tag {}",
+            data_dir,
+            self.settings.tag
+        );
+
+        Ok(data_dir)
+    }
+
+    fn unpack_layers<P>(&self, layers_blobs: &[Vec<u8>], data_dir: P) -> Fallible<()>
+    where
+        P: AsRef<Path>,
+        P: std::fmt::Debug,
+    {
+        dkregistry::render::unpack(&layers_blobs, data_dir.as_ref())?;
+        trace!(
+            "Unpacked {}/{} with {} layers to {:?}",
+            self.settings.registry,
+            self.settings.repository,
+            layers_blobs.len(),
+            data_dir,
+        );
+
+        Ok(())
+    }
+
+    fn remove_disallowed_files<P>(&self, data_dir: P) -> Fallible<()>
+    where
+        P: AsRef<Path>,
+        P: Copy,
+    {
+        walkdir::WalkDir::new(data_dir)
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
+            // start removing files from the leave and walk back to the root
+            .rev()
+            .try_for_each(|entry_result| -> Fallible<()> {
+                let entry = entry_result?;
+                let path = entry.path();
+                let path_stripped = path.strip_prefix(&data_dir)?;
+                if let Some(path_stripped_str) = path_stripped.to_str() {
+                    if !path_stripped_str.is_empty()
+                        && !self
+                            .output_allowlist
+                            .iter()
+                            .any(|re| re.is_match(&path_stripped_str))
+                    {
+                        let ty = entry.file_type();
+                        if ty.is_file() || ty.is_symlink() {
+                            trace!("removing file at '{}'", &path_stripped_str);
+                            std::fs::remove_file(path)?;
+                        } else if ty.is_dir() {
+                            let readdir = std::fs::read_dir(path)?;
+                            if readdir.count() == 0 {
+                                trace!("removing empty directory at '{}'", &path_stripped_str);
+                                std::fs::remove_dir(path)?;
+                            }
+                        }
+                    }
+                }
+
+                Ok(())
+            })
+    }
+
+    async fn update_cache_state(&self, layers: Vec<String>, data_dir: TempDir) {
+        let mut state = self.state.lock().await;
+        state.cached_layers = Some(layers);
+        state.cached_data_dir = Some(data_dir);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "test-net")]
+mod network_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[tokio::test(threaded_scheduler)]
+    async fn openshift_secondary_metadata_extraction() -> Fallible<()> {
+        let tmpdir = tempfile::tempdir()?;
+
+        let settings = DkrV2OpenshiftSecondaryMetadataScraperSettings::deserialize_config(
+            toml::Value::from_str(&format!(
+                r#"
+                    registry = "registry.svc.ci.openshift.org"
+                    repository = "cincinnati-ci-public/cincinnati-graph-data"
+                    tag = "6420f7fbf3724e1e5e329ae8d1e2985973f60c14"
+                    output_allowlist = [ {} ]
+                    output_directory = {:?}
+                "#,
+                DEFAULT_OUTPUT_WHITELIST
+                    .iter()
+                    .map(|s| format!(r#"{:?}"#, s))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                &tmpdir.path(),
+            ))?,
+        )?;
+
+        debug!("Settings: {:#?}", &settings);
+
+        let plugin = Box::leak(Box::new(settings.build_plugin(None)?));
+
+        let mut data_dirs_counter: std::collections::HashMap<PathBuf, usize> = Default::default();
+
+        for _ in 0..2 {
+            let io = tokio::task::spawn({
+                plugin.run(cincinnati::plugins::PluginIO::InternalIO(InternalIO {
+                    graph: Default::default(),
+                    parameters: Default::default(),
+                }))
+            })
+            .await??;
+
+            let regexes = DEFAULT_OUTPUT_WHITELIST
+                .iter()
+                .map(|s| regex::Regex::new(s).unwrap())
+                .collect::<Vec<regex::Regex>>();
+            assert!(!regexes.is_empty(), "no regexes compiled");
+
+            let data_dir = if let cincinnati::plugins::PluginIO::InternalIO(iio) = io {
+                iio.parameters
+                    .get(GRAPH_DATA_DIR_PARAM_KEY)
+                    .map(PathBuf::from)
+                    .unwrap()
+            } else {
+                bail!("expected plugin to return InternalIO");
+            };
+
+            assert!(
+                data_dir.starts_with(tmpdir.path()),
+                "ensure the plugin reports a directory which is on our tmpdir"
+            );
+
+            let extracted_paths: HashSet<String> = walkdir::WalkDir::new(&data_dir)
+                .into_iter()
+                .map(Result::unwrap)
+                .filter(|entry| entry.file_type().is_file())
+                .filter_map(|file| {
+                    let path = file.path();
+                    path.to_str().map(str::to_owned)
+                })
+                .collect();
+            assert!(!extracted_paths.is_empty(), "no files were extracted");
+
+            // ensure all files match the configured regexes
+            extracted_paths.iter().for_each(|path| {
+                assert!(
+                    regexes.iter().any(|re| re.is_match(&path)),
+                    "{} doesn't match any of the regexes: {:#?}",
+                    path,
+                    regexes
+                )
+            });
+
+            // ensure every regex matches at least one file
+            regexes.iter().for_each(|re| {
+                assert!(
+                    extracted_paths.iter().any(|path| re.is_match(path)),
+                    "regex {} didn't match a file",
+                    &re
+                );
+            });
+
+            data_dirs_counter
+                .entry(data_dir)
+                .and_modify(|v| *v += 1)
+                .or_insert(1);
+        }
+
+        assert_eq!(
+            data_dirs_counter.len(),
+            1,
+            "more than one data_dir encountered"
+        );
+        assert_eq!(
+            data_dirs_counter.values().next().unwrap(),
+            &2usize,
+            "first data_dir was not reused"
+        );
+
+        Ok(())
+    }
+}

--- a/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/test_fixtures/build.sh
+++ b/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/test_fixtures/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -xu
+export REPO_BASE="registry.svc.ci.openshift.org/cincinnati-ci-public/cincinnati"
+export AUTHFILE="${CINCINNATI_CI_PUBLIC_DOCKERJSON_PATH}"
+../../../../../../../graph-builder/tests/images/build-n-push-buildah.sh graph-data-6420f7fbf3724e1e5e329ae8d1e2985973f60c14

--- a/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/test_fixtures/graph-data-6420f7fbf3724e1e5e329ae8d1e2985973f60c14/Dockerfile
+++ b/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/test_fixtures/graph-data-6420f7fbf3724e1e5e329ae8d1e2985973f60c14/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/app-sre/busybox as downloader
+ADD https://github.com/openshift/cincinnati-graph-data/archive/e8692fe50ccbfa525cce340f781d56d5a1d4364d.tar.gz /graph-data.tar.gz
+RUN mkdir -p /graph-data
+RUN tar xav -C /graph-data -f /graph-data.tar.gz --no-same-owner
+
+FROM scratch
+COPY --from=downloader /graph-data/* /

--- a/cincinnati/src/plugins/internal/graph_builder/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/mod.rs
@@ -1,5 +1,6 @@
 //! Plugins specific to the graph-builder
 
+pub mod dkrv2_openshift_secondary_metadata_scraper;
 pub mod github_openshift_secondary_metadata_scraper;
 pub mod openshift_secondary_metadata_parser;
 pub mod release_scrape_dockerv2;

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -60,7 +60,7 @@ pub mod cache {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 pub struct Registry {
     pub(crate) scheme: String,
     pub(crate) insecure: bool,
@@ -198,18 +198,13 @@ pub fn read_credentials(
     })
 }
 
-/// Fetches a vector of all release metadata from the given repository, hosted on the given
-/// registry.
-pub async fn fetch_releases(
+pub async fn new_registry_client(
     registry: &Registry,
     repo: &str,
     username: Option<&str>,
     password: Option<&str>,
-    cache: cache::Cache,
-    manifestref_key: &str,
-    concurrency: usize,
-) -> Result<Vec<cincinnati::plugins::internal::graph_builder::release::Release>, Error> {
-    let registry_client = {
+) -> Result<dkregistry::v2::Client, Error> {
+    let client = {
         let client_builder = dkregistry::v2::Client::configure()
             .registry(&registry.host_port_string())
             .insecure_registry(registry.insecure);
@@ -237,6 +232,22 @@ pub async fn fetch_releases(
             }
         }
     };
+
+    Ok(client)
+}
+
+/// Fetches a vector of all release metadata from the given repository, hosted on the given
+/// registry.
+pub async fn fetch_releases(
+    registry: &Registry,
+    repo: &str,
+    username: Option<&str>,
+    password: Option<&str>,
+    cache: cache::Cache,
+    manifestref_key: &str,
+    concurrency: usize,
+) -> Result<Vec<cincinnati::plugins::internal::graph_builder::release::Release>, Error> {
+    let registry_client = new_registry_client(registry, repo, username, password).await?;
 
     let registry_client_get_tags = registry_client.clone();
     let tags = Box::pin(get_tags(repo, &registry_client_get_tags).await);

--- a/cincinnati/src/plugins/internal/mod.rs
+++ b/cincinnati/src/plugins/internal/mod.rs
@@ -10,6 +10,6 @@ pub mod node_remove;
 mod graph_builder;
 
 pub use graph_builder::{
-    github_openshift_secondary_metadata_scraper, openshift_secondary_metadata_parser,
-    release_scrape_dockerv2,
+    dkrv2_openshift_secondary_metadata_scraper, github_openshift_secondary_metadata_scraper,
+    openshift_secondary_metadata_parser, release_scrape_dockerv2,
 };


### PR DESCRIPTION
This plugin implements downloading the secondary metadata container
image from a given registry/repository location that is compatible with
the Docker V2 protocol.