### PR TITLE
add support for root certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,13 +1175,12 @@ dependencies = [
 [[package]]
 name = "dkregistry"
 version = "0.5.1-alpha.0"
-source = "git+https://github.com/camallo/dkregistry-rs.git?rev=6c4ac7700f8870e58aaa5a906a28e65cdf254d58#6c4ac7700f8870e58aaa5a906a28e65cdf254d58"
+source = "git+https://github.com/camallo/dkregistry-rs.git?rev=0a3c99b7ede0c177a4389e0ffd9e566572633f8c#0a3c99b7ede0c177a4389e0ffd9e566572633f8c"
 dependencies = [
  "async-stream",
  "base64 0.13.1",
  "bytes",
  "futures",
- "http 0.2.9",
  "libflate",
  "log",
  "mime",
@@ -1772,6 +1771,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http 0.2.9",
+ "hyper 0.14.28",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +1961,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -2963,6 +2976,7 @@ dependencies = [
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2972,12 +2986,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2998,6 +3016,35 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom 0.2.10",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3082,6 +3129,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "log",
+ "ring 0.17.3",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.3",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,6 +3212,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
 
 [[package]]
 name = "security-framework"
@@ -3391,6 +3491,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -3728,6 +3834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,6 +4045,18 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -17,7 +17,7 @@ prometheus = "0.13"
 protobuf = "2.20.0"
 quay = { path = "../quay" }
 regex = "^1.9.6"
-reqwest = { version = "^0.11", features = ["gzip"] }
+reqwest = { version = "^0.11", features = ["gzip", "rustls-tls-native-roots", "native-tls"] }
 serde = "1.0.189"
 serde_derive = "1.0.70"
 serde_json = "^1.0.107"
@@ -31,7 +31,7 @@ async-trait = "^0.1"
 tempfile = "^3.8.0"
 flate2 = "^1.0.27"
 tar = "^0.4.40"
-dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "6c4ac7700f8870e58aaa5a906a28e65cdf254d58" }
+dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "0a3c99b7ede0c177a4389e0ffd9e566572633f8c" }
 itertools = "^0.11"
 serde_yaml = "^0.9.25"
 prettydiff = { version = "0.6", optional = true }

--- a/cincinnati/src/plugins/internal/graph_builder/commons.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/commons.rs
@@ -1,3 +1,60 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use actix_web::Error;
+use commons::Fallible;
+use log::debug;
+use reqwest::Certificate;
+
+/// Retrives all the .pem and .crt certificate files from the directory.
+/// Scans till depth of 2, any file/directory below the depth of 2 will be ignored.
+pub fn get_certs_from_dir(dir: &Path) -> Fallible<Vec<Certificate>, Error> {
+    let mut certs: Vec<Certificate> = Vec::new();
+    let mut dirs: Vec<(PathBuf, u8)> = vec![(dir.to_path_buf(), 0)];
+    while !dirs.is_empty() {
+        let (dir, level) = dirs.pop().unwrap();
+        if let Ok(cert_paths) = std::fs::read_dir(dir) {
+            for path in cert_paths {
+                if let Ok(path) = path {
+                    if path.metadata().unwrap().is_file() {
+                        match path.path().extension() {
+                            Some(extension) => {
+                                if extension.to_ascii_lowercase() == "pem"
+                                    || extension.to_ascii_lowercase() == "crt"
+                                {
+                                    let mut cert_buf = Vec::new();
+                                    std::fs::File::open(&path.path())?
+                                        .read_to_end(&mut cert_buf)?;
+                                    let certificate = reqwest::Certificate::from_pem(&cert_buf);
+                                    if certificate.is_ok() {
+                                        debug!(
+                                            "Adding {} to certificates",
+                                            path.path().to_str().unwrap()
+                                        );
+                                        certs.push(certificate.unwrap());
+                                    } else {
+                                        debug!(
+                                            "unable to process certificate {}: {}",
+                                            path.file_name().to_str().unwrap_or_default(),
+                                            certificate.unwrap_err()
+                                        );
+                                    }
+                                };
+                            }
+                            None => {}
+                        };
+                    } else if path.metadata().unwrap().is_dir() {
+                        if level < 2 {
+                            dirs.push((path.path(), level + 1));
+                        };
+                    };
+                }
+            }
+        }
+    }
+    Ok(certs)
+}
+
 #[cfg(test)]
 pub mod tests {
     //! Common functionality for graph-builder tests

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -38,6 +38,8 @@ use url::form_urlencoded;
 pub static GRAPH_DATA_DIR_PARAM_KEY: &str = "io.openshift.upgrades.secondary_metadata.directory";
 /// Defines the key for placing the graph_data tar path in the IO parameters
 pub static SECONDARY_METADATA_PARAM_KEY: &str = "io.openshift.upgrades.secondary_metadata.tar";
+/// Defines the path of default root certificate that graph_data will use
+pub static DEFAULT_ROOT_CERT_DIR: &str = "/etc/pki/ca-trust/extracted/";
 
 lazy_static! {
     /// list of cincinnati versions


### PR DESCRIPTION
uses all the certificates in the directory to make calls. 
this will ensure that, if certificates exist, we'll use them.