### PR TITLE
OTA-1338: dist/cargo_test.sh: Fix various issues 

### DIFF
--- a/dist/cargo_test.sh
+++ b/dist/cargo_test.sh
@@ -31,16 +31,17 @@ function run_tests() {
     rm -rf "${CARGO_TARGET_DIR}"/cov
   fi
 
+  has_failed=false
   for directory in ${!cargo_test_flags[*]}; do
     if [[ "${HAS_KOV}" -eq "1" ]]; then
       # we want to prevent completely untested functions to be stripped
       export RUSTFLAGS='-C link-dead-code'
     fi
 
-    (
-      ${1} /usr/bin/env bash -c "\
-        set -x
+    if ! /usr/bin/env bash -c "\
+        set -xe
         cd ${directory}
+        cargo test --no-run
         mapfile -t tests < <(
           cargo test --no-run --message-format=json ${cargo_test_flags[${directory}]} | \
             jq -r 'select(.profile.test == true) | .executable'
@@ -56,8 +57,9 @@ function run_tests() {
             \$test
           fi
         done
-      "
-    )
+      "; then
+      has_failed=true
+    fi
 
   done
 
@@ -65,6 +67,11 @@ function run_tests() {
     mkdir -p "${ARTIFACTS_DIR}"
     [[ ! -e "${ARTIFACTS_DIR}"/cov ]] || rm -rf "${ARTIFACTS_DIR}"/cov
     cp -rf "${CARGO_TARGET_DIR}"/cov "${ARTIFACTS_DIR}"/
+  fi
+
+  if [ "${has_failed}" == true ]; then
+    echo "at least one error has occurred while running tests; check the output for more information"
+    exit 1
   fi
 
   set +x

--- a/prometheus-query/Cargo.toml
+++ b/prometheus-query/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 commons = { path = "../commons" }
 anyhow = "^1.0"
 futures = "^0.3"
-reqwest = "^0.11"
+reqwest = { version = "^0.11", features = ["blocking", "json"] }
 serde = { version = "^1.0.189", features = ["derive"] }
 serde_derive = "^1.0.84"
 serde_json = "^1.0.109"


### PR DESCRIPTION
The goal of this PR is to fix various issues that prevent the `cargo-test` job to run.

---

[dist/cargo_test.sh: Fail on compile errors](https://github.com/openshift/cincinnati/pull/934/commits/f0d13bce0d7a1490be2e1a6adef02e2128e6b1d7) 

Currently, the `cargo_test.sh` script skips compilation errors of tests,
subsequently does not run the non-existing tests, and exits with a zero
exit code, as no tests failed technically.

On the line:
```
mapfile -t tests < <(
    cargo test --no-run --message-format=json ${cargo_test_flags[${directory}]} | \
    jq -r 'select(.profile.test == true) | .executable'
)
```

the `cargo test` compiles tests. However, when a compilation fails, this
does not cause the script to fail. The exit code is ignored, and the
output is piped to the `jq` command, which continues with a non-zero
code as it parses the json message successfully. However, as no tests
exist, the script continues.

This commit will compile the tests and check for the exit-code of a
compilation. The `cargo test --no-run` command is used to provide
human-readable output of compilation errors. On a non-zero exit code,
the overall script fails immediately. Originally, the script failed on a
first failed test, this commit will ensure the script fails on a first
failed test or a first compilation error.

---

[dist/cargo_test.sh: Fail on any failed test](https://github.com/openshift/cincinnati/pull/934/commits/3fe2fac5e1da6b210d3a771c67c93ec43fdc6a6d) 

Fix the script to fail on any failed test. Currently, the script fails
only when the last element in the `tests` array exits with a non-zero
exit code.

Refactor the compilation of tests to fail the script using
the introduced `-e` option.

---

[prometheus-query/Cargo.toml: Add missing reqwest features](https://github.com/openshift/cincinnati/pull/934/commits/6cda3e613543f503931d643e7d429a721e1b9cd1) 

These features are needed for the code to compile.

---

[dist/cargo_test.sh: Run all tests before exiting due to failure](https://github.com/openshift/cincinnati/pull/934/commits/134b5fe87e44e9cb18388be41b53e6748fb8be76)