### PR TITLE
OTA-545: openapiv3: document parameters and a new content-type

### DIFF
--- a/docs/design/openshift.md
+++ b/docs/design/openshift.md
@@ -96,15 +96,18 @@ The policy engine client API conforms to the [Cincinnati Graph API](cincinnati.m
 
 #### Request ####
 
-HTTP GET requests are used to fetch updates from the policy engine. Requests are made to `/graph` and must include the following URL parameters:
+HTTP GET requests to `/graph` are used to fetch updates from the policy engine with the following URL parameters:
 
 |   Key   | Optional | Description                                                                                                                                             |
 |:-------:|:--------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | arch    | optional | [the architecture identifier][image-config-properties] for the currently installed cluster, or `multi` for payloads that support heterogeneous clusters |
-| version | required | the version number of the currently installed cluster                                                                                                   |
+| version | optional | the version number of the currently installed cluster                                                                                                   |
 | channel | required | the name of the channel to which this cluster is subscribed                                                                                             |
-|   id    | required | the unique identifier (UUID v4) of the cluster                                                                                                          |
-|    *    | optional | any other parameters will be passed to upstream requests                                                                                                |
+|   id    | optional | the unique identifier (UUID v4) of the cluster                                                                                                          |
+
+See [openapiv3.json](../../policy-engine/src/openapiv3.json) for the complete API specification.
+Note that any parameters undefined in the above table are ignored and do not trigger errors in the response.
+There is no way to express _allow/disable unknown query parameters_ in the OpenAPI specs [OpenAPI-Specification/issues/2511](https://github.com/OAI/OpenAPI-Specification/issues/2511) at the moment.
 
 ##### Example ######
 

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -9,6 +9,28 @@ info:
 servers: []
 paths:
   "/graph":
+    parameters: &parameters
+      - in: query
+        name: arch
+        description: The architecture identifier for the currently installed cluster, or
+          "multi" for payloads that support heterogeneous clusters. The returned update
+          graph contains the updates only for the provided architecture. The allowed values
+          of an architecture identifier are listed in the Go Language document for $GOARCH.
+          See https://go.dev/doc/install/source#environment.
+        schema:
+          type: string
+          default: amd64
+      - in: query
+        name: version
+        description: The current version of the cluster.
+        schema:
+          "$ref": "#/components/schemas/Version"
+      - in: query
+        name: id
+        description: The unique identifier of the cluster.
+        schema:
+          type: string
+          example: ceb3b0bb-c689-4db9-bb6a-0122237e33fd
     get: &get
       summary: Get the update graph
       operationId: getGraph
@@ -35,6 +57,7 @@ paths:
           <<: *err400
           description: Generic graph error
   "/v1/graph":
+    parameters: *parameters
     get:
       <<: *get
       operationId: getV1Graph

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -41,6 +41,9 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Graph"
+            application/vnd.redhat.cincinnati.v1+json:
+              schema:
+                "$ref": "#/components/schemas/Graph"
         '400': &err400
           description: Bad client request
           content:

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -50,6 +50,11 @@
                                 "schema": {
                                     "$ref": "#/components/schemas/Graph"
                                 }
+                            },
+                            "application/vnd.redhat.cincinnati.v1+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Graph"
+                                }
                             }
                         }
                     },
@@ -133,6 +138,11 @@
                         "description": "An update graph",
                         "content": {
                             "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Graph"
+                                }
+                            },
+                            "application/vnd.redhat.cincinnati.v1+json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Graph"
                                 }

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -11,6 +11,34 @@
     "servers": [],
     "paths": {
         "/graph": {
+            "parameters": [
+                {
+                    "in": "query",
+                    "name": "arch",
+                    "description": "The architecture identifier for the currently installed cluster, or \"multi\" for payloads that support heterogeneous clusters. The returned update graph contains the updates only for the provided architecture. The allowed values of an architecture identifier are listed in the Go Language document for $GOARCH. See https://go.dev/doc/install/source#environment.",
+                    "schema": {
+                        "type": "string",
+                        "default": "amd64"
+                    }
+                },
+                {
+                    "in": "query",
+                    "name": "version",
+                    "description": "The current version of the cluster.",
+                    "schema": {
+                        "$ref": "#/components/schemas/Version"
+                    }
+                },
+                {
+                    "in": "query",
+                    "name": "id",
+                    "description": "The unique identifier of the cluster.",
+                    "schema": {
+                        "type": "string",
+                        "example": "ceb3b0bb-c689-4db9-bb6a-0122237e33fd"
+                    }
+                }
+            ],
             "get": {
                 "summary": "Get the update graph",
                 "operationId": "getGraph",
@@ -69,6 +97,34 @@
             }
         },
         "/v1/graph": {
+            "parameters": [
+                {
+                    "in": "query",
+                    "name": "arch",
+                    "description": "The architecture identifier for the currently installed cluster, or \"multi\" for payloads that support heterogeneous clusters. The returned update graph contains the updates only for the provided architecture. The allowed values of an architecture identifier are listed in the Go Language document for $GOARCH. See https://go.dev/doc/install/source#environment.",
+                    "schema": {
+                        "type": "string",
+                        "default": "amd64"
+                    }
+                },
+                {
+                    "in": "query",
+                    "name": "version",
+                    "description": "The current version of the cluster.",
+                    "schema": {
+                        "$ref": "#/components/schemas/Version"
+                    }
+                },
+                {
+                    "in": "query",
+                    "name": "id",
+                    "description": "The unique identifier of the cluster.",
+                    "schema": {
+                        "type": "string",
+                        "example": "ceb3b0bb-c689-4db9-bb6a-0122237e33fd"
+                    }
+                }
+            ],
             "get": {
                 "summary": "Get the update graph",
                 "operationId": "getV1Graph",


### PR DESCRIPTION
I do not see any impact from `id` or `version` to the response although they are provided from [CVO's request](https://github.com/openshift/cluster-version-operator/blob/f4a725a7190c53d723bded39293216a2c253f253/pkg/cincinnati/cincinnati.go#L72-L77)).
They are changed to "optional" in the doc.

The required parameters come from App.setting:

https://github.com/openshift/cincinnati/blob/44e74561a4e4e55d6c42264e426fae782660a12b/policy-engine/src/openapi.rs#L24

And it works already. 

```console
$ curl -s "https://api.stage.openshift.com/api/upgrades_info/openapi" | jq '.paths."/api/upgrades_info/graph".parameters'
[
  {
    "in": "query",
    "name": "channel",
    "required": true,
    "schema": {
      "type": "string"
    },
    "style": "form"
  }
]
```

About the content type: `application/vnd.redhat.cincinnati.v1+json` is allowed too.

```console
$ curl -H 'accept: application/vnd.redhat.cincinnati.v1+json' -s 'https://api.openshift.com/api/upgrades_info/graph?channel=a' | jq
{
  "version": 1,
  "nodes": [],
  "edges": [],
  "conditionalEdges": []
}
```

Will rebase after https://github.com/openshift/cincinnati/pull/1030 gets in.

/hold