### PR TITLE
hack: use valid data for dummy secret

### DIFF
--- a/hack/deploy_cincinnati.sh
+++ b/hack/deploy_cincinnati.sh
@@ -12,7 +12,7 @@ export IMAGE_TAG=90efacd
 oc new-project cincinnati
 
 # Create a dummy secret as a workaround to not having real secrets
-oc create secret generic cincinnati-credentials --from-literal=""
+oc create secret generic cincinnati-credentials --from-literal="foo=bar"
 
 
 # Apply oc template

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -55,7 +55,7 @@ backoff oc new-project cincinnati-e2e
 backoff oc project cincinnati-e2e
 
 # Create a dummy secret as a workaround to not having real secrets in e2e
-backoff oc create secret generic cincinnati-credentials --from-literal=""
+backoff oc create secret generic cincinnati-credentials --from-literal="foo=bar"
 
 # Use this pull secret to fetch images from CI
 backoff oc create secret generic ci-pull-secret --from-file=.dockercfg=${PULL_SECRET} --type=kubernetes.io/dockercfg

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -45,6 +45,7 @@ function backoff() {
 PULL_SECRET=${PULL_SECRET:-/var/run/secrets/ci.openshift.io/cluster-profile/pull-secret}
 
 set -euo pipefail
+set -x
 # Copy KUBECONFIG so that it can be mutated
 cp -Lrvf $KUBECONFIG /tmp/kubeconfig
 export KUBECONFIG=/tmp/kubeconfig


### PR DESCRIPTION
`oc create secret` no longer allows empty `--from-literal`. This change adds a dummy value for it to pass.

This PR also prints commands executed so that we'd know where it breaks next time