### PR TITLE
OTA-1351: Migrate base of image of e2e test to ubi9

### DIFF
--- a/dist/Dockerfile.e2e-ubi/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest as rust_builder
+FROM registry.access.redhat.com/ubi9/ubi:latest as rust_builder
 WORKDIR /opt/app-root/src/
 COPY . .
 # copy git information for built crate
@@ -11,10 +11,10 @@ RUN dnf update -y \
 
 RUN hack/build_e2e.sh
 
-FROM registry.access.redhat.com/ubi8/ubi:latest AS vegeta_fetcher
+FROM registry.access.redhat.com/ubi9/ubi:latest AS vegeta_fetcher
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 ENV HOME="/root"
 
@@ -23,7 +23,7 @@ WORKDIR "${HOME}/cincinnati"
 
 # Get oc CLI
 RUN mkdir -p ${HOME}/bin && \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
 ENV PATH="${PATH}:${HOME}/bin"
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test

--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR "${HOME}/cincinnati"
 
 # Get oc CLI
 RUN mkdir -p ${HOME}/bin && \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
 ENV PATH="${PATH}:${HOME}/bin"
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test

--- a/dist/Dockerfile.e2e-ubi8/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi8/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest as rust_builder
+FROM registry.access.redhat.com/ubi9/ubi:latest as rust_builder
 WORKDIR /opt/app-root/src/
 COPY . .
 # copy git information for built crate
@@ -11,10 +11,10 @@ RUN dnf update -y \
 
 RUN hack/build_e2e.sh
 
-FROM registry.access.redhat.com/ubi8/ubi:latest AS vegeta_fetcher
+FROM registry.access.redhat.com/ubi9/ubi:latest AS vegeta_fetcher
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 ENV HOME="/root"
 


### PR DESCRIPTION
Have got 3 successful runs on [5135123](https://github.com/openshift/cincinnati/commit/5135123fb931544c9bd70afdefa704fb71ced101).

So basically `ubi9` and the default `oc` build are working nicely together.

@petr-muller , I did not forget considering revisit the build of the e2e-test image. I have some ideas already but they will be presented by other PRs.