### PR TITLE
ScaledObject threshold value should be a string 'integer'

### DIFF
--- a/dist/openshift/cincinnati-deployment.yaml
+++ b/dist/openshift/cincinnati-deployment.yaml
@@ -189,7 +189,7 @@ objects:
           metadata:
             serverAddress: http://prometheus-app-sre.openshift-customer-monitoring.svc.cluster.local:9090
             metricName: cincinnati_policy_engine_graph_incoming_requests_rate
-            threshold: ${{PE_REQ_AVG}}
+            threshold: "${{PE_REQ_AVG}}"
             query: avg(cincinnati_policy_engine_graph_incoming_requests_rate)
   - apiVersion: monitoring.coreos.com/v1
     kind: PrometheusRule


### PR DESCRIPTION
the threshold value is an integer without quotes, which is invalid. this fixes it