### PR TITLE
OTA-1348: Fix the failing `compare_quay_result_fixture::_20211124_083150_` test

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -691,6 +691,9 @@ impl Serialize for Graph {
 
 #[cfg(any(test, feature = "test"))]
 impl PartialEq for Graph {
+    /// Compares two Graphs.
+    ///
+    /// Does not take into account the `conditional_edges` field of Graphs.
     fn eq(&self, other: &Graph) -> bool {
         let mut releases = self
             .dag
@@ -1035,6 +1038,7 @@ pub mod testing {
     }
 
     /// Compares two Versioned Graphs and gives a verbose error if not equal
+    /// Currently does not take into account conditional edges.
     pub fn compare_versioned_graphs_verbose(
         versioned_left: VersionedGraph,
         versioned_right: VersionedGraph,
@@ -1051,6 +1055,7 @@ pub mod testing {
     }
 
     /// Compares two Graphs and gives a verbose error if not equal.
+    /// Currently does not take into account conditional edges.
     pub fn compare_graphs_verbose(
         mut left: Graph,
         mut right: Graph,

--- a/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/20211124.083150/graph-gb-with-quay-metadata.json
+++ b/cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/20211124.083150/graph-gb-with-quay-metadata.json
@@ -6305,7 +6305,7 @@
         "description": "",
         "io.openshift.upgrades.graph.release.manifestref": "sha256:999a6a4bd731075e389ae601b373194c6cb2c7b4dadd1ad06ef607e86476b129",
         "io.openshift.upgrades.graph.release.channels": "candidate-4.7,fast-4.7,stable-4.7,candidate-4.8,fast-4.8,stable-4.8",
-        "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*"
+        "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*|4\\.6\\..*|.*"
       }
     },
     {
@@ -6347,7 +6347,7 @@
       "payload": "quay.io/openshift-release-dev/ocp-release@sha256:475367e4991d6e8ea3617cf3dfe2dd472db76a89f23484f118932d6bdd6f53e9",
       "metadata": {
         "url": "https://access.redhat.com/errata/RHSA-2021:0957",
-        "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*",
+        "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*|4\\.6\\..*|.*",
         "description": "",
         "io.openshift.upgrades.graph.release.arch": "ppc64le",
         "io.openshift.upgrades.graph.release.manifestref": "sha256:475367e4991d6e8ea3617cf3dfe2dd472db76a89f23484f118932d6bdd6f53e9",
@@ -6384,7 +6384,7 @@
         "io.openshift.upgrades.graph.release.arch": "s390x",
         "description": "",
         "url": "https://access.redhat.com/errata/RHSA-2021:0957",
-        "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*",
+        "io.openshift.upgrades.graph.previous.remove_regex": "4\\.6\\..*|4\\.6\\..*|.*",
         "io.openshift.upgrades.graph.release.manifestref": "sha256:90be6b7e97d8da9fbb2afc7fe6d7dd4da6265fb847ec440e46bda1a25c224b0c",
         "io.openshift.upgrades.graph.release.channels": "candidate-4.7,fast-4.7,stable-4.7,candidate-4.8,fast-4.8,stable-4.8"
       }


### PR DESCRIPTION
**Fix metadata parser test fixture**
The commit [1] has removed conditional edges from normal edges. This was
done using the `io.openshift.upgrades.graph.previous.remove_regex`
metadata key. The `from` regex field of a conditional risk is appended
to the key's value of a respective `to` version. In other words, the
`OpenshiftSecondaryMetadataParser` parser signals using the metadata
key to the `EdgeAddRemove` plugin what edges to remove from the normal
edges thanks to its knowledge of conditional risks.

Unfortunately, a test fixture was not modified to adhere to the new
changes. The `graph-gb-with-quay-metadata.json` file is supposed to
represent graph with the metadata to act as control data.
This PR fixes that.

[1] https://github.com/openshift/cincinnati/commit/72ed35630cfcb0796473deffdc6c6c2c31ed1155

---

**cincinnati/src/lib.rs: Declare openly Graph's == operator limitations**
Even though conditional edges are part of the Graph type and are
equally as important as the graph itself, they are not taken into
account when two Graps are compared using the `==` operator. Declare
this fact more openly.