### PR TITLE
OTA-1382: dist/openshift: Set maxUnavailable:0 in Deployments

### DIFF
--- a/dist/openshift/cinci-with-mh-deployment.yaml
+++ b/dist/openshift/cinci-with-mh-deployment.yaml
@@ -309,7 +309,6 @@ objects:
     kind: PodDisruptionBudget
     metadata:
       name: cincinnati-pdb
-      namespace: cincinnati
     spec:
       maxUnavailable: 1
       selector:

--- a/dist/openshift/cinci-with-mh-deployment.yaml
+++ b/dist/openshift/cinci-with-mh-deployment.yaml
@@ -22,7 +22,7 @@ objects:
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%
-          maxUnavailable: 25%
+          maxUnavailable: 0
           timeoutSeconds: 1200
           updatePeriodSeconds: 1
         type: RollingUpdate

--- a/dist/openshift/cincinnati-deployment.yaml
+++ b/dist/openshift/cincinnati-deployment.yaml
@@ -19,7 +19,7 @@ objects:
         rollingParams:
           intervalSeconds: 1
           maxSurge: 25%
-          maxUnavailable: 25%
+          maxUnavailable: 0
           timeoutSeconds: 1200
           updatePeriodSeconds: 1
         type: RollingUpdate

--- a/dist/openshift/cincinnati-deployment.yaml
+++ b/dist/openshift/cincinnati-deployment.yaml
@@ -256,7 +256,6 @@ objects:
     kind: PodDisruptionBudget
     metadata:
       name: cincinnati-pdb
-      namespace: cincinnati
     spec:
       maxUnavailable: 1
       selector:


### PR DESCRIPTION
We've had this since the Deployment template was created in 55ea56e9b4 (#785).  That was probably just pinning [Kubernetes' default value][1].

But Cincinnati pods come up slowly, and we seem to have trouble coming back out of overwhelmed-by-traffic holes.  Dropping `maxUnavailable` to zero will force us to surge into new configuration, ensuring we always have new-config capacity available before we reduce outgoing-config capacity.

The risk with this approach is if there's no room for new-config capacity, but would be room for a more in-place roll.  But we don't have to worry about that most of the time in our app-interface because we're hosted on autoscaling compute:

```console
app-interface $ grep -A19 machinePools: data/openshift/appsrep08ue2/cluster.yml | sed 's/\(subnet-\).*/\1REDACTED/'
machinePools:
- id: workers-0
  instance_type: m5.2xlarge
  subnet: subnet-REDACTED
  autoscale:
    min_replicas: 1
    max_replicas: 4
- id: workers-1
  instance_type: m5.2xlarge
  subnet: subnet-REDACTED
  autoscale:
    min_replicas: 1
    max_replicas: 4
- id: workers-2
  instance_type: m5.2xlarge
  subnet: subnet-REDACTED
  autoscale:
    min_replicas: 1
    max_replicas: 4
 ```
 
There is still a risk that the cloud provider is temporarily out of our target instance type or whatever, but:

* Machine/Node pools failing to scale could already be an issue, and alerting on that is orthogonal to this change.
* Deployment rollouts failing to progress could already be an issue, and alerting on that is orthogonal to this change.

I'm also sneaking in an unrelated 73ecc1f547b8d470fd231989f013c0eb5231c0f5 to clean up a dead-code PDB `namespace` setting.

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable