### PR TITLE
OTA-1338: dist/cargo_test.sh: Remove coverage, create junits

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.ci]
+# Print out output for failing tests only at the end of the run (it is ugly otherwise)
+failure-output = "final"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+
+[profile.ci.junit]  # this can be some other profile, too
+path = "junit.xml"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 **/*.swp
 .idea
+junit_*.xml

--- a/dist/cargo_test.sh
+++ b/dist/cargo_test.sh
@@ -7,7 +7,8 @@ cargo_test_flags["cincinnati"]="--features test-net"
 cargo_test_flags["commons"]=""
 cargo_test_flags["graph-builder"]="--features test-net"
 cargo_test_flags["policy-engine"]=""
-# TODO: Are we missing metadata-helper and rh-manifest-generator here?
+cargo_test_flags["metadata-helper"]=""
+cargo_test_flags["rh-manifest-generator"]=""
 cargo_test_flags["prometheus-query"]=""
 cargo_test_flags["quay"]="--features test-net"
 

--- a/dist/cargo_test.sh
+++ b/dist/cargo_test.sh
@@ -7,6 +7,7 @@ cargo_test_flags["cincinnati"]="--features test-net"
 cargo_test_flags["commons"]=""
 cargo_test_flags["graph-builder"]="--features test-net"
 cargo_test_flags["policy-engine"]=""
+# TODO: Are we missing metadata-helper and rh-manifest-generator here?
 cargo_test_flags["prometheus-query"]=""
 cargo_test_flags["quay"]="--features test-net"
 
@@ -22,52 +23,36 @@ fi
 declare -A executors
 executors["cargo"]="execute_native"
 
+# Spurious dead code warning
+# shellcheck disable=SC2317
 function run_tests() {
   set -x
+  export ARTIFACT_DIR=${ARTIFACT_DIR:-.}
   export CARGO_TARGET_DIR="$PWD/target"
 
-  if [[ $(type -f kcov) ]]; then
-    export HAS_KOV="${HAS_KOV:-1}"
-    rm -rf "${CARGO_TARGET_DIR}"/cov
+  RUNNER="nextest"
+  if ! cargo nextest --version; then
+    echo "Preferred runner nextest not found"
+    if [ -n "$CI" ]; then
+      echo "Fallback to standard test runner not desirable in CI: exiting"
+      exit 1
+    else
+      echo "Falling back from $RUNNER to standard Rust runner"
+      RUNNER="test"
+    fi
   fi
 
   has_failed=false
   for directory in ${!cargo_test_flags[*]}; do
-    if [[ "${HAS_KOV}" -eq "1" ]]; then
-      # we want to prevent completely untested functions to be stripped
-      export RUSTFLAGS='-C link-dead-code'
+    # intentional, flags need to expand to multiple strings
+    # shellcheck disable=SC2086
+    if [ "$RUNNER" == "nextest" ]; then
+      cargo nextest run --profile ci ${cargo_test_flags[$directory]} --package "${directory}" || has_failed=true
+      cp -r "${CARGO_TARGET_DIR}/nextest/ci/junit.xml" "${ARTIFACT_DIR}/junit_${directory}.xml"
+    else
+      cargo test ${cargo_test_flags[$directory]} --package "${directory}" || has_failed=true
     fi
-
-    if ! /usr/bin/env bash -c "\
-        set -xe
-        cd ${directory}
-        cargo test --no-run
-        mapfile -t tests < <(
-          cargo test --no-run --message-format=json ${cargo_test_flags[${directory}]} | \
-            jq -r 'select(.profile.test == true) | .executable'
-        )
-        for test in \${tests[@]}; do
-          if [[ \"${HAS_KOV}\" -eq \"1\" ]]; then
-            kcov \
-              --exclude-pattern=$HOME/.cargo \
-              --verify \
-              ${CARGO_TARGET_DIR}/cov \
-              \$test
-          else
-            \$test
-          fi
-        done
-      "; then
-      has_failed=true
-    fi
-
   done
-
-  if [[ "${HAS_KOV}" -eq "1" && -n "${ARTIFACTS_DIR}" ]]; then
-    mkdir -p "${ARTIFACTS_DIR}"
-    [[ ! -e "${ARTIFACTS_DIR}"/cov ]] || rm -rf "${ARTIFACTS_DIR}"/cov
-    cp -rf "${CARGO_TARGET_DIR}"/cov "${ARTIFACTS_DIR}"/
-  fi
 
   if [ "${has_failed}" == true ]; then
     echo "at least one error has occurred while running tests; check the output for more information"


### PR DESCRIPTION
It does not seem that code coverage was actually used all, but it made the `cargo_test.sh` unnecessarily complicated by a search for individual test binaries that were then executed separately. The complexity of the bash involved caused us to not even notice when the tests actually failed to compile.

Therefore, remove the coverage-related bash and use Nextest (https://nexte.st) as a test runner. We did not use coverage, but we do use Prow, but because our tests never produced JUnit artifacts that Prow could display, we had to invest the raw test output when tests failed. If we start using tooling that produces JUnit XMLs, our CI jobs can report the individual tests that failed together with their associated output.

When run locally, the script falls back to standard runner when Nextest is not present. In CI, the script fails without Nextest (we do not want CI to silently stop producing JUnits).