### PR TITLE
e2e: don't wait for UWM to start

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -73,9 +73,6 @@ backoff oc -n openshift-monitoring \
         --from-literal='config.yaml={"enableUserWorkload": true}' -o yaml --dry-run=client > /tmp/cluster-monitoring-config.yaml
 backoff oc apply -f /tmp/cluster-monitoring-config.yaml
 
-# Wait for user workload monitoring is deployed
-backoff oc -n openshift-user-workload-monitoring wait --for=condition=Ready pod -l app=thanos-ruler
-
 # Import observability template
 # ServiceMonitors are imported before app deployment to give Prometheus time to catch up with
 # metrics


### PR DESCRIPTION
Skip waiting for UWM to come up as this command is flaking a lot. This is a core platform bug and should be reported instead of being retried.

Instead we'll notice failures in SLO tests