### PR TITLE
Remove dependency on dockerfile.build

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -1,4 +1,27 @@
-FROM quay.io/app-sre/cincinnati:builder AS builder
+FROM registry.centos.org/centos/centos:7 as builder
+
+# base: EPEL repo for extra tools
+RUN yum -y install epel-release
+
+# build: system utilities and libraries
+RUN yum update -y && \
+    yum -y groupinstall 'Development Tools' && \
+    yum -y install gcc openssl-devel protobuf-compiler jq skopeo buildah libgit2 && \
+    yum -y install yamllint && \
+    yum -y install cmake elfutils-libelf-devel libcurl-devel binutils-devel elfutils-devel && \
+    yum clean all
+
+ENV HOME="/root"
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
+
+# build: Rust stable toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.50.0 -y && \
+  rustup install 1.46.0
+
+RUN \
+  mkdir -p $HOME/.cargo/git/ && \
+  find $HOME/. -type d -exec chmod 777 {} \; && \
+  find $HOME/. -type f -exec chmod ugo+rw {} \;
 
 COPY . .
 # copy git information for built crate

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,4 +1,29 @@
-FROM quay.io/app-sre/cincinnati:builder AS rust_builder
+FROM registry.centos.org/centos/centos:7 as rust_builder
+
+# base: EPEL repo for extra tools
+RUN yum -y install epel-release
+
+# build: system utilities and libraries
+RUN yum update -y && \
+    yum -y groupinstall 'Development Tools' && \
+    yum -y install gcc openssl-devel protobuf-compiler jq skopeo buildah libgit2 && \
+    yum -y install yamllint && \
+    yum -y install cmake elfutils-libelf-devel libcurl-devel binutils-devel elfutils-devel && \
+    yum clean all
+
+ENV HOME="/root"
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
+
+# build: Rust stable toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.50.0 -y && \
+  rustup install 1.46.0
+
+RUN \
+  mkdir -p $HOME/.cargo/git/ && \
+  find $HOME/. -type d -exec chmod 777 {} \; && \
+  find $HOME/. -type f -exec chmod ugo+rw {} \;
+
+
 RUN hack/build_e2e.sh
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder


### PR DESCRIPTION
we are doing a multi-stage build in dockerfile.deploy to
remove the dependency on dockerfile.build

this is because we are installing certain modules in dockerfile.build
that are introducing vulnerabilities. We are not carrying these
vulnerabilities in the final container that we are shipping, we are just
using dockerfile.build container as a builder image. This can be achieved
in a multi-stage build, thus not requiring a separate build dockerfile.