### PR TITLE
Update cpaas release branch to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,9 +1689,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2579,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -3293,9 +3293,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,9 +2518,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
 dependencies = [
  "ansi_term 0.12.1",
  "ctor",

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -49,7 +49,7 @@ cached = "^0.32.1"
 mockito = "^0.31.0"
 serde_json = "1.0.79"
 memchr = "^2.4"
-pretty_assertions = "1.2.0"
+pretty_assertions = "1.2.1"
 test-case = "1.2.3"
 prettydiff = "0.6"
 

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -269,7 +269,15 @@ impl Graph {
     pub fn find_by_version_vec(&self, version: &str) -> Vec<(ReleaseId, String)> {
         self.dag
             .node_references()
-            .filter(|nr| nr.weight().version().to_string().contains(version))
+            .filter(|nr| {
+                let v: &str = &nr.weight().version().to_string();
+                if v == version {
+                    true
+                } else {
+                    let version_unsuffixed: Vec<&str> = v.split("+").collect();
+                    version_unsuffixed[0] == version //ignore the architecture(eg +amd64) attached to version
+                }
+            })
             .map(|nr| (ReleaseId(nr.id()), nr.weight().version().to_string()))
             .collect()
     }

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -153,7 +153,11 @@ impl InternalPlugin for ReleaseScrapeDockerv2Plugin {
             self.settings.fetch_concurrency,
         )
         .await
-        .context("failed to fetch all release metadata")?;
+        .context(format!(
+            "failed to fetch all release metadata from {}/{}",
+            &self.registry.host_port_string(),
+            &self.settings.repository
+        ))?;
 
         if releases.is_empty() {
             warn!(

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -458,7 +458,14 @@ async fn get_manifest_and_ref(
     trace!("[{}] Processing {}", &tag, &repo);
     let (manifest, manifestref) = registry_client
         .get_manifest_and_ref(&repo, &tag)
-        .map_err(|e| format_err!("{}", e))
+        .map_err(|e| {
+            format_err!(
+                "fetching manifest and manifestref for {}:{}: {}",
+                &repo,
+                &tag,
+                e
+            )
+        })
         .await?;
 
     let manifestref =
@@ -483,7 +490,14 @@ async fn find_first_release_metadata(
 
         let blob = registry_client
             .get_blob(&repo, &layer_digest)
-            .map_err(|e| format_err!("{}", e))
+            .map_err(|e| {
+                format_err!(
+                    "fetching blob for repo {} with layer_digest {}: {}",
+                    &repo,
+                    &layer_digest,
+                    e
+                )
+            })
             .await?;
 
         let metadata_filename = "release-manifests/release-metadata";

--- a/hack/graph-normalize.sh
+++ b/hack/graph-normalize.sh
@@ -40,6 +40,7 @@ JQ_SCRIPT='
           $reordered_nodes_by_version[.to]]
       ] | sort
     ),
+    conditionalEdges: .conditionalEdges,
   }
 '
 


### PR DESCRIPTION
update the cpaas release branch to include 
better logging of container registry pull errors 
and a fic to version matching in conditional edges