### PR TITLE
Clean up approvers list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,17 +10,11 @@ aliases:
     - jottofar
     - PratikMahajan
   app-sre:
-    - aditya-konarde
     - jfchevrette
     - jmelis
-    - jakedt
-    - jzelinskie
     - maorfr
-    - mmclanerh
     - pbergene
     - skryzhny
-    - tparikh
     - rrati
-    - arilivigni
     - erdii
   cincinnati-reviewers:


### PR DESCRIPTION
Moving on to a new role within Red Hat, so I no longer need this access.

A bunch of other people also moved on to new roles, so removing their access too! 
Thank you for all the collaboration so far! :) 🙌