### PR TITLE
revert mockito to older version and fix tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,6 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
- "mockito",
  "opentelemetry",
  "opentelemetry-jaeger",
  "prometheus",
@@ -2102,8 +2101,6 @@ dependencies = [
  "hyper 1.1.0",
  "lazy_static",
  "log",
- "memchr",
- "mockito",
  "opentelemetry",
  "parking_lot",
  "prometheus",
@@ -2167,21 +2164,20 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "1.2.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d3038e23466858569c2d30a537f691fa0d53b51626630ae08262943e3bbb8b"
+checksum = "80f9fece9bd97ab74339fe19f4bcaf52b76dcc18e5364c7977c1838f76b38de9"
 dependencies = [
  "assert-json-diff",
  "colored",
- "futures",
- "hyper 0.14.28",
+ "httparse",
+ "lazy_static",
  "log",
  "rand 0.8.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
  "similar",
- "tokio",
 ]
 
 [[package]]
@@ -2361,9 +2357,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openapiv3"
-version = "1.0.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e56d5c441965b6425165b7e3223cc933ca469834f4a8b4786817a1f9dc4f13"
+checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
 dependencies = [
  "indexmap 2.0.0",
  "serde",

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -46,7 +46,7 @@ hamcrest2 = "0.3.0"
 cached = "^0.44.0"
 
 [dev-dependencies]
-mockito = "^1.2.0"
+mockito = "0.31.1"
 serde_json = "1.0.107"
 memchr = "^2.5"
 pretty_assertions = "1.4.0"

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -29,4 +29,3 @@ hamcrest2 = "0.3.0"
 
 [dev-dependencies]
 memchr = "^2.5"
-mockito = "^1.2.0"

--- a/metadata-helper/Cargo.toml
+++ b/metadata-helper/Cargo.toml
@@ -37,5 +37,3 @@ built = { version = "^0.7.0", features = [ "git2" ]}
 
 [dev-dependencies]
 tokio = { version = "1.32", features = [ "rt-multi-thread" ] }
-memchr = "^2.5"
-mockito = "1.2.0"

--- a/policy-engine/Cargo.toml
+++ b/policy-engine/Cargo.toml
@@ -16,7 +16,7 @@ futures = "^0.3"
 hyper = "^1.1"
 lazy_static = "^1.2.0"
 log = "^0.4.20"
-openapiv3 = "1.0"
+openapiv3 = "2.0.0"
 parking_lot = "^0.12"
 prometheus = "0.13"
 semver = { version = "^0.11", features = [ "serde" ] }
@@ -38,4 +38,4 @@ built = { version = "^0.7.0", features = [ "git2" ]}
 [dev-dependencies]
 tokio = { version = "1.32", features = [ "rt-multi-thread" ] }
 memchr = "^2.5"
-mockito = "^1.2.0"
+mockito = "0.31.1"

--- a/policy-engine/src/openapi.rs
+++ b/policy-engine/src/openapi.rs
@@ -156,7 +156,7 @@ mod tests {
             .cloned()
             .map(String::from)
             .collect();
-        let path_prefix = "test_prefix".to_string();
+        let path_prefix = "".to_string();
 
         let data = actix_web::web::Data::new(AppState {
             mandatory_params: mandatory_params.clone(),

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.2",
+    "openapi": "3.0.3",
     "info": {
         "version": "0.0.0",
         "title": "OpenShift Cincinnati Policy-Engine",
@@ -71,7 +71,7 @@
         "/v1/graph": {
             "get": {
                 "summary": "Get the update graph",
-                "operationId": "getGraph",
+                "operationId": "getV1Graph",
                 "responses": {
                     "200": {
                         "description": "An update graph",


### PR DESCRIPTION
fix failing tests and reverts mockito dependency to older version. mockito had a major rewrite and changes the way it functions, which will require a major refactor for tests in cincinnati wherever mockito dependency is used.
We might have to either replace the dependency with something similar or refactor the tests.
The issue with newer version of mockito is that individual tests pass but when all the tests are run simaltaneously, the tests might use another instance of the mock which gives us incorrect and inconsistant mock