### PR TITLE
OTA-1302: dist/openshift: Pivot PodDisruptionBudgets to maxUnavailable

### DIFF
--- a/dist/openshift/cinci-with-mh-deployment.yaml
+++ b/dist/openshift/cinci-with-mh-deployment.yaml
@@ -311,7 +311,7 @@ objects:
       name: cincinnati-pdb
       namespace: cincinnati
     spec:
-      minAvailable: ${{PDB_MIN}}
+      maxUnavailable: 1
       selector:
         matchLabels:
           app: cincinnati
@@ -530,6 +530,4 @@ parameters:
   - name: ENVIRONMENT_SECRETS
     value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
   - name: REPLICAS
-    value: "1"
-  - name: PDB_MIN
     value: "1"

--- a/dist/openshift/cincinnati-deployment.yaml
+++ b/dist/openshift/cincinnati-deployment.yaml
@@ -230,7 +230,7 @@ objects:
       name: cincinnati-pdb
       namespace: cincinnati
     spec:
-      minAvailable: ${{PDB_MIN}}
+      maxUnavailable: 1
       selector:
         matchLabels:
           app: cincinnati
@@ -394,6 +394,4 @@ parameters:
   - name: ENVIRONMENT_SECRETS
     value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
   - name: REPLICAS
-    value: "1"
-  - name: PDB_MIN
     value: "1"

--- a/dist/openshift/cincinnati.yaml
+++ b/dist/openshift/cincinnati.yaml
@@ -231,7 +231,7 @@ objects:
       name: cincinnati-pdb
       namespace: cincinnati
     spec:
-      minAvailable: ${{PDB_MIN}}
+      maxUnavailable: 1
       selector:
         matchLabels:
           app: cincinnati
@@ -395,6 +395,4 @@ parameters:
   - name: ENVIRONMENT_SECRETS
     value: '{ "CINCINNATI_GITHUB_SCRAPER_OAUTH_TOKEN_PATH": "/etc/secrets/github_token.key" }'
   - name: REPLICAS
-    value: "1"
-  - name: PDB_MIN
     value: "1"


### PR DESCRIPTION
We've had the PDB_MIN knob since 27f4cb0ac9 (#717).  And while known clients like the cluster-version operator can all gracefully recover from periodic hiccups in update service availability, our current app-interface Envoy configuration seems to latch failing with a loop something like:

1. Everything is happy.
2. Temporary disruption, such as rolling compute nodes, reduces Cincinnati-Pod capacity below the current client load.
3. Envoy, or possibly something else in the deep networking stack between clients and the Cincinnati Pods, tries to be helpful by holding "extra" queries, instead of passing them through to the Cincinnati Pods or rejecting the queries with a [429 Too Many Requests][1] and a [Retry-After][2].
4. Cincinnati-Pod capacity recovers.
5. But continued Envoy-side throttling keeps the backlog of extra queries from draining out.
6. We sit stuck until manual action like scaling up more Cincinnati Pods convinces Envoy to allow the extra queries through.
7. Increased query flow drains the backlog, return to step 1.

As long as we are latching-failing like that, we want to be very conservative in allowing intentional disruption, and `maxUnavailable: 1` gives us that, without needing a tunable knob.  If in the future we get the latching fixed, e.g. by configuring our network stack to 429 extra requests, we can move to a hard-coded 50% or similar, and still won't need a knob.

[1]: https://www.rfc-editor.org/rfc/rfc6585#section-4
[2]: https://www.rfc-editor.org/rfc/rfc7231#section-7.1.3