### PR TITLE
e2e: pull stable vegeta

### DIFF
--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y \
 RUN bash -c "source /opt/app-root/etc/scl_enable && hack/build_e2e.sh"
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder
-RUN env GOBIN=/usr/local/bin go get -u github.com/tsenart/vegeta
+RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/app-sre/cincinnati:builder AS rust_builder
 RUN hack/build_e2e.sh
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder
-RUN env GOBIN=/usr/local/bin go get -u github.com/tsenart/vegeta
+RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta
 
 FROM registry.centos.org/centos/centos:7
 


### PR DESCRIPTION
Use prebuilt stable version of vegeta binaries for testing to prevent build errors.

See https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cincinnati/422/pull-ci-openshift-cincinnati-master-stablerust-e2e/1389575368049954816/build-log.txt