### PR TITLE
hack/build_e2e: Fail fast is subcommands error out

### DIFF
--- a/hack/build_e2e.sh
+++ b/hack/build_e2e.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 type -f jq || {
   echo ERROR: jq is not available.
   exit 1


### PR DESCRIPTION
`set -e` will protect us [from][1]:

```
++ cargo build --tests --features test-e2e-prom-query --message-format=json
++ jq -r 'select(.profile.test == true) | .executable'
...
error: could not compile `cincinnati`.

To learn more, run the command again with --verbose.
+ for f in '/opt/cincinnati/bin/*'
+ mv '/opt/cincinnati/bin/*' '/opt/cincinnati/bin/*'
```

where we failed to compile, but then blindly continued to attempt to install the binary (which we hadn't built).

`-u` and `-o pipefail` guard us from future typos and subcommand failures as the script evolves in the future.

/assign @steveeJ @vrutkovs

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati/314/pull-ci-openshift-cincinnati-master-images/1321211196195475456