### PR TITLE
OTA-915: metadata-helper/src/config/cli: Expose --signatures.dir

### DIFF
--- a/metadata-helper/src/config/cli.rs
+++ b/metadata-helper/src/config/cli.rs
@@ -20,6 +20,10 @@ pub struct CliOptions {
     #[structopt(flatten)]
     pub service: options::ServiceOptions,
 
+    // Signature service options
+    #[structopt(flatten)]
+    pub signatures: options::SignaturesOptions,
+
     // Status service options
     #[structopt(flatten)]
     pub status: options::StatusOptions,
@@ -35,6 +39,7 @@ impl MergeOptions<CliOptions> for AppSettings {
         };
 
         self.try_merge(Some(opts.service))?;
+        self.try_merge(Some(opts.signatures))?;
         self.try_merge(Some(opts.status))?;
 
         Ok(())
@@ -60,6 +65,10 @@ mod tests {
         let svc_port_args = vec!["argv0", "--service.port", "9999"];
         let svc_port_cli = CliOptions::from_iter_safe(svc_port_args).unwrap();
         assert_eq!(svc_port_cli.service.port, Some(9999));
+
+        let sig_dir_args = vec!["argv0", "--signtures.dir", "/a/b"];
+        let sig_dir_cli = CliOptions::from_iter_safe(sig_dir_args).unwrap();
+        assert_eq!(sig_dir_cli.signatures.dir, Some("/a/b"));
     }
 
     #[test]


### PR DESCRIPTION
Exposing the config setting from fb2066960f (#794) as a command-line option, so folks can pass it though without having to drop into TOML [or][1] [hitting][2]:

```
2023-11-08T00:01:57.621922383Z [2023-11-08T00:01:57Z INFO  metadata_helper] application settings:
2023-11-08T00:01:57.621922383Z     AppSettings {
2023-11-08T00:01:57.621922383Z         verbosity: Trace,
2023-11-08T00:01:57.621922383Z         address: ::,
2023-11-08T00:01:57.621922383Z         port: 8082,
2023-11-08T00:01:57.621922383Z         path_prefix: "/api/upgrades_info",
2023-11-08T00:01:57.621922383Z         status_address: ::,
2023-11-08T00:01:57.621922383Z         status_port: 9082,
2023-11-08T00:01:57.621922383Z         signatures_dir: "",
2023-11-08T00:01:57.621922383Z         tracing_endpoint: None,
2023-11-08T00:01:57.621922383Z         backlog: 10,
2023-11-08T00:01:57.621922383Z         max_connections: 10,
2023-11-08T00:01:57.621922383Z         max_connection_rate: 64,
2023-11-08T00:01:57.621922383Z         keep_alive: None,
2023-11-08T00:01:57.621922383Z         client_timeout: 5s,
2023-11-08T00:01:57.621922383Z     }
2023-11-08T00:01:57.622031074Z [2023-11-08T00:01:57Z INFO  metadata_helper] signatures data directory not provided, using /tmp/.tmp2r89fA
```

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati-operator/176/pull-ci-openshift-cincinnati-operator-master-operator-e2e-hypershift-local-graph-data/1722037234359603200
[2]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cincinnati-operator/176/pull-ci-openshift-cincinnati-operator-master-operator-e2e-hypershift-local-graph-data/1722037234359603200/artifacts/operator-e2e-hypershift-local-graph-data/e2e-test/artifacts/inspect/namespaces/openshift-updateservice/pods/example-695fd68b74-wjtv6/metadata/metadata/logs/current.log