### PR TITLE
cincinnati/src/lib: Fix "Abstrat" -> "Abstract" typos

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -1056,7 +1056,7 @@ pub mod testing {
 
                         Ok(())
                     }
-                    Release::Abstract(ar) => panic!("unexpected Abstrat release: {:?}", &ar),
+                    Release::Abstract(ar) => panic!("unexpected Abstract release: {:?}", &ar),
                 }
             })
             .context("replacing the sha by the tag in the payload string")
@@ -1074,7 +1074,7 @@ pub mod testing {
 
                         Ok(())
                     }
-                    Release::Abstract(ar) => panic!("unexpected Abstrat release: {:?}", &ar),
+                    Release::Abstract(ar) => panic!("unexpected Abstract release: {:?}", &ar),
                 }
             })
             .context("removing registry and repo from the payload string")


### PR DESCRIPTION
These snuck in with b77e137dbd (#312).

/assign @steveeJ