### PR TITLE
NO-ISSUE: dist/openshift/*-deployment: Fix rollingParams to rollingUpdate

### DIFF
--- a/dist/openshift/cinci-with-mh-deployment.yaml
+++ b/dist/openshift/cinci-with-mh-deployment.yaml
@@ -19,13 +19,10 @@ objects:
         matchLabels:
           app: cincinnati
       strategy:
-        rollingParams:
-          intervalSeconds: 1
+        type: RollingUpdate
+        rollingUpdate:
           maxSurge: 25%
           maxUnavailable: 0
-          timeoutSeconds: 1200
-          updatePeriodSeconds: 1
-        type: RollingUpdate
       template:
         metadata:
           labels:

--- a/dist/openshift/cincinnati-deployment.yaml
+++ b/dist/openshift/cincinnati-deployment.yaml
@@ -16,13 +16,10 @@ objects:
         matchLabels:
           app: cincinnati
       strategy:
+        type: RollingUpdate
         rollingParams:
-          intervalSeconds: 1
           maxSurge: 25%
           maxUnavailable: 0
-          timeoutSeconds: 1200
-          updatePeriodSeconds: 1
-        type: RollingUpdate
       template:
         metadata:
           labels:


### PR DESCRIPTION
Avoiding:

    warning: error calculating patch from openapi spec: unable to find api field "rollingParams" in io.k8s.api.apps.v1.DeploymentStrategy

because [the Deployment config property is `rollingUpdate`][1]. [`rollingParams` was the DeploymentConfig property][2], and this transition just got overlooked during the 55ea56e9b4 (#785). Happily, changes to the way AppSRE deploys patches or to the Kube API server handling in our host cluster is now warning us about this kind of unrecognized property name, and we can fix the typos in commits like this.

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment
[2]: https://docs.openshift.com/container-platform/4.17/applications/deployments/deployment-strategies.html#deployments-rolling-strategy_deployment-strategies