### PR TITLE
OCPBUGS-56124: ignore single-arch shards of multi images

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -87,20 +87,6 @@ impl Release {
             _ => bail!("could not get manifest reference"),
         }
     }
-
-    /// return the arch identifier set in metadata or returns `none`
-    pub fn metadata_arch_id(&mut self) -> String {
-        let metadata_arch_key = "release.openshift.io/architecture";
-        let no_arch = String::from("none");
-        let arch = self
-            .get_metadata_mut()
-            .map(|metadata| metadata.get(metadata_arch_key))
-            .unwrap_or(None);
-        match arch {
-            Some(arch) => arch.to_string(),
-            _ => no_arch,
-        }
-    }
 }
 
 /// Type to represent a Release with all its information.
@@ -219,7 +205,7 @@ impl Graph {
         R: Into<Release>,
     {
         let missing_manifest_ref = String::from("none");
-        let mut release = release.into();
+        let release = release.into();
         match self.find_by_version(release.version()) {
             Some(id) => {
                 let node = self.dag.node_weight_mut(id.0).expect(EXPECT_NODE_WEIGHT);
@@ -228,18 +214,12 @@ impl Graph {
                     if release.manifestref().unwrap_or(&missing_manifest_ref)
                         != node.manifestref().unwrap_or(&missing_manifest_ref)
                     {
-                        let release_arch = release.metadata_arch_id();
-                        if release_arch == node.metadata_arch_id() {
-                            bail!(
-                                "mismatched manifest ref for concrete release {}: {}, {}",
-                                release.version(),
-                                release.manifestref().unwrap_or(&missing_manifest_ref),
-                                node.manifestref().unwrap_or(&missing_manifest_ref)
-                            )
-                        }
-                        if release_arch == "multi" {
-                            return Ok(id);
-                        }
+                        bail!(
+                            "mismatched manifest ref for concrete release {}: {}, {}",
+                            release.version(),
+                            release.manifestref().unwrap_or(&missing_manifest_ref),
+                            node.manifestref().unwrap_or(&missing_manifest_ref)
+                        )
                     }
                 }
                 *node = release;

--- a/cincinnati/src/plugins/internal/graph_builder/release.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release.rs
@@ -52,6 +52,24 @@ pub struct Metadata {
     pub metadata: MapImpl<String, String>,
 }
 
+impl Metadata {
+    /// return the arch identifier set in metadata or returns `none`
+    pub fn metadata_arch_id(&mut self) -> (String, String) {
+        let layer_metadata_arch_key = "release.openshift.io/architecture";
+        let registry_manifest_arch_key = "io.openshift.upgrades.graph.release.arch";
+        let no_arch = "none".to_string();
+        let layer_metadata_arch = self
+            .metadata
+            .get(layer_metadata_arch_key)
+            .map_or(no_arch.clone(), |s| s.clone());
+        let registry_manifest_arch = self
+            .metadata
+            .get(registry_manifest_arch_key)
+            .map_or(no_arch, |s| s.clone());
+        return (layer_metadata_arch, registry_manifest_arch);
+    }
+}
+
 impl fmt::Display for Metadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
+++ b/cincinnati/src/plugins/internal/graph_builder/release_scrape_dockerv2/registry/mod.rs
@@ -386,7 +386,16 @@ pub async fn fetch_releases(
             )
             .await?
             {
-                Some(release) => release,
+                Some(mut release) => {
+                    let (layer_metadata_arch, registry_manifest_arch) =
+                        release.metadata.metadata_arch_id();
+                    if layer_metadata_arch == "multi" && registry_manifest_arch != "multi" {
+                        // single arch shard of multiarch release. dont want it
+                        return Ok(());
+                    } else {
+                        release
+                    }
+                }
                 None => {
                     // Reminder: this means the layer_digests point to layers
                     // without any release and we've cached this before


### PR DESCRIPTION
Current production Cincinnati occasionally confuses
arch-specific shards of multi-arch images as single-arch releases
Possibly triggered by a race or other buggy handling of Quay 502s while scraping releases.

fix: check if the metadata is multi for layered and registry and ignore
those single arch shards

Also revert our earlier attempt of fixing this issue