### PR TITLE
Version the Cincinnati Graph

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -751,6 +751,7 @@ impl From<Graph> for plugins::interface::Graph {
 #[cfg(any(test, feature = "test"))]
 pub mod testing {
     use super::*;
+    use crate::plugins::internal::versioned_graph::VersionedGraph;
 
     pub fn generate_graph() -> Graph {
         let mut graph = Graph::default();
@@ -925,6 +926,22 @@ pub mod testing {
         pub payload_replace_sha_by_tag_left: bool,
         pub payload_replace_sha_by_tag_right: bool,
         pub payload_remove_registry_and_repo: bool,
+    }
+
+    /// Compares two Versioned Graphs and gives a verbose error if not equal
+    pub fn compare_versioned_graphs_verbose(
+        versioned_left: VersionedGraph,
+        versioned_right: VersionedGraph,
+        settings: CompareGraphsVerboseSettings,
+    ) -> Fallible<()> {
+        if versioned_left.version != versioned_right.version {
+            bail!(
+                "graph version mismatch left: {}, right {}",
+                versioned_left.version,
+                versioned_right.version
+            )
+        }
+        return compare_graphs_verbose(versioned_left.graph, versioned_right.graph, settings);
     }
 
     /// Compares two Graphs and gives a verbose error if not equal.

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -43,8 +43,7 @@ pub use std::collections::BTreeMap as MapImpl;
 pub use std::collections::BTreeSet as SetImpl;
 
 /// Graph type which stores `Release` as node-weights and `Empty` as edge-weights.
-#[derive(Debug, Default)]
-#[cfg_attr(any(test, feature = "test"), derive(Clone))]
+#[derive(Debug, Default, Clone)]
 pub struct Graph {
     dag: Dag<Release, Empty>,
 }

--- a/cincinnati/src/plugins/internal/mod.rs
+++ b/cincinnati/src/plugins/internal/mod.rs
@@ -6,6 +6,7 @@ pub mod cincinnati_graph_fetch;
 pub mod edge_add_remove;
 pub mod metadata_fetch_quay;
 pub mod node_remove;
+pub mod versioned_graph;
 
 mod graph_builder;
 

--- a/cincinnati/src/plugins/internal/versioned_graph.rs
+++ b/cincinnati/src/plugins/internal/versioned_graph.rs
@@ -1,0 +1,32 @@
+use self::cincinnati::plugins::prelude_plugin_impl::*;
+use crate as cincinnati;
+use commons::{CINCINNATI_VERSION, MIN_CINCINNATI_VERSION};
+
+#[derive(Debug, Serialize, Deserialize, SmartDefault)]
+#[serde(default)]
+pub struct VersionedGraph {
+    version: i32,
+    #[serde(flatten)]
+    graph: cincinnati::Graph,
+}
+
+impl VersionedGraph {
+    pub const PLUGIN_NAME: &'static str = "versioned-graph";
+
+    pub fn versioned_graph(io: &InternalIO) -> Fallible<VersionedGraph> {
+        let min_version = match CINCINNATI_VERSION.get(*MIN_CINCINNATI_VERSION) {
+            Some(version) => *version,
+            None => bail!("error parsing minimum cincinnati version"),
+        };
+        Ok(VersionedGraph {
+            version: match io.parameters.get("content_type") {
+                None => min_version,
+                Some(v) => match CINCINNATI_VERSION.get(v.as_str()) {
+                    Some(version) => *version,
+                    None => min_version,
+                },
+            },
+            graph: io.graph.clone(),
+        })
+    }
+}

--- a/cincinnati/src/plugins/internal/versioned_graph.rs
+++ b/cincinnati/src/plugins/internal/versioned_graph.rs
@@ -5,9 +5,9 @@ use commons::{CINCINNATI_VERSION, MIN_CINCINNATI_VERSION};
 #[derive(Debug, Serialize, Deserialize, SmartDefault)]
 #[serde(default)]
 pub struct VersionedGraph {
-    version: i32,
+    pub version: i32,
     #[serde(flatten)]
-    graph: cincinnati::Graph,
+    pub graph: cincinnati::Graph,
 }
 
 impl VersionedGraph {
@@ -28,5 +28,86 @@ impl VersionedGraph {
             },
             graph: io.graph.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate as cincinnati;
+    use std::collections::HashMap;
+
+    use super::*;
+    use cincinnati::testing::{generate_custom_graph, TestMetadata};
+    use commons::testing::init_runtime;
+    use commons::MIN_CINCINNATI_VERSION;
+
+    fn get_min_version() -> Fallible<i32> {
+        match CINCINNATI_VERSION.get(*MIN_CINCINNATI_VERSION) {
+            Some(version) => Ok(*version),
+            None => bail!("error parsing minimum cincinnati version"),
+        }
+    }
+
+    #[test]
+    fn min_version_if_missing() -> Fallible<()> {
+        let _ = init_runtime()?;
+
+        let input_graph: cincinnati::Graph = {
+            let metadata: TestMetadata = vec![(1, [].iter().cloned().collect())];
+            generate_custom_graph("image", metadata, None)
+        };
+
+        let versioned_graph = VersionedGraph::versioned_graph(&InternalIO {
+            graph: input_graph,
+            parameters: Default::default(),
+        })
+        .unwrap();
+
+        assert_eq!(versioned_graph.version, get_min_version().unwrap());
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_min_on_unsupported() -> Fallible<()> {
+        let _ = init_runtime()?;
+
+        let input_graph: cincinnati::Graph = {
+            let metadata: TestMetadata = vec![(1, [].iter().cloned().collect())];
+            generate_custom_graph("image", metadata, None)
+        };
+
+        let mut plugin_params: HashMap<String, String> = HashMap::new();
+        plugin_params.insert(String::from("version"), "application/json".to_string());
+
+        let versioned_graph = VersionedGraph::versioned_graph(&InternalIO {
+            graph: input_graph,
+            parameters: plugin_params,
+        })
+        .unwrap();
+
+        assert_eq!(versioned_graph.version, get_min_version().unwrap());
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_version_1() -> Fallible<()> {
+        let _ = init_runtime()?;
+
+        let input_graph: cincinnati::Graph = {
+            let metadata: TestMetadata = vec![(1, [].iter().cloned().collect())];
+            generate_custom_graph("image", metadata, None)
+        };
+
+        let mut plugin_params: HashMap<String, String> = HashMap::new();
+        plugin_params.insert(String::from("version"), MIN_CINCINNATI_VERSION.to_string());
+
+        let versioned_graph = VersionedGraph::versioned_graph(&InternalIO {
+            graph: input_graph,
+            parameters: plugin_params,
+        })
+        .unwrap();
+
+        assert_eq!(versioned_graph.version, 1);
+        Ok(())
     }
 }

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -109,8 +109,8 @@ pub enum PluginResult {
 }
 
 /// Struct used by the ExternalPlugin trait impl's
-#[derive(Debug)]
-#[cfg_attr(test, derive(Clone, PartialEq))]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct InternalIO {
     pub graph: cincinnati::Graph,
     pub parameters: HashMap<String, String>,

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -25,8 +25,20 @@ pub mod prelude_errors {
 }
 
 use actix_web::http::{header, HeaderMap};
+use std::collections::HashMap;
 use std::collections::HashSet;
 use url::form_urlencoded;
+
+lazy_static! {
+    /// list of cincinnati versions
+    pub static ref CINCINNATI_VERSION: HashMap<&'static str, i32> =
+        [("application/vnd.redhat.cincinnati.v1+json", 1)]
+            .iter()
+            .cloned()
+            .collect();
+    /// minimum cincinnati version supported
+    pub static ref MIN_CINCINNATI_VERSION: &'static str = "application/vnd.redhat.cincinnati.v1+json";
+}
 
 /// Strip all but one leading slash and all trailing slashes
 pub fn parse_path_prefix<S>(path_prefix: S) -> String
@@ -94,34 +106,57 @@ pub fn ensure_query_params(
 /// Make sure the client can accept the provided media type.
 pub fn validate_content_type(
     headers: &HeaderMap,
-    content_type: &'static str,
-) -> Result<(), GraphError> {
+    mut content_type: Vec<actix_web::http::HeaderValue>,
+    accept_default: actix_web::http::HeaderValue,
+) -> Result<String, GraphError> {
     let header_value = match headers.get(header::ACCEPT) {
-        None => return Ok(()),
+        None => {
+            let minimum_version = MIN_CINCINNATI_VERSION.to_string();
+            return Ok(minimum_version);
+        }
         Some(v) => v,
     };
 
-    let full_type = header::HeaderValue::from_static(content_type);
     let wildcard = header::HeaderValue::from_static("*");
     let double_wildcard = header::HeaderValue::from_static("*/*");
-    let top_type = content_type.split("/").next().unwrap_or("");
-    let top_type_wildcard = header::HeaderValue::from_str(&format!("{}/*", top_type));
-    assert!(
-        top_type_wildcard.is_ok(),
-        "could not form top-type wildcard from {}",
-        top_type
-    );
 
-    let acceptable_content_types: Vec<actix_web::http::HeaderValue> = vec![
-        full_type,
-        wildcard,
-        double_wildcard,
-        top_type_wildcard.unwrap(),
-    ];
+    let mut top_types: Vec<actix_web::http::HeaderValue> = content_type
+        .iter()
+        .map(|ct| {
+            let top_type = ct.to_str().unwrap_or("").split("/").next().unwrap_or("");
+            let top_type_wildcard = header::HeaderValue::from_str(&format!("{}/*", top_type));
+            assert!(
+                top_type_wildcard.is_ok(),
+                "could not form top-type wildcard from {}",
+                top_type
+            );
+            top_type_wildcard.unwrap()
+        })
+        .collect();
+
+    let mut acceptable_content_types: Vec<actix_web::http::HeaderValue> =
+        vec![wildcard, double_wildcard, accept_default.clone()];
+    acceptable_content_types.append(&mut content_type);
+    acceptable_content_types.append(&mut top_types);
 
     // FIXME: this is not a full-blown Accept parser
     if acceptable_content_types.iter().any(|c| c == header_value) {
-        Ok(())
+        return if header_value
+            .to_str()
+            .unwrap_or("")
+            .split("/")
+            .any(|i| i == "*")
+        {
+            Ok(header::HeaderValue::to_str(&accept_default)
+                .unwrap()
+                .parse()
+                .unwrap())
+        } else {
+            match header::HeaderValue::to_str(header_value) {
+                Ok(a) => Ok(a.parse().unwrap()),
+                Err(_e) => Ok(MIN_CINCINNATI_VERSION.to_string()),
+            }
+        };
     } else {
         Err(GraphError::InvalidContentType)
     }

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -26,17 +26,19 @@ fn e2e_channel_success(channel: &'static str, arch: &'static str) {
         .unwrap();
     let runtime = commons::testing::init_runtime().unwrap();
 
-    let expected: cincinnati::Graph = serde_json::from_str(testdata).unwrap();
+    let expected: cincinnati::plugins::internal::versioned_graph::VersionedGraph =
+        serde_json::from_str(testdata).unwrap();
 
     let res = run_graph_query(channel, arch, &runtime);
 
     assert_eq!(res.status().is_success(), true, "{}", res.status());
     let text = runtime.block_on(res.text()).unwrap();
-    let actual: cincinnati::Graph = serde_json::from_str(&text)
-        .context(format!("Failed to parse '{}' as json", text))
-        .unwrap();
+    let actual: cincinnati::plugins::internal::versioned_graph::VersionedGraph =
+        serde_json::from_str(&text)
+            .context(format!("Failed to parse '{}' as json", text))
+            .unwrap();
 
-    if let Err(e) = cincinnati::testing::compare_graphs_verbose(
+    if let Err(e) = cincinnati::testing::compare_versioned_graphs_verbose(
         expected,
         actual,
         cincinnati::testing::CompareGraphsVerboseSettings {

--- a/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.2_amd64.json
+++ b/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.2_amd64.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "nodes": [
     {
       "version": "4.1.20",

--- a/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.2_s390x.json
+++ b/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.2_s390x.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "nodes": [
     {
       "version": "4.2.11-s390x",

--- a/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.3_amd64.json
+++ b/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.3_amd64.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "nodes": [
     {
       "version": "4.2.16",

--- a/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.3_s390x.json
+++ b/e2e/tests/testdata/b87e7c2782837a3538b0aa3dceb9e8133765ec81_stable-4.3_s390x.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "nodes": [
     {
       "version": "4.3.18",

--- a/graph-builder/src/graph.rs
+++ b/graph-builder/src/graph.rs
@@ -14,6 +14,7 @@
 
 use crate::built_info;
 use crate::config;
+use actix_web::http::header;
 use actix_web::{HttpRequest, HttpResponse};
 use cincinnati::plugins::prelude::*;
 use cincinnati::CONTENT_TYPE;
@@ -108,8 +109,14 @@ pub async fn index(
     let path = req.uri().path();
     GRAPH_INCOMING_REQS.with_label_values(&[path]).inc();
 
-    // Check that the client can accept JSON media type.
-    commons::validate_content_type(req.headers(), CONTENT_TYPE)?;
+    let accept_default = header::HeaderValue::from_static(CONTENT_TYPE);
+
+    // Check that the client can accept media type.
+    let _content_type: String = commons::validate_content_type(
+        req.headers(),
+        vec![accept_default.clone()],
+        accept_default,
+    )?;
 
     // Check for required client parameters.
     let mandatory_params = &app_data.mandatory_params;


### PR DESCRIPTION
This PR versions the cincinnati graph and embeds
the version information into cincinnati graph json.

This commit includes changes that will let us accept
proactive negotiation using ACCEPT header value.
eg. `ACCEPT: application/vnd.redhat.cincinnati.v1+json`

The resultant graph should look like this 
```json
{
"edges":[...],
"nodes": [...],
"version":1
}
```