### PR TITLE
OTA-498: dist: prepare two templates

### DIFF
--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnat
 COPY --from=rust_builder /opt/cincinnati/bin/slo /usr/bin/cincinnati-e2e-slo
 COPY --from=rust_builder /opt/app-root/src/hack/e2e.sh hack/
 COPY --from=rust_builder /opt/app-root/src/dist/openshift/cincinnati.yaml dist/openshift/
+COPY --from=rust_builder /opt/app-root/src/dist/openshift/cincinnati-e2e.yaml dist/openshift/
 COPY --from=rust_builder /opt/app-root/src/dist/openshift/observability.yaml dist/openshift/
 COPY --from=golang_builder /usr/local/bin/vegeta /usr/bin
 COPY --from=rust_builder /opt/app-root/src/hack/load-testing.sh /usr/local/bin/load-testing.sh

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -51,6 +51,7 @@ COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnat
 COPY --from=rust_builder /opt/cincinnati/bin/slo /usr/bin/cincinnati-e2e-slo
 COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/e2e.sh hack/
 COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/cincinnati.yaml dist/openshift/
+COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/cincinnati-e2e.yaml dist/openshift/
 COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/observability.yaml dist/openshift/
 COPY --from=golang_builder /usr/local/bin/vegeta /usr/bin
 COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/load-testing.sh /usr/local/bin/load-testing.sh

--- a/dist/openshift/cincinnati-e2e.yaml
+++ b/dist/openshift/cincinnati-e2e.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: cincinnati
+objects:
+  - apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: openshift-update-service
+      annotations:
+        olm.providedAPIs: ''
+    spec: {}
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      labels:
+        operators.coreos.com/cincinnati-operator.openshift-update-service: ''
+      name: cincinnati-operator
+    spec:
+      channel: v1
+      installPlanApproval: Automatic
+      name: cincinnati-operator
+      source: redhat-operators
+      sourceNamespace: openshift-marketplace
+      config:
+        env:
+          - name: RELATED_IMAGE_OPERAND
+            value: "${IMAGE}:${IMAGE_TAG}"
+  - apiVersion: updateservice.operator.openshift.io/v1
+    kind: UpdateService
+    metadata:
+      name: e2e
+    spec:
+      graphDataImage: ${GRAPHDATA_IMAGE}
+      releases: quay.io/openshift-release-dev/ocp-release
+      replicas: ${{REPLICAS}}
+parameters:
+  - name: IMAGE
+    value: "quay.io/app-sre/cincinnati"
+    displayName: cincinnati image
+    description: cincinnati docker image. Defaults to quay.io/app-sre/cincinnati
+  - name: IMAGE_TAG
+    value: "latest"
+    displayName: cincinnati version
+    description: cincinnati version which defaults to latest
+  - name: GRAPHDATA_IMAGE
+    value: "registry.ci.openshift.org/cincinnati-ci-public/cincinnati-graph-data:stable"
+    description: cincinnati-graph-data image pullspec
+  - name: REPLICAS
+    value: "2"
+  - name: GB_LOG_VERBOSITY
+    value: "vvv"
+    displayName: Graph builder log verbosity. Deprecated
+  - name: PE_LOG_VERBOSITY
+    value: "vv"
+    displayName: Policy engine log verbosity. Deprecated
+  - name: PE_MEMORY_LIMIT
+    value: "1G"
+    displayName: Policy engine memory limit. Deprecated

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -4,37 +4,249 @@ kind: Template
 metadata:
   name: cincinnati
 objects:
-  - apiVersion: operators.coreos.com/v1
-    kind: OperatorGroup
-    metadata:
-      name: openshift-update-service
-      annotations:
-        olm.providedAPIs: ''
-    spec: {}
-  - apiVersion: operators.coreos.com/v1alpha1
-    kind: Subscription
+  - apiVersion: v1
+    kind: DeploymentConfig
     metadata:
       labels:
-        operators.coreos.com/cincinnati-operator.openshift-update-service: ''
-      name: cincinnati-operator
+        app: cincinnati
+      name: cincinnati
     spec:
