### PR TITLE
WIP Bump semver to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
  "quay",
  "regex",
  "reqwest",
- "semver 0.11.0",
+ "semver 1.0.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1442,7 +1442,7 @@ dependencies = [
  "quay",
  "regex",
  "reqwest",
- "semver 0.11.0",
+ "semver 1.0.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2320,7 +2320,7 @@ dependencies = [
  "openapiv3",
  "opentelemetry",
  "prometheus 0.12.0",
- "semver 0.11.0",
+ "semver 1.0.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2886,6 +2886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
+ "serde",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
+dependencies = [
  "serde",
 ]
 

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.6", features = [ "time", "fs", "macros", "rt-multi-thread
 tokio-stream = { version = "0.1", features = ["fs"] }
 toml = "^0.5"
 url = "^2.2"
-semver = { version = "^0.11", features = [ "serde" ] }
+semver = { version = "^1.0", features = [ "serde" ] }
 async-trait = "^0.1"
 tempfile = "^3.1.0"
 flate2 = "^1.0.1"

--- a/cincinnati/src/plugins/internal/arch_filter.rs
+++ b/cincinnati/src/plugins/internal/arch_filter.rs
@@ -135,7 +135,7 @@ impl InternalPlugin for ArchFilterPlugin {
                     semver::Version::parse(&release_version)
                         .context(release_version.clone())
                         .map(|mut version| {
-                            version.build.retain(|elem| elem.to_string() != arch);
+                            version.build = semver::BuildMetadata::new(&arch).unwrap();
                             trace!("rewriting version {} ->  {}", release_version, version);
                             version.to_string()
                         })?

--- a/cincinnati/src/plugins/internal/edge_add_remove.rs
+++ b/cincinnati/src/plugins/internal/edge_add_remove.rs
@@ -320,7 +320,7 @@ fn try_annotate_semver_build(
         .get("io.openshift.upgrades.graph.release.arch")
     {
         let mut version = semver::Version::parse(version)?;
-        version.build = vec![semver::Identifier::AlphaNumeric(arch.to_string())];
+        version.build = semver::BuildMetadata::new(arch).unwrap();
         version.to_string()
     } else {
         version.to_string()

--- a/cincinnati/src/plugins/internal/graph_builder/release.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release.rs
@@ -170,9 +170,9 @@ mod tests {
             source: "test-0.0.1".to_string(),
             metadata: Metadata {
                 kind: MetadataKind::V0,
-                version: semver::Version::from((0, 0, 1)),
+                version: semver::Version::new(0, 0, 1),
                 next: Default::default(),
-                previous: vec![semver::Version::from((0, 0, 0))],
+                previous: vec![semver::Version::new(0, 0, 0)],
                 metadata: Default::default(),
             },
         }];
@@ -190,15 +190,9 @@ mod tests {
             source: "test-0.0.1".to_string(),
             metadata: Metadata {
                 kind: MetadataKind::V0,
-                version: semver::Version::from((0, 0, 1)),
-                next: vec![
-                    semver::Version::from((0, 0, 2)),
-                    semver::Version::from((0, 0, 2)),
-                ],
-                previous: vec![
-                    semver::Version::from((0, 0, 0)),
-                    semver::Version::from((0, 0, 0)),
-                ],
+                version: semver::Version::new(0, 0, 1),
+                next: vec![semver::Version::new(0, 0, 2), semver::Version::new(0, 0, 2)],
+                previous: vec![semver::Version::new(0, 0, 0), semver::Version::new(0, 0, 0)],
                 metadata: Default::default(),
             },
         }];
@@ -225,7 +219,7 @@ mod tests {
             source: "test-0.0.1".to_string(),
             metadata: Metadata {
                 kind: MetadataKind::V0,
-                version: semver::Version::from((0, 0, 1)),
+                version: semver::Version::new(0, 0, 1),
                 next: Default::default(),
                 previous: Default::default(),
                 metadata: valid,
@@ -236,7 +230,7 @@ mod tests {
             source: "test-0.0.1".to_string(),
             metadata: Metadata {
                 kind: MetadataKind::V0,
-                version: semver::Version::from((0, 0, 1)),
+                version: semver::Version::new(0, 0, 1),
                 next: Default::default(),
                 previous: Default::default(),
                 metadata: invalid,

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -405,7 +405,7 @@ async fn lookup_or_fetch(
                 // Process the manifest architecture if given
                 if let Some(arch) = arch {
                     // Encode the architecture as SemVer information
-                    metadata.version.build = vec![semver::Identifier::AlphaNumeric(arch.clone())];
+                    metadata.version.build = semver::BuildMetadata::new(&arch).unwrap();
 
                     // Attach the architecture for later processing
                     metadata

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -21,7 +21,7 @@ prometheus = "0.12"
 quay = { path = "../quay" }
 regex = "^1.5.4"
 reqwest = "^0.11"
-semver = { version = "^0.11", features = [ "serde" ] }
+semver = { version = "^1.0", features = [ "serde" ] }
 serde = "^1.0.126"
 serde_derive = "^1.0.70"
 serde_json = "^1.0.22"

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "^1.2.0"
 log = "^0.4.3"
 openapiv3 = "0.5"
 prometheus = "0.12"
-semver = { version = "^0.11", features = [ "serde" ] }
+semver = { version = "^1.0", features = [ "serde" ] }
 serde = "^1.0.126"
 serde_derive = "^1.0.70"
 serde_json = "^1.0.22"


### PR DESCRIPTION
https://crates.io/crates/semver was updated to 1.0 and changed the interface.

Supercedes #442

TODO:
* [ ] Fix `e2e_channel_success` tests