### PR TITLE
update api version for pod disruption budget

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -201,7 +201,7 @@ objects:
           targetPort: ${{PE_STATUS_PORT}}
       selector:
         deploymentconfig: cincinnati
-  - apiVersion: policy/v1beta1
+  - apiVersion: policy/v1
     kind: PodDisruptionBudget
     metadata:
       name: cincinnati-pdb

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -207,7 +207,7 @@ objects:
       name: cincinnati-pdb
       namespace: cincinnati
     spec:
-      minAvailable: 1
+      minAvailable: ${{PDB_MIN}}
       selector:
         matchLabels:
           app: cincinnati
@@ -364,4 +364,6 @@ parameters:
   - name: ENVIRONMENT_SECRETS
     value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
   - name: REPLICAS
+    value: "1"
+  - name: PDB_MIN
     value: "1"


### PR DESCRIPTION
policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+,
unavailable in v1.25+; use policy/v1 PodDisruptionBudget