### PR TITLE
NO-JIRA: Remove an unused import

### DIFF
--- a/policy-engine/src/config/mod.rs
+++ b/policy-engine/src/config/mod.rs
@@ -15,4 +15,3 @@ mod settings;
 pub(crate) use self::file::FileOptions;
 
 pub use self::settings::AppSettings;
-pub use self::settings::DEFAULT_UPSTREAM_URL;


### PR DESCRIPTION

```
$ cargo build --release
...
warning: unused import: `self::settings::DEFAULT_UPSTREAM_URL`
  --> policy-engine/src/config/mod.rs:18:9
   |
18 | pub use self::settings::DEFAULT_UPSTREAM_URL;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `policy-engine` (bin "policy-engine") generated 1 warning (run `cargo fix --bin "policy-engine"` to apply 1 suggestion)
```