### PR TITLE
Add a few Just recipes for CI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,8 +26,33 @@ clippy:
 commit +args="": format
 	git commit {{args}}
 
-build:
-	cargo build
+build *args:
+	cargo build {{args}}
+	just copy_bin "{{bin_folder}}"
+
+bin_folder := env('bin_folder', "")
+copy_bin:
+	@[[ -z "{{bin_folder}}" ]] || just _copy_bin
+
+_copy_bin:
+	@echo "copying binaries to {{bin_folder}}"
+	mkdir -vp "{{bin_folder}}"
+	for file in graph-builder policy-engine metadata-helper; do cp -vf "target/release/${file}" "{{bin_folder}}/"; done
+
+build_e2e:
+	hack/build_e2e.sh
+
+run_e2e:
+	hack/e2e.sh
+
+cargo_test:
+	dist/cargo_test.sh
+
+prepare_ci_credentials:
+	dist/prepare_ci_credentials.sh
+
+yamllint:
+	dist/prow_yaml_lint.sh
 
 _coverage:
 	cargo kcov --verbose --all --no-clean-rebuild --open

--- a/dist/prow_yaml_lint.sh
+++ b/dist/prow_yaml_lint.sh
@@ -3,6 +3,8 @@
 set -euxo pipefail
 
 cfg="$(mktemp)"
+trap 'rm -vf -- "$cfg"' EXIT
+
 cat >"$cfg" <<EOF
 extends: default
 


### PR DESCRIPTION
We can use the recepies introduced in the pull to simply the
commands used in the CI configuration for cincinnati, e.g.,
[binary_build_commands](https://github.com/openshift/release/blob/9af68e55fceec72c1779b4b3e8fa9d1209630b78/ci-operator/config/openshift/cincinnati/openshift-cincinnati-master.yaml#L10).

It will become `bin_folder="/go/bin" just build --release`.

Other recepies serve the same purpose. My plan is to use
only `just` cmd in the configuration, like `make` for other
Go projects.

/hold
https://github.com/openshift/release/pull/64588 goes first

