### PR TITLE
redeploy cincinnati on configuration change

### DIFF
--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -232,6 +232,8 @@ objects:
     kind: ConfigMap
     metadata:
       name: cincinnati-configs
+      annotations:
+        qontract.recycle: true
     data:
       gb.toml: |
         verbosity = "${GB_LOG_VERBOSITY}"


### PR DESCRIPTION
this is required to redeploy cincinnati when GB configs
are changed.