### PR TITLE
NO-JIRA: Fix downstream build

### DIFF
--- a/dist/Dockerfile.deploy/Dockerfile
+++ b/dist/Dockerfile.deploy/Dockerfile
@@ -13,8 +13,8 @@ ENV PATH="${HOME}/.cargo/bin:${PATH}"
 WORKDIR ${HOME}
 
 # build: Rust stable toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.76.0 -y && \
-  rustup install 1.76.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.84.1 -y && \
+  rustup install 1.84.1
 
 RUN \
   mkdir -p $HOME/.cargo/git/ && \


### PR DESCRIPTION
The [last successful run](https://ci.int.devshift.net/job/openshift-cincinnati-gh-build-master/630/) is on 6284444607fccc52f738f187a60d7b6c52a689c7.

The [first failing run](https://ci.int.devshift.net/job/openshift-cincinnati-gh-build-master/631/) is on 88bb8cb71d7309de4535864627e85dca11712ce5.

I reproduced it by running `dist/build.sh` and verify the fix comming with the pull.

The Rust has moved to `1.84.1` and this one is left behind unintentionally: I thought the downstream has its own Dockerfile to build `cincinnati` but it turns out I was wrong. 
I will make it use `dnf install` with another pull.

