### PR TITLE
NO-JIRA: Update docs about Quick-Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,35 +9,33 @@ Prepare custom environment variables
 ```console
 # Please change these accordingly
 export CINCINNATI_REGISTRY="https://quay.io"
-export CINCINNATI_REPO="redhat/openshift-cincinnati-test-public-manual"
+export CINCINNATI_REPO="openshift-ota/openshift-cincinnati-test-public-manual"
 ```
+
+See the details about [pushing images to the above repo](./docs/developer/push-to-openshift-cincinnati-test-public-manual.md).
 
 ### Executables on the build host
 
 ```console
 cargo run --package graph-builder -- --service.address 0.0.0.0 --upstream.registry.url "${CINCINNATI_REGISTRY}" --upstream.registry.repository "${CINCINNATI_REPO}" &
 cargo run --package policy-engine -- --service.address 0.0.0.0 &
- curl --verbose --header 'Accept:application/json' http://localhost:8081/graph\?channel=a
+ curl -s 'Accept:application/json' http://localhost:8081/graph\?channel\=candidate-4.18 | jq
 {
-    "nodes":
-    [{
-        "version":"0.0.0",
-        "payload":"quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d",
-        "metadata":{
-            "io.openshift.upgrades.graph.release.channels":"a",
-            "io.openshift.upgrades.graph.release.manifestref":"sha256:a264db3ac5288c9903dc3db269fca03a0b122fe4af80b57fc5087b329995013d"
-        }
-    },
+  "version": 1,
+  "nodes": [
     {
-        "version":"0.0.1",
-        "payload":"quay.io/redhat/openshift-cincinnati-test-public-manual@sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
-        "metadata":{
-            "io.openshift.upgrades.graph.release.manifestref":"sha256:73df5efa869eaf57d4125f7655e05e1a72b59d05e55fea06d3701ea5b59234ff",
-            "io.openshift.upgrades.graph.release.channels":"a",
-            "kind":"test"
-        }
-    }],
-    "edges":[[0,1]]
+      "version": "4.18.3",
+      "payload": "quay.io/openshift-ota/openshift-cincinnati-test-public-manual@sha256:fdcb3da3a1086d664df31a1fa2a629c77780f844d458af956928cca297da343c",
+      "metadata": {
+        "io.openshift.upgrades.graph.release.manifestref": "sha256:fdcb3da3a1086d664df31a1fa2a629c77780f844d458af956928cca297da343c",
+        "io.openshift.upgrades.graph.release.channels": "candidate-4.18,eus-4.18,fast-4.18,stable-4.18,candidate-4.19",
+        "io.openshift.upgrades.graph.previous.remove_regex": ".*|4[.]17[.].*|4[.](17[.](1[01]|0-.*|[0-9])|18.0-(ec[.].*|rc[.][0-3]))",
+        "url": "https://access.redhat.com/errata/RHBA-2025:2229"
+      }
+    }
+  ],
+  "edges": [],
+  "conditionalEdges": []
 }
 ```
 

--- a/docs/developer/push-to-openshift-cincinnati-test-public-manual.md
+++ b/docs/developer/push-to-openshift-cincinnati-test-public-manual.md
@@ -49,7 +49,7 @@ $ buildah push --authfile ~/.docker/config.json quay.io/openshift-ota/openshift-
 
 We have to use `--format docker` to build the image when using `buildah`. Otherwise, the default `oci` would lead to an image that `graph-builder` yields "unknown media type ManifestV2S1" error to and then ignores. See [the supported media types](https://github.com/camallo/dkregistry-rs/blob/3e242ee9e39646da6ff4a886e080085cc1810d37/src/v2/manifest/mod.rs#L74-L96).
 
-We cannot use `postman` to build the image because `podman build --format docker` does not work. See [podman/issues/21294](https://github.com/containers/podman/issues/21294).
+We cannot use `podman` to build the image because `podman build --format docker` does not work. See [podman/issues/21294](https://github.com/containers/podman/issues/21294).
 
 ```console
 $ docker manifest inspect quay.io/openshift-ota/openshift-cincinnati-test-public-manual:4.18.12-x86_64-podman

--- a/docs/developer/push-to-openshift-cincinnati-test-public-manual.md
+++ b/docs/developer/push-to-openshift-cincinnati-test-public-manual.md
@@ -1,0 +1,71 @@
+# Repository openshift-cincinnati-test-public-manual
+
+The image repository [quay.io/openshift-ota/openshift-cincinnati-test-public-manual](https://quay.io/repository/openshift-ota/openshift-cincinnati-test-public-manual?tab=tags) is created for testing as
+a release repo for `graph-builder` to scrape. 
+
+## Mirror
+
+The simplest way to make an image in the `openshift-cincinnati-test-public-manual` repo is to mirror one from `quay.io/openshift-release-dev/ocp-release`. E.g.,
+
+```console
+$ oc image mirror --keep-manifest-list --registry-config=/tmp/docker.json --max-per-registry=10 quay.io/openshift-release-dev/ocp-release:4.18.11-multi=quay.io/openshift-ota/openshift-cincinnati-test-public-manual:4.18.11-multi
+```
+
+We can mirror all the interesting cases to `openshift-cincinnati-test-public-manual` so that using the repo as the scraping target in CI e2e tests will keep `cincinnati` away from regression.
+
+## Build and Push
+
+For example, we can build and push `quay.io/openshift-ota/openshift-cincinnati-test-public-manual:4.18.6` with the following files in the current folder:
+
+```console
+$ for file in ./*; do echo "$file"; cat "$file"; done
+./Dockerfile
+FROM alpine
+CMD ["echo", "Hello World!!"]
+LABEL io.openshift.release="4.18.6"
+COPY release-metadata /release-manifests/release-metadata
+./release-metadata
+{
+  "kind": "cincinnati-metadata-v0",
+  "version": "4.18.6",
+  "previous": [
+    "4.18.3"
+  ],
+  "metadata": {
+    "url": "https://access.redhat.com/errata/RHSA-202X:ABAB"
+  }
+}
+```
+
+with `buildah`:
+
+```console
+$ buildah bud --format docker -t quay.io/openshift-ota/openshift-cincinnati-test-public-manual:4.18.6 .
+$ buildah push --authfile ~/.docker/config.json quay.io/openshift-ota/openshift-cincinnati-test-public-manual:4.18.6
+```
+
+
+## Format of Image's Manifest and Metadata
+
+We have to use `--format docker` to build the image when using `buildah`. Otherwise, the default `oci` would lead to an image that `graph-builder` yields "unknown media type ManifestV2S1" error to and then ignores. See [the supported media types](https://github.com/camallo/dkregistry-rs/blob/3e242ee9e39646da6ff4a886e080085cc1810d37/src/v2/manifest/mod.rs#L74-L96).
+
+We cannot use `postman` to build the image because `podman build --format docker` does not work. See [podman/issues/21294](https://github.com/containers/podman/issues/21294).
+
+```console
+$ docker manifest inspect quay.io/openshift-ota/openshift-cincinnati-test-public-manual:4.18.12-x86_64-podman
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+    ...
+}
+```
+
+Note that `podman manifest inspect` the above image led to errors. So does `buildah`. However, `docker` works.
+
+Besides `buildah`, `openshift/build` generates the images that `graph-builder` is happy with. The following table contains the testing results about these build tools.
+
+| command         | version                                                       | os                                    | install                     | working |
+|-----------------|---------------------------------------------------------------|---------------------------------------|-----------------------------|---------|
+| buildah         | buildah version 1.39.2 (image-spec 1.1.0, runtime-spec 1.2.0) | Fedora Linux 40 (Workstation Edition) | sudo dnf -y install buildah | yes     |
+| openshift-build | OSD 4.18.11                                                   | n/a                                   | n/a                         | yes     |
+| podman          | podman version 5.4.2                                          | macOS Sequoia 15.4.1 (24E263)         | brew  install podman        | no      |


### PR DESCRIPTION
Probably We've [lost](https://redhat-internal.slack.com/archives/CJ1J9C3V4/p1746717891272019?thread_ts=1746624149.404019&cid=CJ1J9C3V4) permissions on `redhat/openshift-cincinnati-test-public-manual` and the images there seems broken anyway:

```
$ podman push quay.io/redhat/openshift-cincinnati-test-public-manual:0.0.1
Getting image source signatures
Copying blob sha256:5e5cd7f091759e53239970eba53aa8c335ff97ef714e2e502875e9bef697ab81
Copying config sha256:277ee18becacc780d74619752b6c4e3c1ac33dc3349a2f3b2919355191a16a13
Error: writing blob: initiating layer upload to /v2/redhat/openshift-cincinnati-test-public-manual/blobs/uploads/ in quay.io: unauthorized: access to the requested resource is not authorized
```

Let us start to use `openshift-ota/openshift-cincinnati-test-public-manual` now.
A doc about pushing images to it is also included in the pull.