### PR TITLE
reduce redundant pulling of layer digest

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -15,6 +15,7 @@
 use crate as cincinnati;
 
 use self::cincinnati::plugins::internal::graph_builder::release::Metadata;
+use self::cincinnati::plugins::internal::graph_builder::release::MetadataKind;
 use self::cincinnati::plugins::prelude_plugin_impl::*;
 
 use flate2::read::GzDecoder;
@@ -22,6 +23,7 @@ use futures::lock::Mutex as FuturesMutex;
 use futures::prelude::*;
 use futures::TryStreamExt;
 use log::{debug, error, trace, warn};
+use semver::Version;
 use serde::Deserialize;
 use serde_json;
 use std::fs::File;
@@ -377,6 +379,15 @@ async fn lookup_or_fetch(
             cached_metadata.clone()
         }
         None => {
+            let placeholder = Option::from(Metadata {
+                kind: MetadataKind::V0,
+                version: Version::new(0, 0, 0),
+                previous: vec![],
+                next: vec![],
+                metadata: Default::default(),
+            });
+            cache.write().await.insert(manifestref.clone(), placeholder);
+
             let metadata = find_first_release_metadata(
                 layer_digests,
                 registry_client,


### PR DESCRIPTION
In a scenario when a worker is actively pulling the layer
digest and another worker checks the cache for the same release,
it resulted in a cache miss and redundant downloading of the
layer digest.
this commit fixes the issue with the use of a placeholder which
takes place of the release till all the layer digests are downloaded.
This will not result in a cache miss thus stopping the redundant
pulling of layers.
The placeholder in the cache will be replaced with updated values
once the layer digest is pulled.