### PR TITLE
Improve SLO test comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,12 +1123,14 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 name = "e2e"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert-json-diff",
  "chrono",
  "cincinnati",
  "commons",
  "env_logger",
  "failure",
+ "hamcrest2",
  "lazy_static",
  "prometheus-query",
  "reqwest",
@@ -1481,6 +1483,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hamcrest2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f837c62de05dc9cc71ff6486cd85de8856a330395ae338a04bfcefe5e91075"
+dependencies = [
+ "num",
+ "regex",
 ]
 
 [[package]]
@@ -1906,6 +1918,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +1962,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +1999,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Vadim Rutkovsky <vrutkovs@redhat.com>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "^1.0"
 assert-json-diff = "2.0.1"
 chrono = "^0.4.0"
 env_logger = "^0.8"
@@ -13,7 +14,8 @@ reqwest = { version="^0.11", features = ["blocking"] }
 serde = "^1.0.70"
 serde_derive = "^1.0.70"
 serde_json = "^1.0.22"
-test-case = "1.0.0"
+test-case = { version = "1.1.0", features = ["hamcrest_assertions"] }
+hamcrest2 = "0.3.0"
 url = "^2.2"
 commons = { path = "../commons" }
 tokio = { version = "1.5", features = [ "fs", "rt-multi-thread" ] }

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -30,9 +30,11 @@ fn e2e_channel_success(channel: &'static str, arch: &'static str) {
 
     let res = run_graph_query(channel, arch, &runtime);
 
-    assert_eq!(res.status().is_success(), true);
+    assert_eq!(res.status().is_success(), true, "{}", res.status());
     let text = runtime.block_on(res.text()).unwrap();
-    let actual: cincinnati::Graph = serde_json::from_str(&text).unwrap();
+    let actual: cincinnati::Graph = serde_json::from_str(&text)
+        .context(format!("Failed to parse '{}' as json", text))
+        .unwrap();
 
     if let Err(e) = cincinnati::testing::compare_graphs_verbose(
         expected,
@@ -89,5 +91,6 @@ fn run_graph_query(channel: &'static str, arch: &'static str, runtime: &Runtime)
                 .header(ORIGIN, ORIGIN_HEADER_VALUE.clone())
                 .send(),
         )
+        .context("Failed to execute Prometheus query")
         .unwrap()
 }

--- a/e2e/tests/slo.rs
+++ b/e2e/tests/slo.rs
@@ -1,29 +1,12 @@
+use anyhow::Context;
+use hamcrest2::prelude::*;
 use prometheus_query::v1::queries::{QueryData, QueryResult, QuerySuccess, VectorResult};
 use prometheus_query::v1::Client;
+use serde_json::{Map, Value};
 use std::env;
 use test_case::test_case;
 
