### PR TITLE
OTA-1572: OSUS openapi specification passes the lint check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 **/*.swp
 .idea
 junit_*.xml
+node_modules/
+package-lock.json
+package.json

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,6 @@
+---
+extends: '@ibm-cloud/openapi-ruleset'
+rules:
+  ### those two rules are error by default
+  ibm-enum-casing-convention: warn
+  ibm-property-casing-convention: warn

--- a/Justfile
+++ b/Justfile
@@ -57,6 +57,16 @@ yamllint:
 generate_openapi:
 	yq . --indent 4 docs/design/policy-engine-openapi.yaml > policy-engine/src/openapiv3.json
 
+# the default config file for lint-openapi is .spectral.yaml
+# npm install @ibm-cloud/openapi-ruleset
+# https://github.com/IBM/openapi-validator/blob/main/docs/ibm-cloud-rules.md#customization
+openapi_lint:
+	npm list @ibm-cloud/openapi-ruleset || npm install @ibm-cloud/openapi-ruleset
+	lint-openapi policy-engine/src/openapiv3.json
+
+verify_openapi: openapi_lint generate_openapi
+	git diff --exit-code -- policy-engine/src/openapiv3.json
+
 _coverage:
 	cargo kcov --verbose --all --no-clean-rebuild --open
 

--- a/Justfile
+++ b/Justfile
@@ -55,7 +55,7 @@ yamllint:
 	dist/prow_yaml_lint.sh
 
 generate_openapi:
-	yq --indent 4 < docs/design/policy-engine-openapi.yaml > policy-engine/src/openapiv3.json
+	yq . --indent 4 docs/design/policy-engine-openapi.yaml > policy-engine/src/openapiv3.json
 
 _coverage:
 	cargo kcov --verbose --all --no-clean-rebuild --open

--- a/Justfile
+++ b/Justfile
@@ -54,6 +54,9 @@ prepare_ci_credentials:
 yamllint:
 	dist/prow_yaml_lint.sh
 
+generate_openapi:
+	yq --indent 4 < docs/design/policy-engine-openapi.yaml > policy-engine/src/openapiv3.json
+
 _coverage:
 	cargo kcov --verbose --all --no-clean-rebuild --open
 

--- a/dist/prow_yaml_lint.sh
+++ b/dist/prow_yaml_lint.sh
@@ -12,6 +12,7 @@ ignore:
 - cincinnati/src/plugins/internal/graph_builder/openshift_secondary_metadata_parser/test_fixtures/
 - vendor/
 - dist/grafana/dashboards/
+- node_modules/
 
 rules:
   line-length:

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -8,9 +8,10 @@ info:
   contact: {}
 servers: []
 paths:
-  "/graph":
-    get:
+  "/graph": 
+    get: &function
       summary: Get the update graph
+      operationId: getGraph
       responses:
         '200':
           description: An update graph
@@ -43,7 +44,9 @@ paths:
               schema:
                 "$ref": "#/components/schemas/GraphError"
   "/v1/graph":
-    "$ref": "#/paths/~1graph"
+    get:
+      <<: *function
+      operationId: getV1Graph
 components:
   schemas:
     Version:

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -9,7 +9,7 @@ info:
 servers: []
 paths:
   "/graph":
-    get: &function
+    get: &get
       summary: Get the update graph
       operationId: getGraph
       responses:
@@ -19,33 +19,24 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Graph"
-        '400':
+        '400': &err400
           description: Bad client request
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/GraphError"
         '406':
+          <<: *err400
           description: Invalid Content-Type
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GraphError"
         '500':
+          <<: *err400
           description: Internal error
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GraphError"
         default:
+          <<: *err400
           description: Generic graph error
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GraphError"
   "/v1/graph":
     get:
-      <<: *function
+      <<: *get
       operationId: getV1Graph
 components:
   schemas:

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -8,7 +8,7 @@ info:
   contact: {}
 servers: []
 paths:
-  "/graph": 
+  "/graph":
     get: &function
       summary: Get the update graph
       operationId: getGraph
@@ -72,9 +72,9 @@ components:
             "$ref": "#/components/schemas/ConditionalEdges"
     Node:
       required:
-      - version
-      - payload
-      - metadata
+        - version
+        - payload
+        - metadata
       properties:
         version:
           type: string
@@ -96,12 +96,12 @@ components:
         edges:
           type: array
           example:
-          - from: 4.17.18
-            to: 4.17.19
+            - from: 4.17.18
+              to: 4.17.19
           items:
             required:
-            - from
-            - to
+              - from
+              - to
             type: object
             description: |
               a conditional edge represents a conditional update path
@@ -117,13 +117,13 @@ components:
           type: array
           description: a set of risks for the associated conditional update path
           example:
-          - url: https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html
-            name: PreRelease
-            message: |
-              This is a prerelease version, and you should update to 4.18.1 or later releases, even if that
-              means updating to a newer 4.17 first.
-            matchingRules:
-            - type: Always
+            - url: https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html
+              name: PreRelease
+              message: |
+                This is a prerelease version, and you should update to 4.18.1 or later releases, even if that
+                means updating to a newer 4.17 first.
+              matchingRules:
+                - type: Always
           items:
             type: object
             properties:
@@ -148,7 +148,7 @@ components:
                   that result is used, and no further entries should be attempted.
                   If no condition can be successfully evaluated, the update should not be recommended.
                 example:
-                - type: Always
+                  - type: Always
                 items:
                   type: object
                   properties:
@@ -156,12 +156,12 @@ components:
                       type: string
                       description: the type of the matching rule
                       enum:
-                      - Always
-                      - PromQL
+                        - Always
+                        - PromQL
                     promql:
                       type: object
                       required:
-                      - promql
+                        - promql
                       description: the matching rule of type PromQL.
                       properties:
                         promql:
@@ -172,8 +172,8 @@ components:
                             0 * group(cluster_operator_conditions{_id=""})
     GraphError:
       required:
-      - kind
-      - value
+        - kind
+        - value
       properties:
         kind:
           type: string

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -1,0 +1,179 @@
+---
+openapi: 3.0.3
+info:
+  version: 0.0.0
+  title: OpenShift Cincinnati Policy-Engine
+  license:
+    name: Apache2
+  contact: {}
+servers: []
+paths:
+  "/graph":
+    get:
+      summary: Get the update graph
+      responses:
+        '200':
+          description: An update graph
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Graph"
+        '400':
+          description: Bad client request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GraphError"
+        '406':
+          description: Invalid Content-Type
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GraphError"
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GraphError"
+        default:
+          description: Generic graph error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GraphError"
+  "/v1/graph":
+    "$ref": "#/paths/~1graph"
+components:
+  schemas:
+    Version:
+      type: string
+      description: The version of an OpenShift release
+      example: 4.16.3
+    Graph:
+      properties:
+        version:
+          type: integer
+          example: 1
+        nodes:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Node"
+        edges:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Edge"
+        conditionalEdges:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ConditionalEdges"
+    Node:
+      required:
+      - version
+      - payload
+      - metadata
+      properties:
+        version:
+          type: string
+        payload:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    Edge:
+      type: array
+      items:
+        type: integer
+        format: int32
+    ConditionalEdges:
+      type: object
+      description: the conditional edges of the graph.
+      properties:
+        edges:
+          type: array
+          example:
+          - from: 4.17.18
+            to: 4.17.19
+          items:
+            required:
+            - from
+            - to
+            type: object
+            description: |
+              a conditional edge represents a conditional update path
+              from an OpenShift release to another.
+            properties:
+              from:
+                description: the version from which the upgrade is
+                "$ref": "#/components/schemas/Version"
+              to:
+                description: the version to which the upgrade is
+                "$ref": "#/components/schemas/Version"
+        risks:
+          type: array
+          description: a set of risks for the associated conditional update path
+          example:
+          - url: https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html
+            name: PreRelease
+            message: |
+              This is a prerelease version, and you should update to 4.18.1 or later releases, even if that
+              means updating to a newer 4.17 first.
+            matchingRules:
+            - type: Always
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+                description: the URI documenting the risk
+              name:
+                type: string
+                description: the name of the risk
+              message:
+                type: string
+                description: a human-oriented message describing the risk
+              matchingRules:
+                type: array
+                description: |
+                  It defines the conditions for deciding which clusters have the update recommended
+                  and which do not.
+                  The array is ordered by decreasing precedence. Consumers should walk the array in order.
+                  For a given entry, if a condition type is unrecognized, or fails to evaluate, consumers
+                  should proceed to the next entry.
+                  If a condition successfully evaluates (either as a match or as an explicit does-not-match),
+                  that result is used, and no further entries should be attempted.
+                  If no condition can be successfully evaluated, the update should not be recommended.
+                example:
+                - type: Always
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: the type of the matching rule
+                      enum:
+                      - Always
+                      - PromQL
+                    promql:
+                      type: object
+                      required:
+                      - promql
+                      description: the matching rule of type PromQL.
+                      properties:
+                        promql:
+                          type: string
+                          example: |
+                            group(cluster_operator_conditions{_id="",name="aro"})
+                            or
+                            0 * group(cluster_operator_conditions{_id=""})
+    GraphError:
+      required:
+      - kind
+      - value
+      properties:
+        kind:
+          type: string
+        value:
+          type: string
+security: []

--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -45,10 +45,17 @@ components:
       description: The version of an OpenShift release
       example: 4.16.3
     Graph:
+      required:
+        - version
+        - nodes
+        - edges
+        - conditionalEdges
       properties:
         version:
           type: integer
           example: 1
+          minimum: 1
+          maximum: 2147483647
         nodes:
           type: array
           items:
@@ -80,9 +87,14 @@ components:
       items:
         type: integer
         format: int32
+        minimum: 1
+        maximum: 2147483647
     ConditionalEdges:
       type: object
       description: the conditional edges of the graph.
+      required:
+        - edges
+        - risks
       properties:
         edges:
           type: array
@@ -99,10 +111,8 @@ components:
               from an OpenShift release to another.
             properties:
               from:
-                description: the version from which the upgrade is
                 "$ref": "#/components/schemas/Version"
               to:
-                description: the version to which the upgrade is
                 "$ref": "#/components/schemas/Version"
         risks:
           type: array
@@ -117,6 +127,8 @@ components:
                 - type: Always
           items:
             type: object
+            required:
+              - matchingRules
             properties:
               url:
                 type: string
@@ -142,6 +154,8 @@ components:
                   - type: Always
                 items:
                   type: object
+                  required:
+                    - type
                   properties:
                     type:
                       type: string

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -135,10 +135,18 @@
                 "example": "4.16.3"
             },
             "Graph": {
+                "required": [
+                    "version",
+                    "nodes",
+                    "edges",
+                    "conditionalEdges"
+                ],
                 "properties": {
                     "version": {
                         "type": "integer",
-                        "example": 1
+                        "example": 1,
+                        "minimum": 1,
+                        "maximum": 2147483647
                     },
                     "nodes": {
                         "type": "array",
@@ -185,12 +193,18 @@
                 "type": "array",
                 "items": {
                     "type": "integer",
-                    "format": "int32"
+                    "format": "int32",
+                    "minimum": 1,
+                    "maximum": 2147483647
                 }
             },
             "ConditionalEdges": {
                 "type": "object",
                 "description": "the conditional edges of the graph.",
+                "required": [
+                    "edges",
+                    "risks"
+                ],
                 "properties": {
                     "edges": {
                         "type": "array",
@@ -209,11 +223,9 @@
                             "description": "a conditional edge represents a conditional update path\nfrom an OpenShift release to another.\n",
                             "properties": {
                                 "from": {
-                                    "description": "the version from which the upgrade is",
                                     "$ref": "#/components/schemas/Version"
                                 },
                                 "to": {
-                                    "description": "the version to which the upgrade is",
                                     "$ref": "#/components/schemas/Version"
                                 }
                             }
@@ -236,6 +248,9 @@
                         ],
                         "items": {
                             "type": "object",
+                            "required": [
+                                "matchingRules"
+                            ],
                             "properties": {
                                 "url": {
                                     "type": "string",
@@ -259,6 +274,9 @@
                                     ],
                                     "items": {
                                         "type": "object",
+                                        "required": [
+                                            "type"
+                                        ],
                                         "properties": {
                                             "type": {
                                                 "type": "string",

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -13,6 +13,7 @@
         "/graph": {
             "get": {
                 "summary": "Get the update graph",
+                "operationId": "getGraph",
                 "responses": {
                     "200": {
                         "description": "An update graph",
@@ -68,7 +69,62 @@
             }
         },
         "/v1/graph": {
-            "$ref": "#/paths/~1graph"
+            "get": {
+                "summary": "Get the update graph",
+                "operationId": "getV1Graph",
+                "responses": {
+                    "200": {
+                        "description": "An update graph",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Graph"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad client request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "Invalid Content-Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Generic graph error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GraphError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {


### PR DESCRIPTION
The commits before the last one are preps for the task:

- Generate `policy-engine/src/openapiv3.json` from `docs/design/policy-engine-openapi.yaml`: `json` is more for machines [while](https://aws.amazon.com/compare/the-difference-between-yaml-and-json/) `yaml` for human.
- Another advantage is that alias and anchor are available for `yaml` those can used to [avoid duplications](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd).
- In addition, we recovers operationId that is removed as a tradeoff in ce799df3b183b95f08fb476fab4087836e550ed9

Most importantly, the last commit
- Fix the issues detected by the tool, and
- Add `just verify_openapi` is to ensure the pipeline of generation and going to be used in CI to avoid regression.
