### PR TITLE
template: bump initialDelaySeconds

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -68,14 +68,14 @@ objects:
                 httpGet:
                   path: /liveness
                   port: ${{GB_STATUS_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 30
                 periodSeconds: 10
                 timeoutSeconds: 3
               readinessProbe:
                 httpGet:
                   path: /readiness
                   port: ${{GB_STATUS_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 30
                 periodSeconds: 10
                 timeoutSeconds: 3
               resources:
@@ -146,7 +146,7 @@ objects:
               livenessProbe:
                 tcpSocket:
                   port: ${{PE_PORT}}
-                initialDelaySeconds: 3
+                initialDelaySeconds: 30
                 periodSeconds: 10
                 timeoutSeconds: 3
               resources:


### PR DESCRIPTION
Due to the amount of images to parse graph-builder can't complete the scrape in allotted time (~35 secs).

The scrape never completed in less than 30 secs on our CI, so this change bumps initialDelaySeconds to 30 to make sure e2e tests pass consistently