### PR TITLE
NO-JIRA: deps: remove unused `failure` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-case",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "toml 0.8.2",
@@ -1161,7 +1162,6 @@ dependencies = [
  "cincinnati",
  "commons",
  "env_logger",
- "failure",
  "hamcrest2",
  "lazy_static",
  "prometheus-query",
@@ -1251,28 +1251,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,18 +3571,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cincinnati/Cargo.toml
+++ b/cincinnati/Cargo.toml
@@ -44,6 +44,7 @@ zeroize = "=1.3.0"
 hamcrest2 = "0.3.0"
 cached = "^0.44.0"
 similar = { version = "2.6.0", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 mockito = "0.31.1"

--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -179,10 +179,8 @@ pub struct Empty;
 
 /// Errors that can be returned by the methods in this library
 pub mod errors {
-    use commons::prelude_errors::*;
-
     /// Edge already exists
-    #[derive(Debug, Fail, Eq, PartialEq)]
+    #[derive(Debug, thiserror::Error, Eq, PartialEq)]
     #[error("edge from {:?} to {:?} already exists", from, to)]
     pub struct EdgeAlreadyExists {
         pub(crate) from: String,
@@ -190,7 +188,7 @@ pub mod errors {
     }
 
     /// Edge doesn't exist
-    #[derive(Debug, Fail, Eq, PartialEq)]
+    #[derive(Debug, thiserror::Error, Eq, PartialEq)]
     #[error("edge from '{:?}' to '{:?}' doesn't exist", from, to)]
     pub struct EdgeDoesntExist {
         pub(crate) from: String,
@@ -198,7 +196,7 @@ pub mod errors {
     }
 
     /// Missing node weight
-    #[derive(Debug, Fail, Eq, PartialEq)]
+    #[derive(Debug, thiserror::Error, Eq, PartialEq)]
     #[error("NodeWeight with index {} is missing", 0)]
     pub struct NodeWeightMissing(pub(crate) usize);
 }

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/plugin.rs
@@ -175,7 +175,7 @@ impl PluginSettings for OpenshiftSecondaryMetadataParserSettings {
     }
 }
 
-#[derive(Debug, Fail, strum_macros::EnumDiscriminants)]
+#[derive(Debug, thiserror::Error, strum_macros::EnumDiscriminants)]
 #[strum(serialize_all = "snake_case")]
 #[strum_discriminants(derive(Hash, Serialize, Deserialize), serde(rename_all = "snake_case"))]
 pub enum DeserializeDirectoryFilesError {

--- a/cincinnati/src/plugins/mod.rs
+++ b/cincinnati/src/plugins/mod.rs
@@ -95,7 +95,7 @@ pub enum PluginIO {
 }
 
 /// Error type which corresponds to interface::PluginError
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ExternalError {
     #[error("PluginError: {:?}", 0)]
     PluginError(PluginError),

--- a/commons/src/errors.rs
+++ b/commons/src/errors.rs
@@ -11,9 +11,6 @@ pub mod prelude {
     pub use anyhow::Context;
     pub use anyhow::Error;
     pub use anyhow::Result as Fallible;
-
-    // Macro imports
-    pub use thiserror::Error as Fail;
 }
 pub use prelude::*;
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = "^1.0"
 assert-json-diff = "2.0.2"
 chrono = "^0.4.38"
 env_logger = "^0.10"
-failure = "^0.1.1"
 reqwest = { version="^0.11", features = ["blocking"] }
 serde = "^1.0.189"
 serde_derive = "^1.0.70"


### PR DESCRIPTION
It seems that this crate was used in the past to provide `Error` traits implementation, but was eventually replaced with `thiserror::Error` (see the removed `use thiserror::Error as Fail` rename). The `Fail` trait was only derived at several places, so I dropped the rename and used `thiserror::Error` directly in derives. The `Fail` from the commons package was also used in the cincinnati package, relying on a transitive dependency when the code is actually directly used. I dropped this indirection and made cincinnati package depend on thiserror (same version like commons)

Also opportunistically bump `thiserror` from 1.0.49 to 1.0.55
