### PR TITLE
dist/openshift: Declare group in Template apiVersion

### DIFF
--- a/dist/openshift/cincinnati-e2e.yaml
+++ b/dist/openshift/cincinnati-e2e.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: cincinnati

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: cincinnati

--- a/dist/openshift/observability.yaml
+++ b/dist/openshift/observability.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: cincinnati-observability


### PR DESCRIPTION
As defined [here][1] and documented [here][2].  Unclear to me why the initial empty-group `apiVersion` had been working, but we'd been using that approach since cfa2c314fc (#23).  Adding the group should [avoid][3]:

    + oc process -f dist/openshift/observability.yaml -p NAMESPACE=openshift-update-service
    error: failed to read input object (not a Template?): resource mapping not found for name: "cincinnati-observability" namespace: "" from "dist/openshift/observability.yaml": no matches for kind "Template" in version "v1"
    ensure CRDs are installed first

and match:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/31237/rehearse-31237-pull-ci-openshift-cincinnati-master-e2e/1557741650380328960/artifacts/e2e/gather-must-gather/artifacts/must-gather.tar | tar tvz | grep 'cluster-scoped-resources.*template' | grep -v counts
-rw------- 1010620000/root     3224 2022-08-11 11:17 quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-347d2a0427701d8f358d53ecc3e6b4e5779af090bbce71577fa019255e7f4a21/cluster-scoped-resources/apiregistration.k8s.io/apiservices/v1.template.openshift.io.yaml
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/31237/rehearse-31237-pull-ci-openshift-cincinnati-master-e2e/1557741650380328960/artifacts/e2e/gather-must-gather/artifacts/must-gather.tar | tar xOz quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-347d2a0427701d8f358d53ecc3e6b4e5779af090bbce71577fa019255e7f4a21/cluster-scoped-resources/apiregistration.k8s.io/apiservices/v1.template.openshift.io.yaml | yaml2json | jq -c '.spec | {group, version}'
{"group":"template.openshift.io","version":"v1"}
```

[1]: https://github.com/openshift/api/blame/72d2ca90c49733567a5530e42aece2e68bd709ea/template/install.go#L11
[2]: https://docs.openshift.com/container-platform/4.10/rest_api/template_apis/template-template-openshift-io-v1.html
[3]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31237/rehearse-31237-pull-ci-openshift-cincinnati-master-e2e/1557741650380328960#1:build-log.txt%3A108-110