### PR TITLE
OCPBUGS-22392: support namespaced auth for registries

### DIFF
--- a/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/dkrv2_openshift_secondary_metadata_scraper/plugin.rs
@@ -188,16 +188,21 @@ impl DkrV2OpenshiftSecondaryMetadataScraperPlugin {
 
         let data_dir = tempfile::tempdir_in(&settings.output_directory)?;
 
-        let registry = registry::Registry::try_from_str(&settings.registry)
-            .context(format!("Parsing {} as Registry", &settings.registry))?;
+        let mut ns_registry = settings.registry.clone();
+        ns_registry.push_str(&settings.repository);
+
+        let registry = registry::Registry::try_from_str(&ns_registry)
+            .context(format!("trying to extract Registry from {}", &ns_registry))?;
 
         if let Some(credentials_path) = &settings.credentials_path {
-            let (username, password) =
-                registry::read_credentials(Some(credentials_path), &registry.host_port_string())
-                    .context(format!(
-                        "Reading registry credentials from {:?}",
-                        credentials_path
-                    ))?;
+            let (username, password) = registry::read_credentials(
+                Some(credentials_path),
+                &registry.host_port_namespaced_string(),
+            )
+            .context(format!(
+                "Reading registry credentials from {:?}",
+                credentials_path
+            ))?;
 
             settings.username = username;
             settings.password = password;

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/plugin.rs
@@ -117,18 +117,21 @@ impl ReleaseScrapeDockerv2Plugin {
             prometheus_registry.register(Box::new(graph_upstream_raw_releases.clone()))?;
         }
 
-        let registry = registry::Registry::try_from_str(&settings.registry)
-            .context(format!("Parsing {} as Registry", &settings.registry))?;
+        let mut ns_registry = settings.registry.clone();
+        ns_registry.push_str(&format!("/{}", settings.repository));
+
+        let registry = registry::Registry::try_from_str(&ns_registry)
+            .context(format!("trying to extract Registry from {}", &ns_registry))?;
 
         if let Some(credentials_path) = &settings.credentials_path {
             let (username, password) = registry::read_credentials(
                 Some(credentials_path),
-                &registry.host_port_string(),
+                &registry.host_port_namespaced_string(),
             )
             .unwrap_or_else(|err| {
                 warn!(
                     "Error reading registry credentials from {:?}. Access to {:?} will be unauthenticated: {} ",
-                    credentials_path, &registry.host_port_string() ,err
+                    credentials_path, &registry.host_port_namespaced_string() ,err
                 );
                 (None, None)
             });


### PR DESCRIPTION
this commit adds support for namespaced auth in cincinnati.
we'll be able to support dockerconfigjson that have namespaced
auth like `sub.domain.com/ns1`

previously cincinnati used to ignore `/ns1` part and just checked
for `sub.domain.com` which resulted in namespaced auth being not found