### PR TITLE
add cors headers while querying Cincinnati

### DIFF
--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -76,11 +76,6 @@ fn main() -> Result<(), Error> {
     HttpServer::new(move || {
         App::new()
             .wrap(middleware::Compress::default())
-            .wrap(
-                Cors::default()
-                    .allow_any_origin()
-                    .allowed_methods(vec!["HEAD", "GET"]),
-            )
             .app_data(actix_web::web::Data::new(RegistryWrapper(registry)))
             .service(
                 actix_web::web::resource("/metrics")
@@ -109,6 +104,11 @@ fn main() -> Result<(), Error> {
                 set_span_tags(&req, &span);
                 srv.call(req).instrument(span)
             })
+            .wrap(
+                Cors::default()
+                    .allow_any_origin()
+                    .allowed_methods(vec!["HEAD", "GET"]),
+            )
             .app_data(actix_web::web::Data::<AppState>::new(state.clone()))
             .service(
                 actix_web::web::resource(&format!("{}/v1/graph", app_prefix))


### PR DESCRIPTION
317f5c5d05d5f39b27ace1788a780632c3e4c4d0  added cors headers for `/metrics`
this PR adds cors headers for endpoints used while
querying cincinnati

Allow simple requests by including the:
  Access-Control-Allow-Origin: *

Also, drop CORS headers for `metrics` endpoint