### PR TITLE
OTA-1348: Improve the diff output in the `compare_graphs_verbose` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "similar",
  "smart-default",
  "strum 0.26.2",
  "strum_macros 0.25.2",
@@ -3416,9 +3417,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,6 @@ dependencies = [
  "opentelemetry",
  "pgp",
  "pretty_assertions",
- "prettydiff",
  "prometheus",
  "protobuf",
  "protoc-rust",
@@ -948,27 +947,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,27 +1125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dkregistry"
 version = "0.5.1-alpha.0"
 source = "git+https://github.com/camallo/dkregistry-rs.git?rev=0a3c99b7ede0c177a4389e0ffd9e566572633f8c#0a3c99b7ede0c177a4389e0ffd9e566572633f8c"
@@ -1246,12 +1203,6 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2454,15 +2405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pad"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,32 +2609,6 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi",
-]
-
-[[package]]
-name = "prettydiff"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1fec61082821f8236cf6c0c14e8172b62ce8a72a0eedc30d3b247bb68dc11"
-dependencies = [
- "ansi_term",
- "pad",
- "prettytable-rs",
- "structopt",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width",
 ]
 
 [[package]]
@@ -2910,17 +2826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -3653,17 +3558,6 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix 0.38.7",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -52,6 +52,7 @@ memchr = "^2.7"
 pretty_assertions = "1.4.0"
 test-case = "1.2.3"
 prettydiff = "0.6"
+similar = "2.6.0"
 
 [build-dependencies]
 protoc-rust = "2.28"

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -34,7 +34,6 @@ tar = "^0.4.40"
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs.git", rev = "0a3c99b7ede0c177a4389e0ffd9e566572633f8c" }
 itertools = "^0.12"
 serde_yaml = "^0.9.25"
-prettydiff = { version = "0.6", optional = true }
 opentelemetry = "0.14.0"
 strum = "^0.26"
 strum_macros = "^0.25"
@@ -51,7 +50,6 @@ serde_json = "1.0.109"
 memchr = "^2.7"
 pretty_assertions = "1.4.0"
 test-case = "1.2.3"
-prettydiff = "0.6"
 similar = "2.6.0"
 
 [build-dependencies]
@@ -62,4 +60,4 @@ codegen-protoc = []
 test-net = []
 test-net-private = []
 # Used on a few implementations which shall not be used in non-test code
-test = [ "prettydiff" ]
+test = []

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -43,6 +43,7 @@ pgp = "^0.7.2"
 zeroize = "=1.3.0"
 hamcrest2 = "0.3.0"
 cached = "^0.44.0"
+similar = { version = "2.6.0", optional = true }
 
 [dev-dependencies]
 mockito = "0.31.1"
@@ -60,4 +61,4 @@ codegen-protoc = []
 test-net = []
 test-net-private = []
 # Used on a few implementations which shall not be used in non-test code
-test = []
+test = ["similar"]

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -1084,34 +1084,44 @@ pub mod testing {
 
         let edges_left = left.get_edges(false)?;
         let edges_right = right.get_edges(false)?;
+        let diff_radius = 25;
         output.push("edges: ".into());
         output.push(
-            prettydiff::diff_lines(
+            similar::TextDiff::from_lines(
                 &serde_json::to_string_pretty(&edges_left)?,
                 &serde_json::to_string_pretty(&edges_right)?,
             )
-            .format(),
+            .unified_diff()
+            .context_radius(diff_radius)
+            .header("left", "right")
+            .to_string(),
         );
 
         let releases_left: std::collections::BTreeSet<Release> = (&left).into();
         let releases_right: std::collections::BTreeSet<Release> = (&right).into();
         output.push("nodes:".into());
         output.push(
-            prettydiff::diff_lines(
+            similar::TextDiff::from_lines(
                 Box::leak(Box::new(serde_json::to_string_pretty(&releases_left)?)),
                 Box::leak(Box::new(serde_json::to_string_pretty(&releases_right)?)),
             )
-            .format(),
+            .unified_diff()
+            .context_radius(diff_radius)
+            .header("left", "right")
+            .to_string(),
         );
 
         if !settings.unwanted_metadata_keys.is_empty() {
             output.push("removed metadata:".into());
             output.push(
-                prettydiff::diff_lines(
+                similar::TextDiff::from_lines(
                     &serde_json::to_string_pretty(&removed_keys_left)?,
                     &serde_json::to_string_pretty(&removed_keys_right)?,
                 )
-                .format(),
+                .unified_diff()
+                .context_radius(diff_radius)
+                .header("left", "right")
+                .to_string(),
             );
         }
 


### PR DESCRIPTION
The previously used prettydiff library outputted the difference in lines
using colored text to differentiate between changes. However, the
colored text can't be observed in logs. The library also outputted all
of the processed lines. This resulted in ten of thousands of lines.

The newly used similar library fixes all of the above-mentioned issues.

A larger context radius is chosen as the context can be easily lost in
the logs otherwise.

Example of the new output:
```
--- left
+++ right
@@ -377,57 +377,57 @@
   "4.7.28+ppc64le": {
     "io.openshift.upgrades.graph.previous.remove_regex": "^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0-9]|4[.]7[.]2[0123])[+].*$"
   },
   "4.7.28+s390x": {
     "io.openshift.upgrades.graph.previous.remove_regex": "^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0-9]|4[.]7[.]2[0123])[+].*$"
   },
   "4.7.29+amd64": {
     "io.openshift.upgrades.graph.previous.remove_regex": "^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0123456789]|4[.]7[.]2[0123])[+].*$"
   },
   "4.7.29+ppc64le": {
     "io.openshift.upgrades.graph.previous.remove_regex": "^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0123456789]|4[.]7[.]2[0123])[+].*$"
   },
   "4.7.29+s390x": {
     "io.openshift.upgrades.graph.previous.remove_regex": "^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0123456789]|4[.]7[.]2[0123])[+].*$"
   },
   "4.7.3+amd64": {
     "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*"
   },
   "4.7.3+ppc64le": {
     "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*"
   },
   "4.7.3+s390x": {
     "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*"
   },
   "4.7.4+amd64": {
-    "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*"
+    "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*|4\\.6\\..*|.*"
   },
```