### PR TITLE
change the prometheus `endpoint` label to `uri_path` due to conflict

### DIFF
--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -67,7 +67,7 @@ lazy_static! {
     static ref GRAPH_INCOMING_REQS: IntCounterVec = IntCounterVec::new(
         Opts::new("graph_incoming_requests_total",
         "Total number of incoming HTTP client request"),
-        &["endpoint"]
+        &["uri_path"]
     )
     .unwrap();
     static ref BUILD_INFO: Counter = Counter::with_opts(opts!(

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -20,7 +20,7 @@ lazy_static! {
     static ref GRAPH_INCOMING_REQS: IntCounterVec = IntCounterVec::new(
         Opts::new("graph_incoming_requests_total",
         "Total number of incoming HTTP client request"),
-        &["endpoint"]
+        &["uri_path"]
     )
     .unwrap();
     // Histogram with custom bucket values for serving latency metric (in seconds), values are picked based on monthly data


### PR DESCRIPTION
there is a prometheus label with `endpoint`.
Before this commit, series labels looked like:
```
cincinnati_pe_graph_incoming_requests_total{container="cincinnati-policy-engine",endpoint="status-pe",exported_endpoint="/api/upgrades_info/graph",instance="10.130.2.191:9081",job="cincinnati-policy-engine",namespace="cincinnati-stage",pod="cincinnati-248-9k69d",service="cincinnati-policy-engine"}
```
this commit will change the `exported_endpoint` label to `uri_path`