### PR TITLE
NO-JIRA: Simplify dist/prow_yaml_lint.sh

### DIFF
--- a/dist/prow_yaml_lint.sh
+++ b/dist/prow_yaml_lint.sh
@@ -2,17 +2,20 @@
 
 set -euxo pipefail
 
-YAML_LINTER='yamllint'
-YAML_RULES='{extends: default, rules: {line-length: {max: 120}}}'
-YAML_LINT_CMD=("${YAML_LINTER}" '-s' '-d' "${YAML_RULES}")
+cfg="$(mktemp)"
+cat >"$cfg" <<EOF
+extends: default
 
-if ! type -f "${YAML_LINTER}"; then
-  echo "error: could not find ${YAML_LINTER} in PATH"
-  exit 1
-fi
+ignore:
+- cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/
+- vendor/
+- dist/grafana/dashboards/
 
-find . \
-  -path "./cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures" -prune -o \
-  -path "./vendor" -prune -o \
-  -path "./dist/grafana/dashboards" -prune -o \
-  -type f \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -L 1 -0 "${YAML_LINT_CMD[@]}"
+rules:
+  line-length:
+    max: 120
+EOF
+
+yamllint -v
+
+yamllint -s -c "$cfg" .


### PR DESCRIPTION
Refer https://yamllint.readthedocs.io/en/stable/configuration.html

- Replace the ignored folders identified by `find` with `ignore` in the inline config.
- The default yaml files '*.yaml', '*.yml', and '.yamllint'
- ~Add `--list-files` to show the files that `yamllint` processes.~

The job looks nice:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cincinnati/1010/pull-ci-openshift-cincinnati-master-yaml-lint/1905401248773836800/artifacts/test/build-log.txt
+ yamllint -v
yamllint 1.35.1
+ yamllint --list-files -s -d '{extends: default, rules: {line-length: {max: 120}}, ignore: [cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/, vendor/, dist/grafana/dashboards/]}' .
./.github/dependabot.yml
./dist/openshift/cinci-with-mh-deployment.yaml
./dist/openshift/cincinnati-deployment.yaml
./dist/openshift/cincinnati-e2e.yaml
./dist/openshift/load-testing.yaml
./dist/openshift/observability.yaml
```

These are the same set of files as the original `find` cmd:

```console
$ find . -path ./cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures -prune -o -path ./vendor -prune -o -path ./dist/grafana/dashboards -prune -o -type f '(' -name '*.yaml' -o -name '*.yml' ')' -print0
| xargs -L 1 -0 echo
./dist/openshift/observability.yaml
./dist/openshift/cincinnati-e2e.yaml
./dist/openshift/load-testing.yaml
./dist/openshift/cincinnati-deployment.yaml
./dist/openshift/cinci-with-mh-deployment.yaml
./.github/dependabot.yml
```