### PR TITLE
OTA-561: Make actix-web HttpServer settings configurable

### DIFF
--- a/policy-engine/src/config/settings.rs
+++ b/policy-engine/src/config/settings.rs
@@ -8,6 +8,7 @@ use custom_debug_derive::Debug as CustomDebug;
 use hyper::Uri;
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
 use structopt::StructOpt;
 
 /// Default URL to upstream graph provider.
@@ -51,6 +52,22 @@ pub struct AppSettings {
 
     /// Jaeger host and port for tracing support
     pub tracing_endpoint: Option<String>,
+
+    /// Actix-web maximum number of pending connections, defaults to 2048: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.backlog
+    #[default(10)]
+    pub backlog: u32,
+    /// Actix-web per-worker number of concurrent connections, defaults to 25000: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.max_connections
+    #[default(10)]
+    pub max_connections: usize,
+    /// Actix-web maximum per-worker concurrent connection establish process, defaults to 256: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.max_connections
+    #[default(64)]
+    pub max_connection_rate: usize,
+    /// Actix-web server keepalive, defaults to 5s: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.keep_alive
+    #[default(None)]
+    pub keep_alive: Option<Duration>,
+    /// Actix-web server client timeout for first request, defaults to 5s: https://docs.rs/actix-web/latest/actix_web/struct.HttpServer.html#method.client_timeout
+    #[default(Duration::new(5, 0))]
+    pub client_timeout: Duration,
 }
 
 impl AppSettings {

--- a/policy-engine/src/main.rs
+++ b/policy-engine/src/main.rs
@@ -38,7 +38,6 @@ use opentelemetry::{
 };
 use prometheus::{labels, opts, Counter, Registry};
 use std::collections::HashSet;
-use std::time::Duration;
 
 #[allow(dead_code)]
 /// Build info
@@ -129,7 +128,11 @@ async fn main() -> Result<(), Error> {
             )
             .default_service(actix_web::web::route().to(default_response))
     })
-    .keep_alive(Duration::new(10, 0))
+    .backlog(settings.backlog)
+    .max_connections(settings.max_connections)
+    .max_connection_rate(settings.max_connection_rate)
+    .keep_alive(settings.keep_alive)
+    .client_request_timeout(settings.client_timeout)
     .bind((settings.address, settings.port))?
     .run();
 


### PR DESCRIPTION
Allow changing actix-web settings without recompiling OSUS.

/cc @LalatenduMohanty @wking 
/hold

until load testing on stage is complete