### PR TITLE
OTA-1348: Increment `http_upstream_reqs` on errors

### DIFF
--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -239,6 +239,9 @@ mod tests {
                     parameters: Default::default(),
                 });
 
+                // TODO: This check is not reliable, it seems the individual tests interact with each other somehow?
+                // Apparently sometimes the plugins talk to a different mock than expected (such as one created in
+                // "failure" tests). Reproduce by commenting out failure tests, suddenly all success tests pass.
                 let processed_graph = runtime
                     .block_on(future_processed_graph)
                     .expect("plugin run failed")
@@ -302,6 +305,9 @@ mod tests {
                     parameters: Default::default(),
                 });
 
+                // TODO: This check is not reliable, it seems the individual tests interact with each other somehow?
+                // Apparently sometimes the plugins talk to a different mock than expected (such as one created in
+                // "success" tests). Reproduce by commenting out success tests, suddenly all failure tests pass.
                 assert!(runtime.block_on(future_result).is_err());
 
                 assert_eq!(1, plugin.http_upstream_reqs.get() as usize);

--- a/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
+++ b/cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs
@@ -230,11 +230,9 @@ mod tests {
                 let timeout: u64 = 30;
                 let plugin =
                     CincinnatiGraphFetchPlugin::try_new(mockito::server_url(), timeout, None)?;
-                let http_upstream_reqs = plugin.http_upstream_reqs.clone();
-                let http_upstream_errors_total = plugin.http_upstream_errors_total.clone();
 
-                assert_eq!(0, http_upstream_reqs.clone().get() as u64);
-                assert_eq!(0, http_upstream_errors_total.clone().get() as u64);
+                assert_eq!(0, plugin.http_upstream_reqs.get() as u64);
+                assert_eq!(0, plugin.http_upstream_errors_total.get() as u64);
 
                 let future_processed_graph = plugin.run_internal(InternalIO {
                     graph: Default::default(),
@@ -248,8 +246,8 @@ mod tests {
 
                 assert_eq!($expected_graph, processed_graph);
 
-                assert_eq!(1, http_upstream_reqs.get() as u64);
-                assert_eq!(0, http_upstream_errors_total.get() as u64);
+                assert_eq!(1, plugin.http_upstream_reqs.get() as u64);
+                assert_eq!(0, plugin.http_upstream_errors_total.get() as u64);
 
                 Ok(())
             }
@@ -295,11 +293,9 @@ mod tests {
                     .create();
 
                 let plugin = CincinnatiGraphFetchPlugin::try_new($upstream.to_string(), 30, None)?;
-                let http_upstream_reqs = plugin.http_upstream_reqs.clone();
-                let http_upstream_errors_total = plugin.http_upstream_errors_total.clone();
 
-                assert_eq!(0, http_upstream_reqs.clone().get() as u64);
-                assert_eq!(0, http_upstream_errors_total.clone().get() as u64);
+                assert_eq!(0, plugin.http_upstream_reqs.get() as u64);
+                assert_eq!(0, plugin.http_upstream_errors_total.get() as u64);
 
                 let future_result = plugin.run_internal(InternalIO {
                     graph: Default::default(),
@@ -308,8 +304,8 @@ mod tests {
 
                 assert!(runtime.block_on(future_result).is_err());
 
-                assert_eq!(1, http_upstream_reqs.get() as usize);
-                assert_eq!(1, http_upstream_errors_total.get() as usize);
+                assert_eq!(1, plugin.http_upstream_reqs.get() as usize);
+                assert_eq!(1, plugin.http_upstream_errors_total.get() as usize);
 
                 Ok(())
             }


### PR DESCRIPTION
**increment `http_upstream_reqs` on errors**

Previously the `http_upstream_reqs` was only incremented when `cached_graph`
call was successful (and result was not cached). When `cached_graph` actually
made the call internally but it was not successful, the `.await?` shortcut
returned the error right away and the counter was never incremented, even
when the call was actually made.

This is actually tested in the `fetch_upstream_failure_test` macro:

```rust
assert_eq!(1, plugin.http_upstream_reqs.get() as usize);
```

These tests are failing for some time and it is hard to imagine how they
were ever passing.

---

**cincinnati_graph_fetch: simplify tests**

The `clone()` calls are `Arc::clone()` tests under the hood, so they
result in returning smart pointers. This is legit (we still `get()` on a
correct thing when testing) but it does not seem to be necessary and it
is confusing (how are we expecting a clone to be incremented? aha, they
are not actually clones under the hood!) so we can remove them

---

**cincinnati-graph-fetch: add comments about reliability**

During pair programming with David we discovered these tests are flaking:

There is a check that blocks on the asychnonous IO operation and asserts
that its result was an error (failure tests) or not (success test):

```rust
assert!(runtime.block_on(future_result).is_err());
```

We have seen these flaking as if individual tests interacted with each
other, such as if the plugin actually communicated with a graph-builder
mock created in a different test. This can be reproduced easily by running
all tests locally (some will randomly fail), then comment out the success
ones, suddenly all failure tests pass. This still indicates the tests
are not working correctly (they still communicate with a differently
failing mock server).

```
assertion failed: runtime.block_on(future_result).is_err()
thread 'plugins::internal::cincinnati_graph_fetch::tests::fetch_fail_request_fails_with_404' panicked at cincinnati/src/plugins/internal/cincinnati_graph_fetch.rs:338:5:
assertion failed: runtime.block_on(future_result).is_err()
```
