### PR TITLE
NO-JIRA: Modify just-format

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ metadata_reference_revision:
 	read -r var <"{{testdata_dir}}"/metadata_revision; printf $var
 
 format:
-	cargo fmt --all
+	cargo fmt --all -- --check
 
 clippy:
 	cargo clippy --all-targets --all-features


### PR DESCRIPTION
To be aligned with https://github.com/openshift/cincinnati/blob/de0aa9b81a01d38a6408c7ed0b5b9e13b3cc7658/dist/prow_rustfmt.sh#L10

I plan to use it in CI to replace the existing CI jobs for code formatting.

https://github.com/openshift/release/blob/d057304262de729cffb0389710803caf14f0ada9/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml#L127-L134

We do not need to format in 2 Rust versions.
Instead format only in the version with it the cincinnati is built which is one of the outcome from [OTA-1456](https://issues.redhat.com/browse/OTA-1456?focusedId=26880045&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26880045).