### PR TITLE
NO-JIRA: e2e: use images built with dependencies

### DIFF
--- a/dist/Dockerfile.e2e-ubi/Dockerfile
+++ b/dist/Dockerfile.e2e-ubi/Dockerfile
@@ -1,28 +1,13 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as rust_builder
+FROM registry.ci.openshift.org/cincinnati-ci-public/rust:ubi9 as rust_builder
 WORKDIR /opt/app-root/src/
 COPY . .
 USER 0
-RUN dnf update -y \
-    && dnf install -y jq rust cargo \
-    && dnf install -y openssl-devel \
-    && dnf clean all
-
 RUN hack/build_e2e.sh
 
-FROM registry.access.redhat.com/ubi9/ubi:latest AS vegeta_fetcher
-RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz| tar xvzf - -C /usr/local/bin/ vegeta
-
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.ci.openshift.org/cincinnati-ci-public/rust:e2e-test-ubi9
 
 ENV HOME="/root"
-
-RUN mkdir -p "${HOME}/cincinnati"
 WORKDIR "${HOME}/cincinnati"
-
-# Get oc CLI
-RUN mkdir -p ${HOME}/bin && \
-    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz 2>/dev/null | tar xzf - -C "${HOME}/bin/" oc
-ENV PATH="${PATH}:${HOME}/bin"
 
 COPY --from=rust_builder /opt/cincinnati/bin/e2e /usr/bin/cincinnati-e2e-test
 COPY --from=rust_builder /opt/cincinnati/bin/prometheus_query /usr/bin/cincinnati-prometheus_query-test
@@ -33,7 +18,6 @@ COPY --from=rust_builder /opt/app-root/src/dist/openshift/cincinnati-deployment.
 COPY --from=rust_builder /opt/app-root/src/dist/openshift/cincinnati-e2e.yaml dist/openshift/
 COPY --from=rust_builder /opt/app-root/src/dist/openshift/observability.yaml dist/openshift/
 COPY --from=rust_builder /opt/app-root/src/dist/openshift/load-testing.yaml dist/openshift/
-COPY --from=vegeta_fetcher /usr/local/bin/vegeta /usr/bin
 COPY --from=rust_builder /opt/app-root/src/e2e/tests/testdata e2e/tests/testdata
 COPY --from=rust_builder /opt/app-root/src/dist/prepare_ci_credentials.sh dist/
 COPY --from=rust_builder /opt/app-root/src/dist/cargo_test.sh dist/


### PR DESCRIPTION
This simplifies the builds in CI run.

Requires https://github.com/openshift/release/pull/62541

The images are built on ota-stage and pushed (to test this PR) to my own repo from quay.io: The [job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cincinnati/1006/pull-ci-openshift-cincinnati-master-e2e/1899599233976111104) is green.

```
$ oc image mirror --keep-manifest-list=true default-route-openshift-image-registry.apps.ota-stage.q2z4.p1.openshiftapps.com/hongkliu-test/rust:e2e-test-ubi9=quay.io/hongkliu/test:rust-e2e-test-ubi9 default-route-openshift-image-registry.apps.ota-stage.q2z4.p1.openshiftapps.com/hongkliu-test/rust:ubi9=quay.io/hongkliu/test:rust-ubi9 -a /tmp/p.c
```