### PR TITLE
OTA-946: openshift_secondary_metadata_parser: Support graph-data 1.2.0

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 pub static DEFAULT_KEY_FILTER: &str = "io.openshift.upgrades.graph";
-static SUPPORTED_VERSIONS: &[&str] = &["1.0.0", "1.1.0"];
+static SUPPORTED_VERSIONS: &[&str] = &["1.0.0", "1.1.0", "1.2.0"];
 
 pub mod graph_data_model {
     //! This module contains the data types corresponding to the graph data files.


### PR DESCRIPTION
openshift/cincinnati-graph-data@9e9e97cf2a (openshift/cincinnati-graph-data#3509) defined that graph-data version, adding only:

    signatures/{algorithm}/{digest}/signature-{number}

Cincinnati learned how to process those paths already in fb2066960f (#794) and #816. This commit just catches up the supported-version set, to avoid failing [like][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cincinnati-operator/176/pull-ci-openshift-cincinnati-operator-master-operator-e2e-hypershift-local-graph-data/1722001220597452800/artifacts/operator-e2e-hypershift-local-graph-data/e2e-test/artifacts/inspect/namespaces/openshift-updateservice/pods/example-5cd78cdf8b-vqcgv/graph-builder/graph-builder/logs/current.log | tail -n3
2023-11-07T21:50:33.646877602Z [2023-11-07T21:50:33Z TRACE cincinnati::plugins] Running next plugin 'openshift-secondary-metadata-parse'
2023-11-07T21:50:33.657154577Z [2023-11-07T21:50:33Z ERROR graph_builder::graph] unrecognized graph-data version 1.2.0
2023-11-07T21:50:33.657154577Z     ; supported versions: ["1.0.0", "1.1.0"]
```

when run against graph-data that declares itself to use the new version.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati-operator/176/pull-ci-openshift-cincinnati-operator-master-operator-e2e-hypershift-local-graph-data/1722001220597452800