### PR TITLE
add sha256 as supported algo for metadata-helper

### DIFF
--- a/metadata-helper/src/signatures.rs
+++ b/metadata-helper/src/signatures.rs
@@ -24,7 +24,7 @@ lazy_static! {
     ))
     .unwrap();
     // Supported Signatures Algo
-    static ref SUPPORTED_ALGO: HashSet<&'static str> = HashSet::from(["sha"]);
+    static ref SUPPORTED_ALGO: HashSet<&'static str> = HashSet::from(["sha", "sha256"]);
 }
 
 /// Register relevant metrics to a prometheus registry.


### PR DESCRIPTION
most of the signatures served by metadata-helper use `sha256` algorithm. 
this PR basically adds support for `sha256` signatures. 
Earlier we used to reject requests citing `algo not supported`