### PR TITLE
Replace twoway crate with memchr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "memchr",
  "mockito",
  "opentelemetry",
  "pgp",
@@ -729,7 +730,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "twoway",
  "url",
  "walkdir",
 ]
@@ -786,6 +786,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
+ "memchr",
  "mockito",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -797,7 +798,6 @@ dependencies = [
  "thiserror",
  "thrift",
  "tokio",
- "twoway",
  "url",
 ]
 
@@ -1435,6 +1435,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "memchr",
  "opentelemetry",
  "parking_lot",
  "prometheus 0.12.0",
@@ -1452,7 +1453,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "twoway",
  "url",
 ]
 
@@ -2315,6 +2315,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "log",
+ "memchr",
  "mockito",
  "openapiv3",
  "opentelemetry",
@@ -2328,7 +2329,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
- "twoway",
  "url",
 ]
 
@@ -3561,16 +3561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twoway"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b40075910de3a912adbd80b5d8bad6ad10a23eeb1f5bf9d4006839e899ba5bc"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,12 +3571,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicode-bidi"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -45,7 +45,7 @@ pgp = "^0.7.1"
 [dev-dependencies]
 mockito = "^0.30.0"
 serde_json = "1.0.22"
-twoway = "^0.2"
+memchr = "^2.4"
 pretty_assertions = "0.7.2"
 test-case = "1.0.0"
 prettydiff = "0.4"

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -174,6 +174,7 @@ mod tests {
     use cincinnati::testing::generate_custom_graph;
     use commons::metrics::{self, RegistryWrapper};
     use commons::testing::{self, init_runtime};
+    use memchr::memmem;
     use prometheus::Registry;
 
     macro_rules! fetch_upstream_success_test {
@@ -339,15 +340,17 @@ mod tests {
             if let actix_web::body::Body::Bytes(bytes) = body {
                 assert!(!bytes.is_empty());
                 println!("{:?}", std::str::from_utf8(bytes.as_ref()));
-                assert!(twoway::find_bytes(
+                assert!(memmem::find_iter(
                     bytes.as_ref(),
-                    format!("{}_http_upstream_errors_total 0\n", &metrics_prefix).as_bytes()
+                    format!("{}_http_upstream_errors_total 0\n", &metrics_prefix).as_bytes(),
                 )
+                .next()
                 .is_some());
-                assert!(twoway::find_bytes(
+                assert!(memmem::find_iter(
                     bytes.as_ref(),
-                    format!("{}_http_upstream_requests_total 0\n", &metrics_prefix).as_bytes()
+                    format!("{}_http_upstream_requests_total 0\n", &metrics_prefix).as_bytes(),
                 )
+                .next()
                 .is_some());
             } else {
                 bail!("expected Body")

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -25,5 +25,5 @@ thrift = "0.13"
 actix-service = "2.0.0-beta.4"
 
 [dev-dependencies]
-twoway = "^0.2"
+memchr = "^2.4"
 mockito = "^0.30.0"

--- a/commons/src/metrics.rs
+++ b/commons/src/metrics.rs
@@ -50,6 +50,7 @@ pub fn new_registry(prefix: Option<String>) -> Fallible<Registry> {
 mod tests {
     use super::*;
     use crate::testing;
+    use memchr::memmem;
 
     #[test]
     fn serve_metrics_basic() -> Fallible<()> {
@@ -69,10 +70,11 @@ mod tests {
         if let actix_web::body::ResponseBody::Body(body) = resp.body() {
             if let actix_web::body::Body::Bytes(bytes) = body {
                 assert!(!bytes.is_empty());
-                assert!(twoway::find_bytes(
+                assert!(memmem::find_iter(
                     bytes.as_ref(),
                     format!("{}_dummy_gauge 42\n", metrics_prefix).as_bytes()
                 )
+                .next()
                 .is_some());
             } else {
                 bail!("expected Body")

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -43,7 +43,7 @@ actix-service = "2.0.0-beta.4"
 built = { version = "^0.5.0", features = [ "git2" ]}
 
 [dev-dependencies]
-twoway = "^0.2"
+memchr = "^2.4"
 
 [features]
 test-net = []

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -158,6 +158,7 @@ mod tests {
     use commons::metrics::RegistryWrapper;
     use commons::testing;
     use graph_builder::status::{serve_liveness, serve_readiness};
+    use memchr::memmem;
     use parking_lot::RwLock;
     use prometheus::Registry;
     use std::collections::HashSet;
@@ -195,7 +196,9 @@ mod tests {
                 assert!(!bytes.is_empty());
                 println!("{:?}", std::str::from_utf8(bytes.as_ref()));
                 assert!(
-                    twoway::find_bytes(bytes.as_ref(), b"cincinnati_gb_dummy_gauge 42\n").is_some()
+                    memmem::find_iter(bytes.as_ref(), b"cincinnati_gb_dummy_gauge 42\n")
+                        .next()
+                        .is_some()
                 );
             } else {
                 bail!("expected Body")

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -36,5 +36,5 @@ built = { version = "^0.5.0", features = [ "git2" ]}
 
 [dev-dependencies]
 tokio = { version = "1.6", features = [ "rt-multi-thread" ] }
-twoway = "^0.2"
+memchr = "^2.4"
 mockito = "^0.30.0"


### PR DESCRIPTION
twoway is deprecated and memchr is recommended.

See https://github.com/bluss/twoway/commit/e99b3c718df1117ad7f54c33f6540c8f46cc17dd