### PR TITLE
Bug 1916188: Dockerfile.deploy: copy sourcecode

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,5 +1,6 @@
 FROM quay.io/app-sre/cincinnati:builder AS builder
 
+COPY . .
 # copy git information for built crate
 COPY .git/ ./.git/
 


### PR DESCRIPTION
CI tests don't require the source code to be copied here, but without it 
stage deploy procedure is broken