### PR TITLE
fix manifestref error if digest value missing

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -75,12 +75,16 @@ impl Release {
     }
 
     /// Returns the `manifestref` of a given `Release`
-    pub fn manifestref(&self) -> Result<&String, Error> {
+    pub fn manifestref(&self) -> Result<String, Error> {
         let digestkey = String::from("io.openshift.upgrades.graph.release.manifestref");
         match self {
             Release::Concrete(release) => {
                 let digest = release.metadata.get(&digestkey);
-                Ok(digest.map(|d| d).unwrap())
+                let manifestref = match digest.map(|d| d) {
+                    Some(manifestref) => manifestref.clone(),
+                    None => String::from("no manifestref for release"),
+                };
+                Ok(manifestref)
             }
             _ => bail!("could not get manifest reference"),
         }


### PR DESCRIPTION
Currently if a ConcreteRelease is missing the manifestref digest,
Cincinnati tries to unwrap() this value which causes it to panic
becuase of the absense of digest.

This commit returns an invalid value for manifestref digest if
it is missing in the ConcreteRelease.
This will cause a mismatch in fn add_release() which will prevent
cincinnati from adding this release. Thus preventing the panic
and throwing an easily readable error.