### PR TITLE
Bug 1910150: Removing the unreadable_file.yaml

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/invalid0/cincinnati-graph-data/blocked-edges/unreadable_file.yaml
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/invalid0/cincinnati-graph-data/blocked-edges/unreadable_file.yaml
@@ -1,1 +1,0 @@
-/does/not/exist


### PR DESCRIPTION
As it is causing the downstream build to fail with below error

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>