### PR TITLE
add_edge: log more context about `WouldCycle` error

### DIFF
--- a/cincinnati/src/lib.rs
+++ b/cincinnati/src/lib.rs
@@ -262,9 +262,17 @@ impl Graph {
             }));
         }
 
-        self.dag
-            .add_edge(from.0, to.0, Empty {})
-            .map_err(Into::into)
+        self.dag.add_edge(from.0, to.0, Empty {}).map_err(|e| {
+            if let WouldCycle(_) = e {
+                log::debug!(
+                    "WouldCycle error when adding edge from '{}' to '{}': {:?}",
+                    from_release,
+                    to_release,
+                    e
+                );
+            }
+            e.into()
+        })
     }
 
     /// Add edges for all given key/value pairs of releases.


### PR DESCRIPTION
The update graph cannot have cycles, so we have code that prevents that from happening. In a, as of Sep 2025 not so recent, case where the input images contained a release with metadata indicating it can be updated from itself and therefore creating a self-cycle in the graph, it was harder than expected to troubleshoot, because it was not logged _which_ input image hit the `WouldCycle` error:

```
[2025-05-30T14:08:18Z ERROR graph_builder::graph] WouldCycle
```

Add more logging to this case to make it clear what input item results in a cycle in the graph:

```
[2025-06-02T14:07:44Z DEBUG cincinnati] WouldCycle error when adding edge from '4.20.0-ec.1+arm64' to '4.20.0-ec.1+arm64': WouldCycle
```