### PR TITLE
Update base image for e2e container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,16 +2372,28 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2392,11 +2404,10 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
- "autocfg 1.0.1",
  "cc",
  "libc",
  "pkg-config",

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -1,15 +1,15 @@
-FROM registry.centos.org/centos/centos:7 as rust_builder
+FROM quay.io/centos/centos:stream9 as rust_builder
 
 # base: EPEL repo for extra tools
-RUN yum -y install epel-release
+RUN dnf -y install epel-release
 
 # build: system utilities and libraries
-RUN yum update -y && \
-    yum -y groupinstall 'Development Tools' && \
-    yum -y install gcc openssl-devel protobuf-compiler jq skopeo buildah libgit2 && \
-    yum -y install yamllint && \
-    yum -y install cmake elfutils-libelf-devel libcurl-devel binutils-devel elfutils-devel && \
-    yum clean all
+RUN dnf update -y && \
+    dnf -y groupinstall 'Development Tools' && \
+    dnf -y install gcc openssl-devel jq skopeo buildah libgit2 && \
+    dnf -y install yamllint && \
+    dnf -y install cmake elfutils-libelf-devel libcurl-devel binutils-devel elfutils-devel && \
+    dnf clean all
 
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"
@@ -23,13 +23,15 @@ RUN \
   find $HOME/. -type d -exec chmod 777 {} \; && \
   find $HOME/. -type f -exec chmod ugo+rw {} \;
 
-
+WORKDIR /opt/app-root/src/
+COPY . .
+COPY .git .git
 RUN hack/build_e2e.sh
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS golang_builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS golang_builder
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta
 
-FROM registry.centos.org/centos/centos:7
+FROM quay.io/centos/centos:stream9
 
 ENV HOME="/root"
 

--- a/dist/Dockerfile.e2e/Dockerfile
+++ b/dist/Dockerfile.e2e/Dockerfile
@@ -51,15 +51,15 @@ RUN yum update -y && \
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test
 COPY --from=rust_builder /opt/cincinnati/bin/slo /usr/bin/cincinnati-e2e-slo
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/e2e.sh hack/
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/hack/vegeta.targets hack/
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/cincinnati.yaml dist/openshift/
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/cincinnati-e2e.yaml dist/openshift/
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/observability.yaml dist/openshift/
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/openshift/load-testing.yaml dist/openshift/
+COPY --from=rust_builder /opt/app-root/src/hack/e2e.sh hack/
+COPY --from=rust_builder /opt/app-root/src/hack/vegeta.targets hack/
+COPY --from=rust_builder /opt/app-root/src/dist/openshift/cincinnati.yaml dist/openshift/
+COPY --from=rust_builder /opt/app-root/src/dist/openshift/cincinnati-e2e.yaml dist/openshift/
+COPY --from=rust_builder /opt/app-root/src/dist/openshift/observability.yaml dist/openshift/
+COPY --from=rust_builder /opt/app-root/src/dist/openshift/load-testing.yaml dist/openshift/
 COPY --from=golang_builder /usr/local/bin/vegeta /usr/bin
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/e2e/tests/testdata e2e/tests/testdata
-COPY --from=rust_builder /go/src/github.com/openshift/cincinnati/dist/prepare_ci_credentials.sh dist/
+COPY --from=rust_builder /opt/app-root/src/e2e/tests/testdata e2e/tests/testdata
+COPY --from=rust_builder /opt/app-root/src/dist/prepare_ci_credentials.sh dist/
 
 ENV E2E_TESTDATA_DIR "e2e/tests/testdata"
 


### PR DESCRIPTION
This builds over https://github.com/openshift/cincinnati/pull/786

- [dist] update base image for e2e container
- Bump openssl-sys and openssl
- Dockerfile.e2e: Fix source paths in copy commands
