### PR TITLE
e2e ubi8: copy cargo_test.sh

### DIFF
--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -36,6 +36,7 @@ COPY --from=rust_builder /opt/app-root/src/hack/load-testing.sh /usr/local/bin/l
 COPY --from=rust_builder /opt/app-root/src/hack/vegeta.targets vegeta.targets
 COPY --from=rust_builder /opt/app-root/src/e2e/tests/testdata e2e/tests/testdata
 COPY --from=rust_builder /opt/app-root/src/dist/prepare_ci_credentials.sh dist/
+COPY --from=rust_builder /opt/app-root/src/dist/cargo_test.sh dist/
 
 ENV E2E_TESTDATA_DIR "e2e/tests/testdata"
 


### PR DESCRIPTION
In UBI8 setup we have to re-use e2e container to run unit tests, so the 
image has to have all the necessary scripts