### PR TITLE
Bug 1916188: Dockerfile: remove extra copies

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,9 +1,5 @@
 FROM quay.io/app-sre/cincinnati:builder AS builder
 
-WORKDIR /go/src/github.com/openshift/cincinnati/
-
-# build
-COPY . .
 # copy git information for built crate
 COPY .git/ ./.git/
 

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,7 +1,4 @@
 FROM quay.io/app-sre/cincinnati:builder AS rust_builder
-# build e2e tests
-COPY . .
-
 RUN hack/build_e2e.sh
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder
@@ -27,17 +24,14 @@ RUN yum update -y && \
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test
 COPY --from=rust_builder /opt/cincinnati/bin/slo /usr/bin/cincinnati-e2e-slo
-COPY --from=rust_builder hack/e2e.sh hack/
-COPY --from=rust_builder dist/openshift/cincinnati.yaml dist/openshift/
-COPY --from=rust_builder dist/openshift/observability.yaml dist/openshift/
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/e2e.sh hack/
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/cincinnati.yaml dist/openshift/
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/observability.yaml dist/openshift/
 COPY --from=golang_builder /usr/local/bin/vegeta /usr/bin
-COPY --from=rust_builder hack/load-testing.sh /usr/local/bin/load-testing.sh
-COPY --from=rust_builder hack/vegeta.targets vegeta.targets
-COPY --from=rust_builder e2e/tests/testdata e2e/tests/testdata
-
-COPY --from=rust_builder dist/prow_yaml_lint.sh dist/
-COPY --from=rust_builder dist/prow_rustfmt.sh dist/
-COPY --from=rust_builder dist/prepare_ci_credentials.sh dist/
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/load-testing.sh /usr/local/bin/load-testing.sh
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/vegeta.targets vegeta.targets
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/e2e/tests/testdata e2e/tests/testdata
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/prepare_ci_credentials.sh dist/
 
 ENV E2E_TESTDATA_DIR "e2e/tests/testdata"
 

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="${PATH}:${HOME}/bin"
 
 # Install container tools
 RUN yum update -y && \
-    yum install -y skopeo buildah yamllint && \
+    yum install -y skopeo buildah && \
     yum clean all
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -50,7 +50,8 @@ oc secrets link default ci-pull-secret --for=pull
 
 # Reconfigure monitoring operator to support user workloads
 # https://docs.openshift.com/container-platform/4.3/monitoring/monitoring-your-own-services.html
-oc -n openshift-monitoring create configmap cluster-monitoring-config --from-literal='config.yaml={"techPreviewUserWorkload": {"enabled": true}}'
+oc -n openshift-monitoring create configmap cluster-monitoring-config --from-literal='config.yaml={"techPreviewUserWorkload": {"enabled": true}}' -o yaml --dry-run=client > /tmp/cluster-monitoring-config.yaml
+oc apply -f /tmp/cluster-monitoring-config.yaml
 
 # Import observability template
 # ServiceMonitors are imported before app deployment to give Prometheus time to catch up with


### PR DESCRIPTION
This is no longer required, as builder already contains those