### PR TITLE
fix version matching for conditional edges

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -269,7 +269,15 @@ impl Graph {
     pub fn find_by_version_vec(&self, version: &str) -> Vec<(ReleaseId, String)> {
         self.dag
             .node_references()
-            .filter(|nr| nr.weight().version().to_string().contains(version))
+            .filter(|nr| {
+                let v: &str = &nr.weight().version().to_string();
+                if v == version {
+                    true
+                } else {
+                    let version_unsuffixed: Vec<&str> = v.split("+").collect();
+                    version_unsuffixed[0] == version //ignore the architecture(eg +amd64) attached to version
+                }
+            })
             .map(|nr| (ReleaseId(nr.id()), nr.weight().version().to_string()))
             .collect()
     }


### PR DESCRIPTION
we were using `.contains` method as the versions are suffixed with
architectures like `+amd64`, etc.
This inadvertently led to blocking versions like `4.7.45` which matched
`4.7.4` which was conditionally blocked.
This commit fixes the issue.