-// Service reports at all times
-#[test_case(r#"min_over_time(up{job="cincinnati-policy-engine"}[1h])"#, "1")]
-#[test_case(r#"min_over_time(up{job="cincinnati-graph-builder"}[1h])"#, "1")]
-// No upstream errors
-#[test_case("max_over_time(cincinnati_pe_http_upstream_errors_total[1h])", "0")]
-#[test_case("max_over_time(cincinnati_gb_graph_upstream_errors_total[1h])", "0")]
-// Use clamp_min to bring up the minimal serve duration to 1s
-// If the quantile would produce a bigger result this test would fail
-#[test_case(
-    "clamp_min(histogram_quantile(0.90, sum(cincinnati_pe_v1_graph_serve_duration_seconds_bucket) by (le)), 1)",
-    "1"
-)]
-// At least one scrape has been performed
-#[test_case("clamp_max(cincinnati_gb_graph_upstream_scrapes_total, 1)", "1")]
-// No scrape errors
-#[test_case("cincinnati_gb_graph_upstream_errors_total", "0")]
-// Graph builder reports valid git commit
-#[test_case("cincinnati_gb_build_info{git_commit!='unknown'}", "1")]
-// Policy engine reports valid git commit
-#[test_case("cincinnati_pe_build_info{git_commit!='unknown'}", "1")]
-fn check_slo(query: &'static str, expected: &'static str) {
+fn get_query_result_string(query: &'static str) -> VectorResult {
     let prometheus_api_base = match env::var("PROM_ENDPOINT") {
         Ok(env) => format!("{}/api/v1/query", env),
         _ => panic!("PROM_ENDPOINT unset"),
@@ -39,10 +22,12 @@ fn check_slo(query: &'static str, expected: &'static str) {
         .access_token(Some(prometheus_token))
         .accept_invalid_certs(Some(true))
         .build()
+        .context("Failed to establish Prometheus connection")
         .unwrap();
 
     let result: QuerySuccess = match prometheus_client
         .query(query.to_string(), None, None)
+        .context("Error running query")
         .unwrap()
     {
         QueryResult::Success(query_success) => query_success,
@@ -53,6 +38,59 @@ fn check_slo(query: &'static str, expected: &'static str) {
         _ => panic!("expected vector"),
     };
     assert_ne!(vector_data.len(), 0, "the vector contains 0 elements");
-    let first_result: &VectorResult = vector_data.get(0).unwrap();
-    assert_eq!(first_result.sample().to_string(), expected);
+    return vector_data.get(0).unwrap().clone();
+}
+
+fn check_slo_exact(query: &'static str) -> String {
+    get_query_result_string(query).sample().to_string()
+}
+
+// Service reports at all times
+#[test_case(r#"min_over_time(up{job="cincinnati-policy-engine"}[1h])"# => 1)]
+#[test_case(r#"min_over_time(up{job="cincinnati-graph-builder"}[1h])"# => 1)]
+// No scrape errors
+#[test_case("cincinnati_gb_graph_upstream_errors_total" => is less_than(1))]
+// No upstream errors
+#[test_case("cincinnati_pe_http_upstream_errors_total" => is less_than(1))]
+// At least one scrape has been performed
+#[test_case("cincinnati_gb_graph_upstream_scrapes_total" => is greater_than_or_equal_to(1))]
+fn check_slo_numeric(query: &'static str) -> i32 {
+    get_query_result_string(query)
+        .sample()
+        .to_string()
+        .parse::<i32>()
+        .unwrap()
+}
+
+// Minimal serve duration is less than 1s
+#[test_case(
+    "histogram_quantile(0.90, sum(cincinnati_pe_v1_graph_serve_duration_seconds_bucket) by (le))"
+     => is less_than(0.5)
+)]
+fn check_slo_float(query: &'static str) -> f32 {
+    get_query_result_string(query)
+        .sample()
+        .to_string()
+        .parse::<f32>()
+        .unwrap()
+}
+
+// Graph builder reports valid git commit
+#[test_case("cincinnati_gb_build_info", "git_commit" => is not(eq("unknown")))]
+// Policy engine reports valid git commit
+#[test_case("cincinnati_pe_build_info", "git_commit" => is not(eq("unknown")))]
+fn check_slo_parameter(query: &'static str, parameter: &'static str) -> String {
+    let result = get_query_result_string(query);
+    let metric: &Map<String, Value> = match result.metric() {
+        Value::Object(v) => v,
+        _ => panic!("Non-object value received"),
+    };
+    let param_value: &Value = match metric.get(parameter) {
+        None => panic!("{} not found in {:#?}", parameter, metric),
+        Some(v) => v,
+    };
+    match param_value {
+        Value::String(v) => v.to_string(),
+        _ => panic!("Expected {} to be a string", param_value.to_string()),
+    }
 }

--- a/prometheus-query/src/v1/queries/mod.rs
+++ b/prometheus-query/src/v1/queries/mod.rs
@@ -58,6 +58,9 @@ impl VectorResult {
     pub fn sample(&self) -> &String {
         &self.value.sample
     }
+    pub fn metric(&self) -> &serde_json::Value {
+        &self.metric
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This uses hamcrest2 to have more complicated matching of the expected results, enabling us to use lg/gt/is/is not etc.

From plain match/no match tests we now have:
* compare integer results for `min_over_time(up)`
* less_than for `*_upstream_errors_total` and serve_duration histogram
* greater_than_or_equal_to for `graph_upstream_scrapes_total`
* is not eq  for  git commit in cincinnati_gb_build_info

Reference: https://issues.redhat.com/browse/OTA-366