### PR TITLE
[dockerfile][deploy][build] use /root as WORKDIR

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -14,6 +14,8 @@ RUN yum update -y && \
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
+WORKDIR ${HOME}
+
 # build: Rust stable toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.50.0 -y && \
   rustup install 1.46.0
@@ -29,8 +31,8 @@ COPY .git/ ./.git/
 
 RUN cargo build --release && \
     mkdir -p /opt/cincinnati/bin && \
-    cp -rvf target/release/graph-builder /opt/cincinnati/bin && \
-    cp -rvf target/release/policy-engine /opt/cincinnati/bin
+    cp -rvf $HOME/target/release/graph-builder /opt/cincinnati/bin && \
+    cp -rvf $HOME/target/release/policy-engine /opt/cincinnati/bin
 
 FROM registry.centos.org/centos/centos:7
 


### PR DESCRIPTION
use `/root` as WORKDIR instead of current `/`.
this change is particularly needed as using `/` is the cause
for missing git information from `graph-builder` and
`policy-engine` binary.