### PR TITLE
openshift_secondary_metadata_parser: Accept graph-data 1.1.0

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -7,7 +7,7 @@ use self::cincinnati::plugins::prelude_plugin_impl::*;
 use std::collections::HashSet;
 
 pub static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
-static SUPPORTED_VERSIONS: &[&str] = &["1.0.0"];
+static SUPPORTED_VERSIONS: &[&str] = &["1.0.0", "1.1.0"];
 
 pub mod graph_data_model {
     //! This module contains the data types corresponding to the graph data files.


### PR DESCRIPTION
Backporting #538 to 4.9.