### PR TITLE
replace HPA with keda ScaledObject

### DIFF
--- a/dist/openshift/cincinnati-deployment.yaml
+++ b/dist/openshift/cincinnati-deployment.yaml
@@ -11,7 +11,6 @@ objects:
         app: cincinnati
       name: cincinnati
     spec:
-      replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
           app: cincinnati
@@ -174,29 +173,24 @@ objects:
                 name: cincinnati-configs
       triggers:
         - type: ConfigChange
-  - apiVersion: autoscaling/v2
-    kind: HorizontalPodAutoscaler
+  - apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
     metadata:
-      name: cincinnati-hpa
+      name: cincinnati-scaler
       labels:
         app: cincinnati
     spec:
       scaleTargetRef:
-        apiVersion: apps/v1
-        kind: Deployment
         name: cincinnati
-      minReplicas: ${{MIN_REPLICAS}}
-      maxReplicas: ${{MAX_REPLICAS}}
-      # Using 'Pods' type, as the metric is summed by pod, so each pod has its own value and
-      # HPA will automatically average across all pods. We want to scale based on per-pod metrics
-      metrics:
-        - type: Pods
-          pods:
-            metric:
-              name: cincinnati_policy_engine_graph_incoming_requests_rate
-            target:
-              type: AverageValue
-              averageValue: ${{PE_REQ_AVG}}
+      maxReplicaCount: ${{MAX_REPLICAS}}
+      minReplicaCount: ${{MIN_REPLICAS}}
+      triggers:
+        - type: prometheus
+          metadata:
+            serverAddress: http://prometheus-app-sre.openshift-customer-monitoring.svc.cluster.local:9090
+            metricName: cincinnati_policy_engine_graph_incoming_requests_rate
+            threshold: ${{PE_REQ_AVG}}
+            query: avg(cincinnati_policy_engine_graph_incoming_requests_rate)
   - apiVersion: monitoring.coreos.com/v1
     kind: PrometheusRule
     metadata:


### PR DESCRIPTION
HPA wont give us custom prometheus metrics in OCP instance,
thus we need to add keda ScaledObject which allows us to run
custom prometheus queries and in the background runs HPA.
OCP instance needs Keda for this to work.