### PR TITLE
replace rust-toolset image with UBI

### DIFF
--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -1,14 +1,15 @@
-FROM registry.redhat.io/rhel8/rust-toolset:1.47.0 as rust_builder
+FROM registry.access.redhat.com/ubi8/ubi:latest as rust_builder
 WORKDIR /opt/app-root/src/
 COPY . .
 # copy git information for built crate
 COPY .git/ ./.git/
 USER 0
 RUN dnf update -y \
-    && dnf install -y jq \
+    && dnf install -y jq rust cargo \
+    && dnf install -y openssl-devel \
     && dnf clean all
 
-RUN bash -c "source /opt/app-root/etc/scl_enable && hack/build_e2e.sh"
+RUN hack/build_e2e.sh
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta


### PR DESCRIPTION
Now that rust-toolset image is deprecated, we need to replace it
with UBI image.
We can now install rust directly in UBI image