### PR TITLE
remove AppSRE from being approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,5 @@
 
 approvers:
   - cincinnati-approvers
-  - app-sre
 reviewers:
   - cincinnati-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,12 +9,4 @@ aliases:
     - LalatenduMohanty
     - jottofar
     - PratikMahajan
-  app-sre:
-    - jfchevrette
-    - jmelis
-    - maorfr
-    - pbergene
-    - skryzhny
-    - rrati
-    - erdii
   cincinnati-reviewers:


### PR DESCRIPTION
When things started out and we had just a few services to run, it made sense that we attempt to be approvers on each of the repositories.
As we manage dozens of services with hundreds of repos, this approach no longer scales and we had decided to not proceed with it. Here is the MR to our onboarding docs which removes this section: https://gitlab.cee.redhat.com/service/app-interface/-/commit/5dd6d564a822ee05eedb7622ea672ea6cc37ebf7

As such, I am submitting this PR to remove all of AppSRE from being approvers.