### PR TITLE
OTA-15: Return `400 Bad Request` for responses that contain an empty graph

### DIFF
--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -85,6 +85,10 @@ pub enum GraphError {
     /// Resource does not exist
     #[error("does not exist: {}", _0)]
     DoesNotExist(String),
+
+    /// No version were found.
+    #[error("no versions found: {}", _0)]
+    NoVersionsFound(String),
 }
 
 impl actix_web::error::ResponseError for GraphError {
@@ -129,6 +133,7 @@ impl GraphError {
             GraphError::ArchVersionError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
             GraphError::FileOpenError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
             GraphError::DoesNotExist(_) => http::StatusCode::NOT_FOUND,
+            GraphError::NoVersionsFound(_) => http::StatusCode::BAD_REQUEST,
         }
     }
 
@@ -146,6 +151,7 @@ impl GraphError {
             GraphError::ArchVersionError(_) => "arch_version_error",
             GraphError::FileOpenError(_) => "file_open_err",
             GraphError::DoesNotExist(_) => "does_not_exist",
+            GraphError::NoVersionsFound(_) => "no_versions_found",
         };
         kind.to_string()
     }

--- a/policy-engine/src/graph.rs
+++ b/policy-engine/src/graph.rs
@@ -113,6 +113,12 @@ where
         Err(other_error) => GraphError::FailedPluginExecution(other_error.to_string()),
     })?;
 
+    if internal_io.graph.releases_count() == 0 {
+        return Err(GraphError::NoVersionsFound(
+            "the specified architecture and/or channel does not contain any versions".to_string(),
+        ));
+    }
+
     let versioned_graph = add_version_information(&internal_io);
 
     let graph_json = serde_json::to_string(&versioned_graph)


### PR DESCRIPTION
Return `400 Bad Request` for responses that contain an empty graph. Such
responses are currently only generated when a specified channel and
architecture result in an empty update graph due to the filtering.

This commit is part of the effort to improve the UX regarding requests
that contain invalid query parameters. In the future, more fine-grained
return messages will be returned.

This pull request references https://issues.redhat.com/browse/OTA-15 