### PR TITLE
OTA-1348: Fix typos in the metadata-helper unit tests

### DIFF
--- a/metadata-helper/src/config/cli.rs
+++ b/metadata-helper/src/config/cli.rs
@@ -66,7 +66,7 @@ mod tests {
         let svc_port_cli = CliOptions::from_iter_safe(svc_port_args).unwrap();
         assert_eq!(svc_port_cli.service.port, Some(9999));
 
-        let sig_dir_args = vec!["argv0", "--signtures.dir", "/a/b"];
+        let sig_dir_args = vec!["argv0", "--signatures.dir", "/a/b"];
         let sig_dir_cli = CliOptions::from_iter_safe(sig_dir_args).unwrap();
         assert_eq!(sig_dir_cli.signatures.dir, Some("/a/b".to_string()));
     }

--- a/metadata-helper/src/config/file.rs
+++ b/metadata-helper/src/config/file.rs
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn toml_merge_settings() {
         let mut settings = AppSettings::default();
-        assert_eq!(settings.status_port, 9081);
+        assert_eq!(settings.status_port, 9082);
 
         let toml_input = "status.port = 2222";
         let file_opts: FileOptions = toml::from_str(toml_input).unwrap();


### PR DESCRIPTION
This PR will fix two failing metadata-helper unit tests by fixing their typos.