### PR TITLE
Cargo: update built to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,14 +587,12 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.3.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2315cfb416f86e05360edc950b1d7d25ecfb00f7f8eba60dbd7882a0f2e944"
+checksum = "c8f1b029cb3929cb0c99780b0c10fe512f60be5438adf5f757e4afa1bc75a984"
 dependencies = [
- "chrono",
+ "cargo-lock 4.0.1",
  "git2",
- "semver 0.9.0",
- "toml",
 ]
 
 [[package]]
@@ -622,6 +620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679"
+dependencies = [
+ "semver 0.9.0",
+ "serde",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -1416,9 +1426,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git2"
-version = "0.10.2"
+version = "0.13.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1af51ea8a906616af45a4ce78eacf25860f7a13ae7bf8a814693f0f4037a26"
+checksum = "b483c6c2145421099df1b4efd50e0f6205479a072199460eff852fa15e5603c7"
 dependencies = [
  "bitflags",
  "libc",
@@ -1722,9 +1732,9 @@ checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.9.2"
+version = "0.12.19+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4870c781f6063efb83150cd22c1ddf6ecf58531419e7570cdcced46970f64a16"
+checksum = "f322155d574c8b9ebe991a04f6908bb49e68a79463338d24a43d6274cb6443e6"
 dependencies = [
  "cc",
  "libc",
@@ -2702,7 +2712,7 @@ name = "rh-manifest-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cargo-lock",
+ "cargo-lock 6.0.1",
  "lazy_static",
  "reqwest",
  "serde",
@@ -2842,6 +2852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser 0.7.0",
+ "serde",
 ]
 
 [[package]]

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -40,7 +40,7 @@ opentelemetry = "0.4.0"
 actix-service = "2.0.0-beta.4"
 
 [build-dependencies]
-built = "^0.3.2"
+built = { version = "^0.4.4", features = [ "git2" ]}
 
 [dev-dependencies]
 twoway = "^0.2"

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -32,7 +32,7 @@ opentelemetry = "0.4.0"
 actix-service = "2.0.0-beta.4"
 
 [build-dependencies]
-built = "^0.3.2"
+built = { version = "^0.4.4", features = [ "git2" ]}
 
 [dev-dependencies]
 tokio = { version = "1.5", features = [ "rt-multi-thread" ] }


### PR DESCRIPTION
Enable "git2" feature to get GIT_VERSION.

Replaces #404