### PR TITLE
Do not replace regex if .*

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -455,13 +455,38 @@ impl OpenshiftSecondaryMetadataParserPlugin {
                                 &to.to_string()
                             )) {
                                 Ok(metadata) => {
-                                    metadata.insert(
-                                        format!(
-                                            "{}.{}",
-                                            self.settings.key_prefix, "previous.remove_regex"
-                                        ),
-                                        blocked_edge.from.to_string(),
-                                    );
+                                    match metadata.get(&format!(
+                                        "{}.{}",
+                                        self.settings.key_prefix, "previous.remove_regex"
+                                    )) {
+                                        None => {
+                                            metadata.insert(
+                                                format!(
+                                                    "{}.{}",
+                                                    self.settings.key_prefix,
+                                                    "previous.remove_regex"
+                                                ),
+                                                blocked_edge.from.to_string(),
+                                            );
+                                        }
+                                        Some(value) => {
+                                            if value == ".*" {
+                                                warn!(
+                                                    "not replacing `.*` with {}",
+                                                    blocked_edge.from.to_string()
+                                                );
+                                            } else {
+                                                metadata.insert(
+                                                    format!(
+                                                        "{}.{}",
+                                                        self.settings.key_prefix,
+                                                        "previous.remove_regex"
+                                                    ),
+                                                    blocked_edge.from.to_string(),
+                                                );
+                                            }
+                                        }
+                                    }
                                 }
                                 Err(e) => warn!("{}", e),
                             };


### PR DESCRIPTION
if the block regex is `.*`, do not replace it with other entries.
this comes into play when we are blocking an edge by using multiple
regex.
for eg. for 4.7.4, there are two regex used, `.*` and `4\.6\..*`
In some cases, cincinnati would replace `.*` with `4\.6\..*` which
was causing cincinnati to create an incorrect and inconsistent graph.
this PR adds a condition to check if the existing regex is `.*` and
does not replace it with any other regex.