### PR TITLE
Update Rust to 1.56/1.52 and use UBI in rust-toolset

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -17,8 +17,8 @@ ENV PATH="${HOME}/.cargo/bin:${PATH}"
 WORKDIR ${HOME}
 
 # build: Rust stable toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.53.0 -y && \
-  rustup install 1.49.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.56.0 -y && \
+  rustup install 1.52.0
 
 RUN \
   mkdir -p $HOME/.cargo/git/ && \

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -15,8 +15,8 @@ ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 # build: Rust stable toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.53.0 -y && \
-  rustup install 1.49.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.56.0 -y && \
+  rustup install 1.52.0
 
 RUN \
   mkdir -p $HOME/.cargo/git/ && \

--- a/dist/Dockerfile.rust-toolset/Dockerfile
+++ b/dist/Dockerfile.rust-toolset/Dockerfile
@@ -1,11 +1,14 @@
-FROM registry.redhat.io/rhel8/rust-toolset:1.47.0 as builder
+FROM registry.access.redhat.com/ubi8/ubi:latest as builder
 WORKDIR /opt/app-root/src/
 COPY . .
 # copy git information for built crate
 COPY .git/ ./.git/
-
 USER 0
-RUN bash -c "source /opt/app-root/etc/scl_enable && cargo build --release" \
+RUN dnf update -y \
+    && dnf install -y jq rust cargo \
+    && dnf install -y openssl-devel \
+    && dnf clean all \
+    && cargo build --release \
     && mkdir -p /opt/cincinnati/bin \
     && cp -rvf target/release/graph-builder /opt/cincinnati/bin \
     && cp -rvf target/release/policy-engine /opt/cincinnati/bin


### PR DESCRIPTION
Dedicated Rust UBI image was deprecated, we should be installing Rust for UBI