### PR TITLE
[policy-engine] add liveness and readiness probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
  "mockito",
  "openapiv3",
  "opentelemetry",
+ "parking_lot 0.12.0",
  "prometheus",
  "semver 0.11.0",
  "serde",

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -144,8 +144,16 @@ objects:
                 - name: status-pe
                   containerPort: ${{PE_STATUS_PORT}}
               livenessProbe:
-                tcpSocket:
-                  port: ${{PE_PORT}}
+                httpGet:
+                  path: /livez
+                  port: ${{GB_STATUS_PORT}}
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 3
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: ${{GB_STATUS_PORT}}
                 initialDelaySeconds: 60
                 periodSeconds: 30
                 timeoutSeconds: 3

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -17,6 +17,7 @@ hyper = "^0.14"
 lazy_static = "^1.2.0"
 log = "^0.4.17"
 openapiv3 = "1.0"
+parking_lot = "^0.12"
 prometheus = "0.13"
 semver = { version = "^0.11", features = [ "serde" ] }
 serde = "^1.0.136"

--- a/policy-engine/src/status.rs
+++ b/policy-engine/src/status.rs
@@ -1,0 +1,30 @@
+//! Status service.
+
+use crate::AppState;
+use actix_web::HttpResponse;
+
+/// Expose liveness status.
+///
+/// Status:
+///  * Live (200 code): The metrics endpoint has started running
+///  * Not Live (503 code): everything else.
+pub async fn serve_liveness(app_data: actix_web::web::Data<AppState>) -> HttpResponse {
+    if app_data.is_live() {
+        HttpResponse::Ok().finish()
+    } else {
+        HttpResponse::ServiceUnavailable().finish()
+    }
+}
+
+/// Expose readiness status.
+///
+/// Status:
+///  * Ready (200 code): the application has been initialized and is available to accept connections.
+///  * Not Ready (503 code): no JSON graph available yet.
+pub async fn serve_readiness(app_data: actix_web::web::Data<AppState>) -> HttpResponse {
+    if app_data.is_ready() {
+        HttpResponse::Ok().finish()
+    } else {
+        HttpResponse::ServiceUnavailable().finish()
+    }
+}


### PR DESCRIPTION
This PR adds liveness and readiness probes to the
policy-engine.
The liveness holds true when the application has initialized.
The readiness endpoint waits for the graph-builder to build
the graph and for the graph to be cached on the policy engine side
before going true.