### PR TITLE
use correct signatures URI and other fixes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -165,6 +165,13 @@ run-metadata-helper:
 		[status]
 		address = "127.0.0.1"
 		port = 9082
+
+		## uncomment [signatures] block to add a custom graph-data directory. Without this config,
+		## metadata-helper will create temp dir to source signatures. MH does not have capability to fetch
+		## signatures from upstream. If directory is not provided, MH wont be able to serve signatures.
+
+		# [signatures]
+		# dir = "/tmp/graph-data/signatures"
 	EOF
 	)
 

--- a/metadata-helper/src/main.rs
+++ b/metadata-helper/src/main.rs
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Error> {
                 actix_web::web::resource(&format!(
                     "{}{}",
                     &format!("{}/signatures", app_prefix),
-                    "/{ALGO}/{DIGEST}/{SIGNATURE}"
+                    "/{ALGO_DIGEST}/{SIGNATURE}"
                 ))
                 .route(actix_web::web::get().to(signatures::index)),
             )

--- a/metadata-helper/src/signatures.rs
+++ b/metadata-helper/src/signatures.rs
@@ -58,8 +58,18 @@ async fn _index(
     let timer = SIGNATURES_SERVE_HIST.start_timer();
 
     let params = req.match_info();
-    let algo = params.get("ALGO").unwrap();
-    let digest = params.get("DIGEST").unwrap();
+    let algo_digest_string = params.get("ALGO_DIGEST").unwrap();
+    let algo_digest: Vec<&str> = algo_digest_string.clone().split('=').collect();
+
+    if algo_digest.len() != 2 {
+        return Err(GraphError::InvalidParams(format!(
+            "provided digest is in incorrect format: {}",
+            algo_digest_string
+        )));
+    }
+
+    let algo = algo_digest[0];
+    let digest = algo_digest[1];
     let signature = params.get("SIGNATURE").unwrap();
 
     if !SUPPORTED_ALGO.contains(algo) {
@@ -78,8 +88,8 @@ async fn _index(
     if f.is_err() {
         timer.observe_duration();
         return Err(GraphError::DoesNotExist(format!(
-            "signature does not exist {}",
-            f.unwrap_err()
+            "signature {}/{}",
+            algo_digest_string, signature
         )));
     }
 


### PR DESCRIPTION
use the correct URI for signatures. Previously we used URI that was meant to be used for file system.

Also adds docs about running metadata-helper using just command.

Removes unnecessary information transferred through error message, now just states which signature does not exist.