### PR TITLE
policy-engine/src/openapiv3: additionalProperties for Node.metadata

### DIFF
--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -101,7 +101,10 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "type": "string"
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
The metadata value is not a string, it is an object whose sub-properties have string values:

```console
$ curl -sH Accept:application/json 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.6' | jq -S '.nodes[] | select(.version == "4.6.1")'
{
  "metadata": {
    "description": "",
    "io.openshift.upgrades.graph.previous.remove_regex": "4\\.5\\.1[45]",
    "io.openshift.upgrades.graph.release.channels": "candidate-4.6,fast-4.6,stable-4.6",
    "io.openshift.upgrades.graph.release.manifestref": "sha256:d78292e9730dd387ff6198197c8b0598da340be7678e8e1e4810b557a926c2b9",
    "url": "https://access.redhat.com/errata/RHBA-2020:4196"
  },
  "payload": "quay.io/openshift-release-dev/ocp-release@sha256:d78292e9730dd387ff6198197c8b0598da340be7678e8e1e4810b557a926c2b9",
  "version": "4.6.1"
}
```

In OpenAPI, that is [represented][2] by [an `additionalProperties` object][1] declaring the type of the child values.

The previous string claim was from the original OpenAPI declaration in d717accb25 (#40).

[1]: https://github.com/OAI/OpenAPI-Specification/blame/3.0.2/versions/3.0.2.md#L2404-L2421
[2]: https://github.com/OAI/OpenAPI-Specification/blame/3.0.2/versions/3.0.2.md#L2305