### PR TITLE
dist/Dockerfile.test-rust: Add a Dockerfile for Rust-tooling with source code

### DIFF
--- a/dist/Dockerfile.test/Dockerfile
+++ b/dist/Dockerfile.test/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/app-sre/cincinnati:builder AS builder
+
+WORKDIR /go/src/github.com/openshift/cincinnati/
+
+# build
+COPY . .


### PR DESCRIPTION
To give us an image we can use for rustfmt checks and similar.  These are traditionally sourced with the following image chain:

1. [Configured `build_root` image][1].
2. Take the build root from 1, and [add the source code][2] to create `pipeline:src`.

But our Rust builder is based on a CentOS image, the CentOS pullspec we have in our Dockerfile is a placeholder, and [`build_root` doesn't support `from` to replace that placeholder with a reference to a CI-registry CentOS image][3].  This new Dockerfile gives us an image explicitly targetted to rustfmt and similar.

[1]: https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
[2]: https://docs.ci.openshift.org/docs/architecture/ci-operator/#building-artifacts
[3]: https://github.com/openshift/release/pull/13224/commits/38b55955cda987f7f75c12f6f90fcec0d5b1f508