### PR TITLE
Serve current graph-data tar through cincinnati

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +376,12 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "assert-json-diff"
@@ -845,6 +874,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "env_logger",
+ "flate2",
  "futures",
  "hamcrest2",
  "lazy_static",
@@ -858,6 +888,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tar",
  "thiserror",
  "thrift 0.17.0",
  "tokio",
@@ -1542,6 +1573,7 @@ name = "graph-builder"
 version = "0.1.0"
 dependencies = [
  "actix",
+ "actix-files",
  "actix-service",
  "actix-web",
  "async-trait",
@@ -1669,6 +1701,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
@@ -1966,6 +2004,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3660,6 +3708,15 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check 0.9.3",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -1,10 +1,10 @@
 use crate as cincinnati;
 
-use self::cincinnati::plugins::internal::graph_builder::github_openshift_secondary_metadata_scraper::plugin::GRAPH_DATA_DIR_PARAM_KEY;
 use self::cincinnati::plugins::prelude::*;
 use self::cincinnati::plugins::prelude_plugin_impl::*;
 
 use crate::conditional_edges::{ConditionalEdge, ConditionalUpdateEdge, ConditionalUpdateRisk};
+use commons::GRAPH_DATA_DIR_PARAM_KEY;
 use std::collections::HashSet;
 use std::path::Path;
 

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -18,10 +18,12 @@ serde_derive = "^1.0.123"
 tokio = { version = "1.16", features = [ "rt-multi-thread" ] }
 url = "^2.3"
 futures = "^0.3"
+flate2 = "^1.0.25"
 opentelemetry = "0.14.0"
 opentelemetry-jaeger = "0.13.0"
 reqwest = "^0.11"
 thrift = "0.17"
+tar = "^0.4.38"
 actix-service = "^2.0.2"
 hamcrest2 = "0.3.0"
 

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -77,6 +77,10 @@ pub enum GraphError {
     /// Failed to parse as Semantic Version
     #[error("failed to process version: {}", _0)]
     ArchVersionError(String),
+
+    /// Failed to open a file
+    #[error("failed to open file: {}", _0)]
+    FileOpenError(String),
 }
 
 impl actix_web::error::ResponseError for GraphError {
@@ -119,6 +123,7 @@ impl GraphError {
             GraphError::MissingParams(_) => http::StatusCode::BAD_REQUEST,
             GraphError::InvalidParams(_) => http::StatusCode::BAD_REQUEST,
             GraphError::ArchVersionError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+            GraphError::FileOpenError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -134,6 +139,7 @@ impl GraphError {
             GraphError::MissingParams(_) => "missing_params",
             GraphError::InvalidParams(_) => "invalid_params",
             GraphError::ArchVersionError(_) => "arch_version_error",
+            GraphError::FileOpenError(_) => "file_open_err",
         };
         kind.to_string()
     }

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -62,6 +62,8 @@ objects:
               ports:
                 - name: graph-builder
                   containerPort: ${{GB_PORT}}
+                - name: graph-builder-public
+                  containerPort: ${{GB_PUBLIC_PORT}}
                 - name: status-gb
                   containerPort: ${{GB_STATUS_PORT}}
               livenessProbe:
@@ -194,6 +196,20 @@ objects:
   - apiVersion: v1
     kind: Service
     metadata:
+      name: cincinnati-graph-builder-public
+      labels:
+        app: cincinnati-graph-builder
+    spec:
+      ports:
+        - name: graph-builder-public
+          protocol: TCP
+          port: ${{GB_PUBLIC_PORT}}
+          targetPort: ${{GB_PUBLIC_PORT}}
+      selector:
+        deploymentconfig: cincinnati
+  - apiVersion: v1
+    kind: Service
+    metadata:
       name: cincinnati-policy-engine
       labels:
         app: cincinnati-policy-engine
@@ -251,6 +267,7 @@ objects:
         pause_secs = ${GB_PAUSE_SECS}
         address = "${GB_ADDRESS}"
         port = ${GB_PORT}
+        public_port = "${GB_PUBLIC_PORT}"
 
         [status]
         address = "${GB_STATUS_ADDRESS}"
@@ -307,6 +324,9 @@ parameters:
   - name: GB_PORT
     value: "8080"
     displayName: Graph builder port
+  - name: GB_PUBLIC_PORT
+    value: "8090"
+    displayName: Graph builder public port
   - name: GB_ADDRESS
     value: "0.0.0.0"
     displayName: Graph builder address

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -9,6 +9,7 @@ build = "src/build.rs"
 actix = "0.13.0"
 actix-web = "^4.0.0-rc.3"
 chrono = "^0.4.20"
+actix-files = "^0.6.2"
 cincinnati = { path = "../cincinnati" }
 commons = { path = "../commons" }
 env_logger = "^0.9"

--- a/graph-builder/src/config/options.rs
+++ b/graph-builder/src/config/options.rs
@@ -50,6 +50,14 @@ pub struct ServiceOptions {
     #[structopt(name = "service_port", long = "service.port", alias = "port")]
     pub port: Option<u16>,
 
+    /// Port to which the server will bind
+    #[structopt(
+        name = "service_public_port",
+        long = "service.public_port",
+        alias = "public_port"
+    )]
+    pub public_port: Option<u16>,
+
     /// Namespace prefix for all service endpoints (e.g. '/<prefix>/graph')
     #[structopt(long = "service.path_prefix", parse(from_str = parse_path_prefix))]
     #[serde(default = "Option::default", deserialize_with = "de_path_prefix")]
@@ -101,6 +109,7 @@ impl MergeOptions<Option<ServiceOptions>> for AppSettings {
             assign_if_some!(self.scrape_timeout_secs, service.scrape_timeout_secs);
             assign_if_some!(self.address, service.address);
             assign_if_some!(self.port, service.port);
+            assign_if_some!(self.public_port, service.public_port);
             assign_if_some!(self.path_prefix, service.path_prefix);
             assign_if_some!(self.tracing_endpoint, service.tracing_endpoint);
             if let Some(params) = service.mandatory_client_parameters {

--- a/graph-builder/src/config/settings.rs
+++ b/graph-builder/src/config/settings.rs
@@ -42,6 +42,10 @@ pub struct AppSettings {
     #[default(8080)]
     pub port: u16,
 
+    /// Public port for graph-builder
+    #[default(8090)]
+    pub public_port: u16,
+
     // TODO(lucab): split this in (TLS, hostname+port).
     /// Target host for the registry scraper.
     #[default(cincinnati::plugins::internal::release_scrape_dockerv2::DEFAULT_SCRAPE_REGISTRY.to_string())]

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Error> {
         let json_graph = Arc::new(RwLock::new(String::new()));
         let live = Arc::new(RwLock::new(false));
         let ready = Arc::new(RwLock::new(false));
-
+        let secondary_metadata = Arc::new(RwLock::new(String::new()));
         graph::State::new(
             json_graph,
             settings.mandatory_client_parameters.clone(),
@@ -70,6 +70,7 @@ async fn main() -> Result<(), Error> {
             ready,
             Box::leak(Box::new(plugins)),
             Box::leak(Box::new(registry)),
+            secondary_metadata,
         )
     };
 


### PR DESCRIPTION
create a tar file after the unnecessary files
are removed from the graph-data directory.
And add the tar file path to internal_io parameters
which can then be used to update the secondary_metadata
state which we use while serving the tar file through a 
new endpoint and port