### PR TITLE
dist/Dockerfiles: switch from docker.io to quay.io

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM quay.io/app-sre/centos:7
 
 # base: EPEL repo for extra tools
 RUN yum -y install epel-release

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -7,7 +7,7 @@ RUN hack/build_e2e.sh
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder
 RUN env GOBIN=/usr/local/bin go get -u github.com/tsenart/vegeta
 
-FROM centos:7
+FROM quay.io/app-sre/centos:7
 
 ENV HOME="/root"
 


### PR DESCRIPTION
This is done because the app-sre pipeline has recently introduced
blocking connections to docker.io to prevent hitting the ratelimit.