### PR TITLE
dist/Dockerfiles: switch from docker.io to quay.io [2]

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo build --release && \
     cp -rvf target/release/graph-builder /opt/cincinnati/bin && \
     cp -rvf target/release/policy-engine /opt/cincinnati/bin
 
-FROM centos:7
+FROM quay.io/app-sre/centos:7
 
 ENV RUST_LOG=actix_web=error,dkregistry=error
 


### PR DESCRIPTION
This is done because the app-sre pipeline has recently introduced
blocking connections to docker.io to prevent hitting the ratelimit.

/cc @wking 