### PR TITLE
add graph-data dockerfile for e2es

### DIFF
--- a/e2e/tests/testdata/Dockerfile
+++ b/e2e/tests/testdata/Dockerfile
@@ -1,0 +1,6 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.1
+RUN dnf install git -y
+WORKDIR /home
+RUN git clone https://github.com/openshift/cincinnati-graph-data.git graph-data && cd graph-data && git checkout 421646a6e9592b179c26b3c77d406820c479a19c
+RUN mkdir -p /var/lib/cincinnati/graph-data
+CMD cp -rp graph-data/* /var/lib/cincinnati/graph-data


### PR DESCRIPTION
add the graph-data dockerfile to create a graph-data container
for cincinnati e2es.
this graph-data container created will be pinned to a specific
commit that we will be using for e2es.
the graphs for e2es will be generated based on this pinned
graph-data commit.