### PR TITLE
Bug 1913442: Adding yamllint to e2e Dockerfile

### DIFF
--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p ${HOME}/bin && \
 ENV PATH="${PATH}:${HOME}/bin"
 
 # Install container tools
-RUN yum -y install skopeo buildah
+RUN yum -y install skopeo buildah yamllint
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test
@@ -35,6 +35,7 @@ COPY --from=rust_builder e2e/tests/testdata e2e/tests/testdata
 
 COPY --from=rust_builder dist/prow_yaml_lint.sh dist/
 COPY --from=rust_builder dist/prow_rustfmt.sh dist/
+COPY --from=rust_builder dist/prepare_ci_credentials.sh dist/
 
 ENV E2E_TESTDATA_DIR "e2e/tests/testdata"
 


### PR DESCRIPTION
As ci/rehearse/openshift/cincinnati/master/yaml-lint is failing in
https://github.com/openshift/release/pull/14518

This PR fixes following errors in https://github.com/openshift/release/pull/14518/
```
error: some steps failed:
  * could not run steps: step cargo-test failed: "cargo-test" pre steps failed: "cargo-test" pod "cargo-test-prepare-credentials" failed: the pod ci-op-llhz1tjz/cargo-test-prepare-credentials failed after 20s (failed containers: test): ContainerFailed one or more containers exited
Container test exited with code 1, reason Error
---
env: dist/prepare_ci_credentials.sh: No such file or directory
error: failed to execute wrapped command: exit status 127 
```
```
test exited with code 1, reason Error
---
+ YAML_LINTER=yamllint
+ YAML_RULES='{extends: default, rules: {line-length: {max: 120}}}'
+ YAML_LINT_CMD=("${YAML_LINTER}" '-s' '-d' "${YAML_RULES}")
+ type -f yamllint
dist/prow_yaml_lint.sh: line 9: type: yamllint: not found
+ echo 'error: could not find yamllint in PATH'
error: could not find yamllint in PATH
+ exit 1 
```

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>