### PR TITLE
Bug 1913442: Dockerfile.e2e: include prepare_ci_credentials.sh

### DIFF
--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=rust_builder e2e/tests/testdata e2e/tests/testdata
 
 COPY --from=rust_builder dist/prow_yaml_lint.sh dist/
 COPY --from=rust_builder dist/prow_rustfmt.sh dist/
+COPY --from=rust_builder dist/prepare_ci_credentials.sh dist/
 
 ENV E2E_TESTDATA_DIR "e2e/tests/testdata"
 


### PR DESCRIPTION
This file should be included in e2e image, as its being use by cargo-test.

Fixes `env: dist/prepare_ci_credentials.sh: No such file or directory` in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/14518/rehearse-14518-pull-ci-openshift-cincinnati-master-cargo-test/1347114392373694464