### PR TITLE
openshift_secondary_metadata_parser: Accept graph-data 1.1.0

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -7,7 +7,7 @@ use self::cincinnati::plugins::prelude_plugin_impl::*;
 use std::collections::HashSet;
 
 pub static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
-static SUPPORTED_VERSIONS: &[&str] = &["1.0.0"];
+static SUPPORTED_VERSIONS: &[&str] = &["1.0.0", "1.1.0"];
 
 pub mod graph_data_model {
     //! This module contains the data types corresponding to the graph data files.


### PR DESCRIPTION
Ideally this would be parsed as SemVer with appropriate compatability resolution ([minor bumps are backwards compatible][1]).  But doing that in Rust in a few minutes is beyond my abilities.  This temporary hack unblocks the 1.1.0 graph-data migration, avoiding:

    2021-09-21T13:09:26Z ERROR graph_builder::graph] unrecognized graph-data version 1.1.0
      ; supported versions: ["1.0.0"]

until we can get that SemVer parser in place.

[1]: https://semver.org/spec/v2.0.0.html#spec-item-7