### PR TITLE
NO-JIRA: dist/Dockerfile.e2e-ubi8/Dockerfile: Fix the `oc` binary to be compatible with the `ubi:8` base image 

### DIFF
--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR "${HOME}/cincinnati"
 
 # Get oc CLI
 RUN mkdir -p ${HOME}/bin && \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
 ENV PATH="${PATH}:${HOME}/bin"
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test


### PR DESCRIPTION
Fix the `oc` binary downloaded for CI tests to be compatible with the
used base image `ubi8`.

From the release notes of OCP 4.16 [1]:
```
...With this release, the default version of OpenShift CLI (oc) is
compiled with Red Hat Enterprise Linux (RHEL) 9 and works properly when
running a cluster with FIPS enabled on RHEL 9. Additionally, a version
of oc compiled with RHEL 8 is also provided, which must be used if you
are running a cluster with FIPS enabled on RHEL 8. (OCPBUGS-23386,
OCPBUGS-28540)
```

The amd64 architecture is chosen as the vegeta binary is as well
downloaded for amd64 machines in the same Dockerfile. The
configuration [2] for the e2e test ensures the architecture to be amd64.

[1] https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-known-issues_release-notes
[2] https://github.com/openshift/release/blob/5a96e1d5df9bd8d98b1e1c92a92f4e1841cf445d/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml#L130