### PR TITLE
cincinnati/src/lib: Fix diff edge sense (correcting left vs. right)

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -977,8 +977,8 @@ pub mod testing {
         output.push("Graphs differ! Showing differences from left to right".into());
         output.push("-----------------------------------------------------".into());
 
-        let edges_left = right.get_edges(false)?;
-        let edges_right = left.get_edges(false)?;
+        let edges_left = left.get_edges(false)?;
+        let edges_right = right.get_edges(false)?;
         output.push("edges: ".into());
         output.push(
             prettydiff::diff_lines(


### PR DESCRIPTION
The mixed inputs I'm correcting landed with the methor in 84faa290fc (#250).

/assign @steveeJ