### PR TITLE
dependabot config: set directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "daily"
     reviewers:


### PR DESCRIPTION
Cargo.toml location needs to be specified.

Fixes https://github.com/openshift/cincinnati/runs/2344900965