### PR TITLE
Bump Rust to 2021 edition

### DIFF
--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cincinnati"
 version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 actix-web = "^4.0.0-rc.3"

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commons"
 version = "0.1.0"
 authors = ["Stefan Junker <mail@stefanjunker.de>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 actix-web = "^4.0.0-rc.3"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e2e"
 version = "0.1.0"
 authors = ["Vadim Rutkovsky <vrutkovs@redhat.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "^1.0"

--- a/graph-builder/Cargo.toml
+++ b/graph-builder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graph-builder"
 version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
-edition = "2018"
+edition = "2021"
 build = "src/build.rs"
 
 [dependencies]

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "policy-engine"
 version = "0.1.0"
 authors = ["Alex Crawford <crawford@redhat.com>"]
-edition = "2018"
+edition = "2021"
 build = "src/build.rs"
 
 [dependencies]

--- a/prometheus-query/Cargo.toml
+++ b/prometheus-query/Cargo.toml
@@ -3,7 +3,7 @@ name = "prometheus-query"
 version = "0.0.0-dev"
 authors = ["Stefan Junker <mail@stefanjunker.de>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 commons = { path = "../commons" }

--- a/quay/Cargo.toml
+++ b/quay/Cargo.toml
@@ -3,7 +3,7 @@ name = "quay"
 version = "0.0.0-dev"
 authors = ["Luca Bruno <luca.bruno@coreos.com>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/rh-manifest-generator/Cargo.toml
+++ b/rh-manifest-generator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rh-manifest-generator"
 version = "0.1.0"
 authors = ["Stefan Junker <mail@stefanjunker.de>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Seeing all the dependabot bumps that fail to pass tests with

```
error: failed to parse manifest at `/root/.cargo/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.3.1/Cargo.toml`
Caused by:
  feature `edition2021` is required 
```

I wonder if there is a good reason to not bump the Rust edition?