### PR TITLE
OTA-915: fix configs and add signature serving deployment

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -157,8 +157,6 @@ run-metadata-helper:
 		verbosity = "vvv"
 
 		[service]
-		scrape_timeout_secs = 300
-		pause_secs = {{pause_secs}}
 		address = "127.0.0.1"
 		port = 8082
 		path_prefix = "{{path_prefix}}"

--- a/Justfile
+++ b/Justfile
@@ -160,13 +160,13 @@ run-metadata-helper:
 		scrape_timeout_secs = 300
 		pause_secs = {{pause_secs}}
 		address = "127.0.0.1"
-		port = 8080
+		port = 8082
 		path_prefix = "{{path_prefix}}"
 		tracing_endpoint = "{{default_tracing_endpoint}}"
 
 		[status]
 		address = "127.0.0.1"
-		port = 9080
+		port = 9082
 	EOF
 	)
 

--- a/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/github_openshift_secondary_metadata_scraper/plugin.rs
@@ -472,6 +472,20 @@ impl InternalPlugin for GithubOpenshiftSecondaryMetadataScraperPlugin {
                 .context("Extracting tarball")?;
 
             let graph_data_tar_path = self.settings.output_directory.join("graph-data.tar.gz");
+            let signatures_path = graph_data_dir.as_path().join("signatures");
+            let signatures_symlink = self.settings.output_directory.join("signatures");
+
+            // create a symlink to signatures directory for metadata-helper
+            // the secondary metadata scraper creates a temp directory to extract graph-data
+            // other containers wont have context of the directory that is being used.
+            // signatures symlink is at /signatures in the graph-data directory and will keep
+            // updating as newer graph-data is scraped.
+            if signatures_path
+                .try_exists()
+                .expect("Can't check if signatures exist")
+            {
+                tokio::fs::symlink(signatures_path, signatures_symlink).await?;
+            }
 
             commons::create_tar(
                 graph_data_tar_path.clone().into_boxed_path(),

--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -28,7 +28,8 @@ COPY .git/ ./.git/
 RUN cargo build --release && \
     mkdir -p /opt/cincinnati/bin && \
     cp -rvf $HOME/target/release/graph-builder /opt/cincinnati/bin && \
-    cp -rvf $HOME/target/release/policy-engine /opt/cincinnati/bin
+    cp -rvf $HOME/target/release/policy-engine /opt/cincinnati/bin && \
+    cp -rvf $HOME/target/release/metadata-helper /opt/cincinnati/bin 
 
 FROM registry.access.redhat.com/ubi8:latest
 

--- a/dist/Dockerfile.rust-toolset/Dockerfile
+++ b/dist/Dockerfile.rust-toolset/Dockerfile
@@ -11,7 +11,8 @@ RUN dnf update -y \
     && cargo build --release \
     && mkdir -p /opt/cincinnati/bin \
     && cp -rvf target/release/graph-builder /opt/cincinnati/bin \
-    && cp -rvf target/release/policy-engine /opt/cincinnati/bin
+    && cp -rvf target/release/policy-engine /opt/cincinnati/bin \
+    && cp -rvf target/release/metadata-helper /opt/cincinnati/bin
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 ENV RUST_LOG=actix_web=error,dkregistry=error

--- a/dist/openshift/cinci-with-mh-deployment.yaml
+++ b/dist/openshift/cinci-with-mh-deployment.yaml
@@ -1,0 +1,535 @@
+# Deployment to deploy Cincinnati with Metadata Helper container
+# Metadata Helper is an optional container and wont be deployed with default
+# cincinnati deployment.
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: cincinnati
+objects:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: cincinnati
+      name: cincinnati
+    spec:
+      replicas: ${{REPLICAS}}
+      selector:
+        matchLabels:
+          app: cincinnati
+      strategy:
+        rollingParams:
+          intervalSeconds: 1
+          maxSurge: 25%
+          maxUnavailable: 25%
+          timeoutSeconds: 1200
+          updatePeriodSeconds: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: cincinnati
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - cincinnati
+                    topologyKey: kubernetes.io/hostname
+          containers:
+            - image: ${IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: Always
+              name: cincinnati-graph-builder
+              env:
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: gb.rust_backtrace
+                      name: cincinnati
+              envFrom:
+                - configMapRef:
+                    name: environment-secrets
+              command:
+                - ${GB_BINARY}
+              args: ["-c", "${GB_CONFIG_PATH}"]
+              ports:
+                - name: graph-builder
+                  containerPort: ${{GB_PORT}}
+                - name: gb-public
+                  containerPort: ${{GB_PUBLIC_PORT}}
+                - name: status-gb
+                  containerPort: ${{GB_STATUS_PORT}}
+              livenessProbe:
+                httpGet:
+                  path: /liveness
+                  port: ${{GB_STATUS_PORT}}
+                initialDelaySeconds: 150
+                periodSeconds: 30
+                timeoutSeconds: 3
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: ${{GB_STATUS_PORT}}
+                initialDelaySeconds: 150
+                periodSeconds: 30
+                timeoutSeconds: 3
+              resources:
+                limits:
+                  cpu: ${GB_CPU_LIMIT}
+                  memory: ${GB_MEMORY_LIMIT}
+                requests:
+                  cpu: ${GB_CPU_REQUEST}
+                  memory: ${GB_MEMORY_REQUEST}
+              volumeMounts:
+                - name: cincinnati-graph-data
+                  mountPath: ${GRAPH_DATA_PATH}
+                - name: secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: configs
+                  mountPath: /etc/configs
+                  readOnly: true
+            - image: ${IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: Always
+              name: cincinnati-metadata-helper
+              env:
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: gb.rust_backtrace
+                      name: cincinnati
+              envFrom:
+                - configMapRef:
+                    name: environment-secrets
+              command:
+                - ${MH_BINARY}
+              args: ["-c", "${MH_CONFIG_PATH}"]
+              ports:
+                - name: metadata-helper
+                  containerPort: ${{MH_PORT}}
+                - name: status-mh
+                  containerPort: ${{MH_STATUS_PORT}}
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: ${{MH_STATUS_PORT}}
+                initialDelaySeconds: 150
+                periodSeconds: 30
+                timeoutSeconds: 3
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: ${{MH_STATUS_PORT}}
+                initialDelaySeconds: 150
+                periodSeconds: 30
+                timeoutSeconds: 3
+              resources:
+                limits:
+                  cpu: ${MH_CPU_LIMIT}
+                  memory: ${MH_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MH_CPU_REQUEST}
+                  memory: ${MH_MEMORY_REQUEST}
+              volumeMounts:
+                - name: cincinnati-graph-data
+                  mountPath: ${GRAPH_DATA_PATH}
+                - name: secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: configs
+                  mountPath: /etc/configs
+                  readOnly: true
+            - image: ${IMAGE}:${IMAGE_TAG}
+              name: cincinnati-policy-engine
+              imagePullPolicy: Always
+              env:
+                - name: ADDRESS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.address
+                      name: cincinnati
+                - name: PE_STATUS_ADDRESS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.status.address
+                      name: cincinnati
+                - name: UPSTREAM
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.upstream
+                      name: cincinnati
+                - name: PE_LOG_VERBOSITY
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.log.verbosity
+                      name: cincinnati
+                - name: "PE_MANDATORY_CLIENT_PARAMETERS"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.mandatory_client_parameters
+                      name: cincinnati
+                - name: "RUST_BACKTRACE"
+                  valueFrom:
+                    configMapKeyRef:
+                      key: pe.rust_backtrace
+                      name: cincinnati
+              command:
+                - ${PE_BINARY}
+              args:
+                [
+                  "-$(PE_LOG_VERBOSITY)",
+                  "--service.address",
+                  "$(ADDRESS)",
+                  "--service.mandatory_client_parameters",
+                  "$(PE_MANDATORY_CLIENT_PARAMETERS)",
+                  "--service.path_prefix",
+                  "${PE_PATH_PREFIX}",
+                  "--service.port",
+                  "${PE_PORT}",
+                  "--status.address",
+                  "$(PE_STATUS_ADDRESS)",
+                  "--status.port",
+                  "${PE_STATUS_PORT}",
+                  "--upstream.cincinnati.url",
+                  "$(UPSTREAM)",
+                ]
+              ports:
+                - name: policy-engine
+                  containerPort: ${{PE_PORT}}
+                - name: status-pe
+                  containerPort: ${{PE_STATUS_PORT}}
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: ${{PE_STATUS_PORT}}
+                initialDelaySeconds: 300
+                periodSeconds: 30
+                timeoutSeconds: 3
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: ${{PE_STATUS_PORT}}
+                initialDelaySeconds: 300
+                periodSeconds: 30
+                timeoutSeconds: 3
+              resources:
+                limits:
+                  cpu: ${PE_CPU_LIMIT}
+                  memory: ${PE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${PE_CPU_REQUEST}
+                  memory: ${PE_MEMORY_REQUEST}
+          volumes:
+            - name: secrets
+              secret:
+                secretName: cincinnati-credentials
+            - name: configs
+              configMap:
+                name: cincinnati-configs
+            - name: cincinnati-graph-data
+              emptyDir: {}
+      triggers:
+        - type: ConfigChange
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cincinnati-graph-builder
+      labels:
+        app: cincinnati-graph-builder
+    spec:
+      ports:
+        - name: graph-builder
+          protocol: TCP
+          port: ${{GB_PORT}}
+          targetPort: ${{GB_PORT}}
+        - name: status-gb
+          protocol: TCP
+          port: ${{GB_STATUS_PORT}}
+          targetPort: ${{GB_STATUS_PORT}}
+      selector:
+        app: cincinnati
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cincinnati-gb-public
+      labels:
+        app: cincinnati-graph-builder
+    spec:
+      ports:
+        - name: gb-public
+          protocol: TCP
+          port: ${{GB_PUBLIC_PORT}}
+          targetPort: ${{GB_PUBLIC_PORT}}
+      selector:
+        app: cincinnati
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cincinnati-metadata-helper
+      labels:
+        app: cincinnati-metadata-helper
+    spec:
+      ports:
+        - name: metadata-helper
+          protocol: TCP
+          port: ${{MH_PORT}}
+          targetPort: ${{MH_PORT}}
+        - name: status-mh
+          protocol: TCP
+          port: ${{MH_STATUS_PORT}}
+          targetPort: ${{MH_STATUS_PORT}}
+      selector:
+        app: cincinnati
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: cincinnati-policy-engine
+      labels:
+        app: cincinnati-policy-engine
+    spec:
+      ports:
+        - name: policy-engine
+          protocol: TCP
+          port: 80
+          targetPort: ${{PE_PORT}}
+        - name: status-pe
+          protocol: TCP
+          port: ${{PE_STATUS_PORT}}
+          targetPort: ${{PE_STATUS_PORT}}
+      selector:
+        app: cincinnati
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: cincinnati-pdb
+      namespace: cincinnati
+    spec:
+      minAvailable: ${{PDB_MIN}}
+      selector:
+        matchLabels:
+          app: cincinnati
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cincinnati
+    data:
+      gb.rust_backtrace: "${RUST_BACKTRACE}"
+      pe.address: "0.0.0.0"
+      pe.status.address: "0.0.0.0"
+      pe.upstream: "http://localhost:8080${GB_PATH_PREFIX}/graph"
+      pe.log.verbosity: ${{PE_LOG_VERBOSITY}}
+      pe.mandatory_client_parameters: "channel"
+      pe.rust_backtrace: "${RUST_BACKTRACE}"
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: environment-secrets
+    data: ${{ENVIRONMENT_SECRETS}}
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cincinnati-configs
+      annotations:
+        qontract.recycle: "true"
+    data:
+      gb.toml: |
+        verbosity = "${GB_LOG_VERBOSITY}"
+
+        [service]
+        scrape_timeout_secs = ${GB_SCRAPE_TIMEOUT_SECS}
+        pause_secs = ${GB_PAUSE_SECS}
+        path_prefix = "${GB_PATH_PREFIX}"
+        address = "${GB_ADDRESS}"
+        port = ${GB_PORT}
+        public_port = ${GB_PUBLIC_PORT}
+
+        [status]
+        address = "${GB_STATUS_ADDRESS}"
+        port = ${GB_STATUS_PORT}
+
+        ${GB_PLUGIN_SETTINGS}
+      mh.toml: |
+        verbosity = "${MH_LOG_VERBOSITY}"
+
+        [service]
+        address = "${MH_ADDRESS}"
+        port = ${MH_PORT}
+        path_prefix = "${MH_PATH_PREFIX}"
+
+        [status]
+        address = "${MH_STATUS_ADDRESS}"
+        port = ${MH_STATUS_PORT}
+
+        [signatures]
+        dir = "${GRAPH_DATA_PATH}/signatures"
+parameters:
+  - name: IMAGE
+    value: "quay.io/app-sre/cincinnati"
+    displayName: cincinnati image
+    description: cincinnati docker image. Defaults to quay.io/app-sre/cincinnati
+  - name: IMAGE_TAG
+    value: "latest"
+    displayName: cincinnati version
+    description: cincinnati version which defaults to latest
+  - name: GB_MEMORY_LIMIT
+    value: "768Mi"
+    displayName: "Graph-builder memory limit"
+    description: "Maximum amount of memory (bytes) allowed for graph-builder (default: 523Mi)"
+  - name: GB_CPU_LIMIT
+    value: "750m"
+    displayName: "Graph-builder CPU limit"
+    description: "Maximum amount of CPU (millicores) allowed for graph-builder (default: 750m)"
+  - name: PE_MEMORY_LIMIT
+    value: "1Gi"
+    displayName: "Policy-engine memory limit"
+    description: "Maximum amount of memory (bytes) allowed for policy-engine (default: 512Mi)"
+  - name: PE_CPU_LIMIT
+    value: "750m"
+    displayName: "Policy-engine CPU limit"
+    description: "Maximum amount of CPU (millicores) allowed for policy-engine (default: 750m)"
+  - name: MH_MEMORY_LIMIT
+    value: "768Mi"
+    displayName: "Metadata-helper memory limit"
+    description: "Maximum amount of memory (bytes) allowed for metadata-helper (default: 523Mi)"
+  - name: MH_CPU_LIMIT
+    value: "750m"
+    displayName: "Metadata-helper CPU limit"
+    description: "Maximum amount of CPU (millicores) allowed for metadata-helper (default: 750m)"
+  - name: GB_MEMORY_REQUEST
+    value: "128Mi"
+    displayName: "Graph-builder memory request"
+    description: "Requested amount of memory (bytes) allowed for graph-builder (default: 128Mi)"
+  - name: GB_CPU_REQUEST
+    value: "350m"
+    displayName: "Graph-builder CPU request"
+    description: "Requested amount of CPU (millicores) allowed for graph-builder (default: 350m)"
+  - name: PE_MEMORY_REQUEST
+    value: "128Mi"
+    displayName: "Policy-engine memory request"
+    description: "Requested amount of memory (bytes) allowed for policy-engine (default: 128Mi)"
+  - name: PE_CPU_REQUEST
+    value: "350m"
+    displayName: "Policy-engine CPU request"
+    description: "Requested amount of CPU (millicores) allowed for policy-engine (default: 350m)"
+  - name: MH_MEMORY_REQUEST
+    value: "128Mi"
+    displayName: "Metadata-helper memory request"
+    description: "Requested amount of memory (bytes) allowed for metadata-helper (default: 128Mi)"
+  - name: MH_CPU_REQUEST
+    value: "350m"
+    displayName: "Metadata-helper CPU request"
+    description: "Requested amount of CPU (millicores) allowed for metadata-helper (default: 350m)"
+  - name: GB_SCRAPE_TIMEOUT_SECS
+    value: "300"
+    displayName: Graph-builder scrape timeout in seconds
+  - name: GB_PAUSE_SECS
+    value: "300"
+    displayName: Seconds to pause between scrapes
+  - name: GB_ADDRESS
+    value: "0.0.0.0"
+    displayName: Graph builder address
+  - name: GB_STATUS_ADDRESS
+    value: "0.0.0.0"
+    displayName: Graph builder status address
+  - name: MH_ADDRESS
+    value: "0.0.0.0"
+    displayName: Metadata-helper address
+  - name: MH_STATUS_ADDRESS
+    value: "0.0.0.0"
+    displayName: Metadata-helper status address
+  - name: GB_PORT
+    value: "8080"
+    displayName: Graph builder port
+  - name: GB_PUBLIC_PORT
+    value: "8090"
+    displayName: Graph builder public port
+  - name: GB_STATUS_PORT
+    value: "9080"
+    displayName: Graph builder status port
+  - name: PE_PORT
+    value: "8081"
+    displayName: Policy engine port
+  - name: PE_STATUS_PORT
+    value: "9081"
+    displayName: Policy engine status port
+  - name: MH_PORT
+    value: "8082"
+    displayName: Metadata-helper port
+  - name: MH_STATUS_PORT
+    value: "9082"
+    displayName: Metadata-helper status port
+  - name: GB_PATH_PREFIX
+    value: "/api/upgrades_info"
+    displayName: Graph builder path prefix
+  - name: PE_PATH_PREFIX
+    value: "/api/upgrades_info"
+    displayName: Policy engine path prefix
+  - name: MH_PATH_PREFIX
+    value: "/api/upgrades_info"
+    displayName: Metadata-helper path prefix
+  - name: GB_LOG_VERBOSITY
+    value: "vvv"
+    displayName: Graph builder log verbosity
+  - name: PE_LOG_VERBOSITY
+    value: "vv"
+    displayName: Policy engine log verbosity
+  - name: MH_LOG_VERBOSITY
+    value: "vv"
+    displayName: Metadata-helper log verbosity
+  - name: GB_CINCINNATI_REPO
+    value: "openshift-release-dev/ocp-release"
+    displayName: Graph builder quay repo
+  - name: GB_BINARY
+    value: /usr/bin/graph-builder
+    displayName: Path to graph-builder binary
+  - name: PE_BINARY
+    value: /usr/bin/policy-engine
+    displayName: Path to policy-engine binary
+  - name: MH_BINARY
+    value: /usr/bin/metadata-helper
+    displayName: Path to metadata-helper binary
+  - name: GB_PLUGIN_SETTINGS
+    displayName: Graph builder plugin settings, passed through verbatim.
+    value: |
+      [[plugin_settings]]
+      name = "release-scrape-dockerv2"
+      registry = "quay.io"
+      repository = "openshift-release-dev/ocp-release"
+      fetch_concurrency = 16
+      credentials_path = "/etc/secrets/registry_credentials_docker.json"
+
+      [[plugin_settings]]
+      name = "github-secondary-metadata-scrape"
+      github_org = "openshift"
+      github_repo = "cincinnati-graph-data"
+      reference_branch = "master"
+      output_directory = "/tmp/cincinnati/graph-data"
+      oauth_token_path = "/etc/secrets/github_token.key"
+
+      [[plugin_settings]]
+      name = "openshift-secondary-metadata-parse"
+
+      [[plugin_settings]]
+      name = "edge-add-remove"
+  - name: RUST_BACKTRACE
+    value: "0"
+    displayName: Set RUST_BACKTRACE env var
+  - name: GB_CONFIG_PATH
+    value: "/etc/configs/gb.toml"
+  - name: MH_CONFIG_PATH
+    value: "/etc/configs/mh.toml"
+  - name: GRAPH_DATA_PATH
+    value: "/tmp/cincinnati/graph-data"
+  - name: ENVIRONMENT_SECRETS
+    value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
+  - name: REPLICAS
+    value: "1"
+  - name: PDB_MIN
+    value: "1"

--- a/graph-builder/src/main.rs
+++ b/graph-builder/src/main.rs
@@ -19,7 +19,7 @@ use commons::prelude_errors::*;
 use commons::tracing::{get_context, get_tracer, init_tracer, set_span_tags};
 use futures::future;
 use graph_builder::{self, config, graph, status};
-use log::{debug, info};
+use log::info;
 use opentelemetry::{
     trace::{mark_span_as_active, FutureExt, Tracer},
     Context as ot_context,

--- a/metadata-helper/src/config/cli.rs
+++ b/metadata-helper/src/config/cli.rs
@@ -45,7 +45,6 @@ impl MergeOptions<CliOptions> for AppSettings {
 mod tests {
     use super::CliOptions;
     use crate::config::AppSettings;
-    use commons::MergeOptions;
     use structopt::StructOpt;
 
     #[test]
@@ -53,7 +52,6 @@ mod tests {
         let no_args = vec!["argv0"];
         let no_args_cli = CliOptions::from_iter_safe(no_args).unwrap();
         assert_eq!(no_args_cli.verbosity, 0);
-        assert_eq!(no_args_cli.upstream_method, None);
 
         let verbose_args = vec!["argv0", "-vvv"];
         let verbose_cli = CliOptions::from_iter_safe(verbose_args).unwrap();

--- a/metadata-helper/src/config/file.rs
+++ b/metadata-helper/src/config/file.rs
@@ -82,8 +82,9 @@ mod tests {
     #[test]
     fn toml_sample_config() {
         use super::FileOptions;
+        use std::net::{IpAddr, Ipv4Addr};
 
-        let input_url = hyper::Uri::from_static("0.0.0.0");
+        let input_url = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let opts = {
             use std::io::Write;
 

--- a/metadata-helper/src/config/settings.rs
+++ b/metadata-helper/src/config/settings.rs
@@ -18,7 +18,7 @@ pub struct AppSettings {
     #[default(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub address: IpAddr,
     /// Listening port for the main service.
-    #[default(9081)]
+    #[default(8082)]
     pub port: u16,
     /// Endpoints namespace for the main service.
     pub path_prefix: String,
@@ -27,7 +27,7 @@ pub struct AppSettings {
     #[default(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub status_address: IpAddr,
     /// Listening port for the status service.
-    #[default(9091)]
+    #[default(9082)]
     pub status_port: u16,
 
     /// directory to store signatures

--- a/metadata-helper/src/signatures.rs
+++ b/metadata-helper/src/signatures.rs
@@ -3,7 +3,7 @@ use crate::AppState;
 use actix_files::NamedFile;
 use actix_web::HttpRequest;
 use commons::tracing::get_tracer;
-use commons::{self, api_response_error, format_request, Fallible, GraphError};
+use commons::{self, api_response_error, Fallible, GraphError};
 use opentelemetry::trace::{mark_span_as_active, Tracer};
 use prometheus::{histogram_opts, Histogram, IntCounterVec, Opts, Registry};
 use std::collections::HashSet;

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -8,7 +8,7 @@ use cincinnati::plugins::internal::versioned_graph::VersionedGraph;
 use cincinnati::plugins::{BoxedPlugin, InternalIO};
 use cincinnati::CONTENT_TYPE;
 use commons::tracing::get_tracer;
-use commons::{self, api_response_error, format_request, Fallible, GraphError};
+use commons::{self, api_response_error, Fallible, GraphError};
 use opentelemetry::{
     trace::{mark_span_as_active, FutureExt, Tracer},
     Context as ot_context,


### PR DESCRIPTION
this PR fixes the existing configs/settings, removes unused imports
and adds a sample deployment yaml that deploys the metadata-helper
container along with graph-builder and policy-engine. 
deploying metadata-helper is optional and is used to serve existing signatures