-      channel: v1
-      installPlanApproval: Automatic
-      name: cincinnati-operator
-      source: redhat-operators
-      sourceNamespace: openshift-marketplace
-      config:
-        env:
-          - name: RELATED_IMAGE_OPERAND
-            value: "${IMAGE}:${IMAGE_TAG}"
-  - apiVersion: updateservice.operator.openshift.io/v1
-    kind: UpdateService
-    metadata:
-      name: e2e
-    spec:
-      graphDataImage: ${GRAPHDATA_IMAGE}
-      releases: quay.io/openshift-release-dev/ocp-release
       replicas: ${{REPLICAS}}
+      selector:
+        app: cincinnati
+        deploymentconfig: cincinnati
+      strategy:
+        rollingParams:
+          intervalSeconds: 1
+          maxSurge: 25%
+          maxUnavailable: 25%
+          timeoutSeconds: 1200
+          updatePeriodSeconds: 1
+        type: Rolling
+      template:
+        metadata:
+          labels:
+            app: cincinnati
+            deploymentconfig: cincinnati
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - cincinnati
+                    topologyKey: kubernetes.io/hostname
+          containers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: Always
+              name: cincinnati-graph-builder
+              env:
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: gb.rust_backtrace
+                      name: cincinnati
+              envFrom:
+                - configMapRef:
+                    name: environment-secrets
+              command:
+                - ${GB_BINARY}
+              args: [
+                "-c", "${GB_CONFIG_PATH}"
+              ]
+              ports:
+                - name: graph-builder
+                  containerPort: ${{GB_PORT}}
+                - name: status-gb
+                  containerPort: ${{GB_STATUS_PORT}}
+              livenessProbe:
+                httpGet:
+                  path: /liveness
+                  port: ${{GB_STATUS_PORT}}
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 3
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: ${{GB_STATUS_PORT}}
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 3
+              resources:
+                limits:
+                  cpu: ${GB_CPU_LIMIT}
+                  memory: ${GB_MEMORY_LIMIT}
+                requests:
+                  cpu: ${GB_CPU_REQUEST}
+                  memory: ${GB_MEMORY_REQUEST}
+              volumeMounts:
+                - name: secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: configs
+                  mountPath: /etc/configs
+                  readOnly: true
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: cincinnati-policy-engine
+              imagePullPolicy: Always
+              env:
+                - name: ADDRESS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.address
+                      name: cincinnati
+                - name: PE_STATUS_ADDRESS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.status.address
+                      name: cincinnati
+                - name: UPSTREAM
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.upstream
+                      name: cincinnati
+                - name: PE_LOG_VERBOSITY
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.log.verbosity
+                      name: cincinnati
+                - name: "PE_MANDATORY_CLIENT_PARAMETERS"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.mandatory_client_parameters
+                      name: cincinnati
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.rust_backtrace
+                      name: cincinnati
+              command:
+                - ${PE_BINARY}
+              args: [
+                "-$(PE_LOG_VERBOSITY)",
+                "--service.address", "$(ADDRESS)",
+                "--service.mandatory_client_parameters", "$(PE_MANDATORY_CLIENT_PARAMETERS)",
+                "--service.path_prefix", "${PE_PATH_PREFIX}",
+                "--service.port", "${PE_PORT}",
+                "--status.address", "$(PE_STATUS_ADDRESS)",
+                "--status.port", "${PE_STATUS_PORT}",
+                "--upstream.cincinnati.url", "$(UPSTREAM)",
+              ]
+              ports:
+                - name: policy-engine
+                  containerPort: ${{PE_PORT}}
+                - name: status-pe
+                  containerPort: ${{PE_STATUS_PORT}}
+              livenessProbe:
+                tcpSocket:
+                  port: ${{PE_PORT}}
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 3
+              resources:
+                limits:
+                  cpu: ${PE_CPU_LIMIT}
+                  memory: ${PE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${PE_CPU_REQUEST}
+                  memory: ${PE_MEMORY_REQUEST}
+          volumes:
+            - name: secrets
+              secret:
+                secretName: cincinnati-credentials
+            - name: configs
+              configMap:
+                name: cincinnati-configs
+      triggers:
+        - type: ConfigChange
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cincinnati-graph-builder
+      labels:
+        app: cincinnati-graph-builder
+    spec:
+      ports:
+        - name: graph-builder
+          protocol: TCP
+          port: ${{GB_PORT}}
+          targetPort: ${{GB_PORT}}
+        - name: status-gb
+          protocol: TCP
+          port: ${{GB_STATUS_PORT}}
+          targetPort: ${{GB_STATUS_PORT}}
+      selector:
+        deploymentconfig: cincinnati
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cincinnati-policy-engine
+      labels:
+        app: cincinnati-policy-engine
+    spec:
+      ports:
+        - name: policy-engine
+          protocol: TCP
+          port: 80
+          targetPort: ${{PE_PORT}}
+        - name: status-pe
+          protocol: TCP
+          port: ${{PE_STATUS_PORT}}
+          targetPort: ${{PE_STATUS_PORT}}
+      selector:
+        deploymentconfig: cincinnati
+  - apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      name: cincinnati-pdb
+      namespace: cincinnati
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app: cincinnati
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cincinnati
+    data:
+      gb.rust_backtrace: "${RUST_BACKTRACE}"
+      pe.address: "0.0.0.0"
+      pe.status.address: "0.0.0.0"
+      pe.upstream: "http://localhost:8080/graph"
+      pe.log.verbosity: ${{PE_LOG_VERBOSITY}}
+      pe.mandatory_client_parameters: "channel"
+      pe.rust_backtrace: "${RUST_BACKTRACE}"
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: environment-secrets
+    data: ${{ENVIRONMENT_SECRETS}}
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cincinnati-configs
+    data:
+      gb.toml: |
+        verbosity = "${GB_LOG_VERBOSITY}"
+
+        [service]
+        scrape_timeout_secs = ${GB_SCRAPE_TIMEOUT_SECS}
+        pause_secs = ${GB_PAUSE_SECS}
+        address = "${GB_ADDRESS}"
+        port = ${GB_PORT}
+
+        [status]
+        address = "${GB_STATUS_ADDRESS}"
+        port = ${GB_STATUS_PORT}
+
+        ${GB_PLUGIN_SETTINGS}
 parameters:
   - name: IMAGE
     value: "quay.io/app-sre/cincinnati"
@@ -44,17 +256,112 @@ parameters:
     value: "latest"
     displayName: cincinnati version
     description: cincinnati version which defaults to latest
-  - name: GRAPHDATA_IMAGE
-    value: "registry.ci.openshift.org/cincinnati-ci-public/cincinnati-graph-data:stable"
-    description: cincinnati-graph-data image pullspec
-  - name: REPLICAS
-    value: "2"
+  - name: GB_MEMORY_LIMIT
+    value: "768Mi"
+    displayName: "Graph-builder memory limit"
+    description: "Maximum amount of memory (bytes) allowed for graph-builder (default: 523Mi)"
+  - name: GB_CPU_LIMIT
+    value: "750m"
+    displayName: "Graph-builder CPU limit"
+    description: "Maximum amount of CPU (millicores) allowed for graph-builder (default: 750m)"
+  - name: PE_MEMORY_LIMIT
+    value: "1Gi"
+    displayName: "Policy-engine memory limit"
+    description: "Maximum amount of memory (bytes) allowed for policy-engine (default: 512Mi)"
+  - name: PE_CPU_LIMIT
+    value: "750m"
+    displayName: "Policy-engine CPU limit"
+    description: "Maximum amount of CPU (millicores) allowed for policy-engine (default: 750m)"
+  - name: GB_MEMORY_REQUEST
+    value: "128Mi"
+    displayName: "Graph-builder memory request"
+    description: "Requested amount of memory (bytes) allowed for graph-builder (default: 128Mi)"
+  - name: GB_CPU_REQUEST
+    value: "350m"
+    displayName: "Graph-builder CPU request"
+    description: "Requested amount of CPU (millicores) allowed for graph-builder (default: 350m)"
+  - name: PE_MEMORY_REQUEST
+    value: "128Mi"
+    displayName: "Policy-engine memory request"
+    description: "Requested amount of memory (bytes) allowed for policy-engine (default: 128Mi)"
+  - name: PE_CPU_REQUEST
+    value: "350m"
+    displayName: "Policy-engine CPU request"
+    description: "Requested amount of CPU (millicores) allowed for policy-engine (default: 350m)"
+  - name: GB_SCRAPE_TIMEOUT_SECS
+    value: "300"
+    displayName: Graph-builder scrape timeout in seconds
+  - name: GB_PAUSE_SECS
+    value: "300"
+    displayName: Seconds to pause between scrapes
+  - name: GB_PORT
+    value: "8080"
+    displayName: Graph builder port
+  - name: GB_ADDRESS
+    value: "0.0.0.0"
+    displayName: Graph builder address
+  - name: GB_STATUS_ADDRESS
+    value: "0.0.0.0"
+    displayName: Graph builder status address
+  - name: GB_STATUS_PORT
+    value: "9080"
+    displayName: Graph builder status port
+  - name: GB_PATH_PREFIX
+    value: "/api/upgrades_info"
+    displayName: Graph builder path prefix
+  - name: PE_PORT
+    value: "8081"
+    displayName: Policy engine port
+  - name: PE_STATUS_PORT
+    value: "9081"
+    displayName: Policy engine status port
+  - name: PE_PATH_PREFIX
+    value: "/api/upgrades_info"
+    displayName: Policy engine path prefix
   - name: GB_LOG_VERBOSITY
     value: "vvv"
-    displayName: Graph builder log verbosity. Deprecated
+    displayName: Graph builder log verbosity
   - name: PE_LOG_VERBOSITY
     value: "vv"
-    displayName: Policy engine log verbosity. Deprecated
-  - name: PE_MEMORY_LIMIT
-    value: "1G"
-    displayName: Policy engine memory limit. Deprecated
+    displayName: Policy engine log verbosity
+  - name: GB_CINCINNATI_REPO
+    value: "openshift-release-dev/ocp-release"
+    displayName: Graph builder quay repo
+  - name: GB_BINARY
+    value: /usr/bin/graph-builder
+    displayName: Path to graph-builder binary
+  - name: PE_BINARY
+    value: /usr/bin/policy-engine
+    displayName: Path to policy-engine binary
+  - name: GB_PLUGIN_SETTINGS
+    displayName: Graph builder plugin settings, passed through verbatim.
+    value: |
+      [[plugin_settings]]
+      name = "release-scrape-dockerv2"
+      registry = "quay.io"
+      repository = "openshift-release-dev/ocp-release"
+      fetch_concurrency = 16
+      credentials_path = "/etc/secrets/registry_credentials_docker.json"
+
+      [[plugin_settings]]
+      name = "github-secondary-metadata-scrape"
+      github_org = "openshift"
+      github_repo = "cincinnati-graph-data"
+      reference_branch = "master"
+      output_directory = "/tmp/cincinnati/graph-data"
+      oauth_token_path = "/etc/secrets/github_token.key"
+
+      [[plugin_settings]]
+      name = "openshift-secondary-metadata-parse"
+
+      [[plugin_settings]]
+      name = "edge-add-remove"
+  - name: RUST_BACKTRACE
+    value: "0"
+    displayName: Set RUST_BACKTRACE env var
+  - name: GB_CONFIG_PATH
+    value: "/etc/configs/gb.toml"
+  - name: ENVIRONMENT_SECRETS
+    value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
+  - name: REPLICAS
+    value: "1"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -89,7 +89,7 @@ read -r E2E_METADATA_REVISION <"${E2E_TESTDATA_DIR}"/metadata_revision
 export E2E_METADATA_REVISION
 
 # Render the template and apply subscription/operand
-oc process -f dist/openshift/cincinnati.yaml \
+oc process -f dist/openshift/cincinnati-e2e.yaml \
   -p IMAGE="${IMAGE}" \
   -p IMAGE_TAG="${IMAGE_TAG}" \
   -p REPLICAS=2 \


### PR DESCRIPTION
`cincinnati.yaml` is a template which deploys Cincy traditionally (via DeploymentConfig) and used on stage/prod, `cincinnati-e2e` is an operator-based deployment for e2e tests