### PR TITLE
NO-JIRA: Remove redundant copy of .git

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -22,8 +22,6 @@ RUN \
   find $HOME/. -type f -exec chmod ugo+rw {} \;
 
 COPY . .
-# copy git information for built crate
-COPY .git/ ./.git/
 
 RUN cargo build --release && \
     mkdir -p /opt/cincinnati/bin && \

--- a/dist/Dockerfile.e2e-ubi/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi/Dockerfile
@@ -1,8 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest as rust_builder
 WORKDIR /opt/app-root/src/
 COPY . .
-# copy git information for built crate
-COPY .git/ ./.git/
 USER 0
 RUN dnf update -y \
     && dnf install -y jq rust cargo \

--- a/dist/Dockerfile.rust-toolset/Dockerfile
+++ b/dist/Dockerfile.rust-toolset/Dockerfile
@@ -1,8 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest as builder
 WORKDIR /opt/app-root/src/
 COPY . .
-# copy git information for built crate
-COPY .git/ ./.git/
 USER 0
 RUN dnf update -y \
     && dnf install -y jq rust cargo \


### PR DESCRIPTION
It is not in the scope of https://issues.redhat.com/browse/OCPBUGS-23514, but I feel like it is a good thing to do.

`COPY .git/ ./.git/` is redundant when `COPY . .` is just finished.