### PR TITLE
dist/openshift/cincinnati-e2e: Set targetNamespaces

### DIFF
--- a/dist/openshift/cincinnati-e2e.yaml
+++ b/dist/openshift/cincinnati-e2e.yaml
@@ -10,7 +10,9 @@ objects:
       name: openshift-update-service
       annotations:
         olm.providedAPIs: ''
-    spec: {}
+    spec:
+      targetNamespaces:
+        - "${NAMESPACE}"
   - apiVersion: operators.coreos.com/v1alpha1
     kind: Subscription
     metadata:
@@ -36,6 +38,8 @@ objects:
       releases: quay.io/openshift-release-dev/ocp-release
       replicas: ${{REPLICAS}}
 parameters:
+  - name: NAMESPACE
+    value: "openshift-update-service"
   - name: IMAGE
     value: "quay.io/app-sre/cincinnati"
     displayName: cincinnati image

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -104,6 +104,7 @@ echo "GRAPHDATA_IMAGE=${GRAPH_SOURCE}"
 
 # Render the template and apply subscription/operand
 oc process -f dist/openshift/cincinnati-e2e.yaml \
+  -p NAMESPACE="openshift-update-service" \
   -p IMAGE="${IMAGE}" \
   -p IMAGE_TAG="${IMAGE_TAG}" \
   -p GRAPHDATA_IMAGE="${GRAPH_SOURCE}" \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -127,7 +127,7 @@ backoff oc -n openshift-update-service wait --for=condition=Ready pod -l app=e2e
 }
 
 # Expose services
-PE_URL=$(oc get route e2e-policy-engine-route -o jsonpath='{.spec.host}')
+PE_URL=$(oc get route e2e-route -o jsonpath='{.spec.host}')
 export GRAPH_URL="https://${PE_URL}/api/upgrades_info/graph"
 
 # Wait for route to become available


### PR DESCRIPTION
In the OperatorGroup, as seen [here][1] and [here][2], to catch up with [the operator moving `AllNamespaces` support from `true` to `false` in `installModes`][3].  This [avoids][4]:

```
+ oc get events
LAST SEEN   TYPE      REASON                     OBJECT                                                 MESSAGE
10m         Warning   UnsupportedOperatorGroup   clusterserviceversion/update-service-operator.v5.0.0   AllNamespaces InstallModeType not supported, cannot configure to watch all namespaces
```

[1]: https://github.com/openshift/cincinnati-operator/blob/eed7a92a5efda96545e9be90a6ec65b427026d11/docs/disconnected-updateservice-operator.md#deploy-the-updateservice-operator
[2]: https://github.com/openshift/cincinnati-operator/blob/eed7a92a5efda96545e9be90a6ec65b427026d11/tools/create-sub-group.sh#L23-L25
[3]: https://github.com/openshift/cincinnati-operator/pull/134/commits/1137a5c057902faa0936d16239b0240553509699#diff-ef93a20b4f66d5fb3e6d84caf1169c43d4f750684fabd1a7c27065312dbb7fcdL73-R73
[4]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31237/rehearse-31237-pull-ci-openshift-cincinnati-master-e2e/1557865068975099904#1:build-log.txt%3A897-899