### PR TITLE
WIP Dockerfiles: improve dockerfiles to be compatible with rust-toolset images

### DIFF
--- a/dist/Dockerfile.build/Dockerfile
+++ b/dist/Dockerfile.build/Dockerfile
@@ -29,3 +29,5 @@ RUN \
   mkdir -p $HOME/.cargo/git/ && \
   find $HOME/. -type d -exec chmod 777 {} \; && \
   find $HOME/. -type f -exec chmod ugo+rw {} \;
+
+WORKDIR /go/src/github.com/openshift/cincinnati/

--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -16,8 +16,7 @@ FROM quay.io/app-sre/centos:7
 
 ENV RUST_LOG=actix_web=error,dkregistry=error
 
-RUN yum update -y && \
-    yum install -y openssl && \
+RUN yum install -y openssl && \
     yum clean all
 
 COPY --from=builder /opt/cincinnati/bin/* /usr/bin/

--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/app-sre/cincinnati:builder AS builder
 
-WORKDIR /go/src/github.com/openshift/cincinnati/
-
+# Use root user
+USER 0
 # build
 COPY . .
 # copy git information for built crate

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -2,6 +2,11 @@ FROM quay.io/app-sre/cincinnati:builder AS rust_builder
 # build e2e tests
 COPY . .
 
+# Install jq
+RUN mkdir -p ${HOME}/bin && \
+    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 2>/dev/null -o ${HOME}/bin/jq && chmod a+x ${HOME}/bin/jq
+ENV PATH="${PATH}:${HOME}/bin"
+
 RUN hack/build_e2e.sh
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,6 +1,8 @@
 FROM quay.io/app-sre/cincinnati:builder AS rust_builder
 # build e2e tests
 COPY . .
+# Use root user
+USER 0
 
 # Install jq
 RUN mkdir -p ${HOME}/bin && \
@@ -25,7 +27,7 @@ RUN mkdir -p ${HOME}/bin && \
 ENV PATH="${PATH}:${HOME}/bin"
 
 # Install container tools
-RUN yum -y install skopeo buildah yamllint
+RUN yum -y install yamllint
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -32,18 +32,17 @@ RUN yum -y install yamllint
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test
 COPY --from=rust_builder /opt/cincinnati/bin/slo /usr/bin/cincinnati-e2e-slo
-COPY --from=rust_builder hack/e2e.sh hack/
-COPY --from=rust_builder dist/openshift/cincinnati.yaml dist/openshift/
-COPY --from=rust_builder dist/openshift/observability.yaml dist/openshift/
 COPY --from=golang_builder /usr/local/bin/vegeta /usr/bin
-COPY --from=rust_builder hack/load-testing.sh /usr/local/bin/load-testing.sh
-COPY --from=rust_builder hack/vegeta.targets vegeta.targets
-COPY --from=rust_builder e2e/tests/testdata e2e/tests/testdata
 
-COPY --from=rust_builder dist/prow_yaml_lint.sh dist/
-COPY --from=rust_builder dist/prow_rustfmt.sh dist/
-COPY --from=rust_builder dist/prepare_ci_credentials.sh dist/
-
+COPY hack/e2e.sh hack/
+COPY dist/openshift/cincinnati.yaml dist/openshift/
+COPY dist/openshift/observability.yaml dist/openshift/
+COPY hack/load-testing.sh /usr/local/bin/load-testing.sh
+COPY hack/vegeta.targets vegeta.targets
+COPY e2e/tests/testdata e2e/tests/testdata
+COPY dist/prow_yaml_lint.sh dist/
+COPY dist/prow_rustfmt.sh dist/
+COPY dist/prepare_ci_credentials.sh dist/
 ENV E2E_TESTDATA_DIR "e2e/tests/testdata"
 
 ENTRYPOINT ["hack/e2e.sh"]


### PR DESCRIPTION
Rework dockerfiles so that we could use `registry.redhat.io/rhel8/rust-toolset` as a builder image. This ensures workdir is set once in our builder image, root user set explicitly and `jq` fetched as a binary.

TODO:
* [ ] No `yamllint` in UBI8 images

Precondition for https://github.com/openshift/release/pull/13990