### PR TITLE
Fix just-recipe build

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,7 +28,7 @@ commit +args="": format
 
 build *args:
 	cargo build {{args}}
-	just copy_bin "{{bin_folder}}"
+	just copy_bin
 
 bin_folder := env('bin_folder', "")
 copy_bin:


### PR DESCRIPTION
The `bin_folder` is taken from env. var. with a default value.
During the implementation, I tried taking it as an arg but decided not to go the way.

The `"{{bin_folder}}"` in `just copy_bin "{{bin_folder}}"` looks like a leftover from the above test.
I must have messed up "ctrl+z" or something before creating https://github.com/openshift/cincinnati/pull/1021

```
$ bin_folder="aaa/bbb" just build --release
```

Just tested the current pull with the above cmd, it works well.