### PR TITLE
Dockerfile.deploy: install libgit2

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -14,7 +14,7 @@ FROM registry.centos.org/centos/centos:7
 ENV RUST_LOG=actix_web=error,dkregistry=error
 
 RUN yum update -y && \
-    yum install -y openssl && \
+    yum install -y openssl libgit2 && \
     yum clean all
 
 COPY --from=builder /opt/cincinnati/bin/* /usr/bin/

--- a/e2e/tests/slo.rs
+++ b/e2e/tests/slo.rs
@@ -19,6 +19,10 @@ use test_case::test_case;
 #[test_case("clamp_max(cincinnati_gb_graph_upstream_scrapes_total, 1)", "1")]
 // No scrape errors
 #[test_case("cincinnati_gb_graph_upstream_errors_total", "0")]
+// Graph builder reports valid git commit
+#[test_case("cincinnati_gb_build_info{git_commit!='unknown'}", "1")]
+// Policy engine reports valid git commit
+#[test_case("cincinnati_pe_build_info{git_commit!='unknown'}", "1")]
 fn check_slo(query: &'static str, expected: &'static str) {
     let prometheus_api_base = match env::var("PROM_ENDPOINT") {
         Ok(env) => format!("{}/api/v1/query", env),

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -71,7 +71,7 @@ lazy_static! {
         "build_info",
         "Build information",
         labels!{
-            "git_commit" => match built_info::GIT_VERSION {
+            "git_commit" => match built_info::GIT_COMMIT_HASH {
                 Some(commit) => commit,
                 None => "unknown"
             },

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -50,7 +50,7 @@ lazy_static! {
         "build_info",
         "Build information",
         labels! {
-            "git_commit" => match built_info::GIT_VERSION {
+            "git_commit" => match built_info::GIT_COMMIT_HASH {
                 Some(commit) => commit,
                 None => "unknown"
             },


### PR DESCRIPTION
This lib is required by built crate to set git commit hash in metrics.

Reference: https://issues.redhat.com/browse/OTA-402