### PR TITLE
reduce graph-fetch timeout to 10 seconds

### DIFF
--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 pub static DEFAULT_UPSTREAM_URL: &str = "http://localhost:8080/graph";
 
 /// Default graph-builder connection timeout in seconds.
-pub static DEFAULT_TIMEOUT_SECS: u64 = 30;
+pub static DEFAULT_TIMEOUT_SECS: u64 = 10;
 
 /// Plugin settings.
 #[derive(Clone, CustomDebug, Deserialize, SmartDefault)]


### PR DESCRIPTION
reduce the graph-fetch plugin timeout to 10 seconds to
keep it in sync with keep-alive time of graph-builder.

this is to address the `connection closed before message
completed error`