### PR TITLE
OpenAPI lint: Supply format of Graph.version

### DIFF
--- a/docs/design/policy-engine-openapi.yaml
+++ b/docs/design/policy-engine-openapi.yaml
@@ -85,6 +85,7 @@ components:
       properties:
         version:
           type: integer
+          format: int32
           example: 1
           minimum: 1
           maximum: 2147483647

--- a/policy-engine/src/openapiv3.json
+++ b/policy-engine/src/openapiv3.json
@@ -212,6 +212,7 @@
                 "properties": {
                     "version": {
                         "type": "integer",
+                        "format": "int32",
                         "example": 1,
                         "minimum": 1,
                         "maximum": 2147483647


### PR DESCRIPTION
To avoid

```
Errors:

  Message :   Integer schemas should specify format as one of int32, int64
  Rule    :   ibm-integer-attributes
  Path    :   components.schemas.Graph.properties.version
  Line    :   213

```

Detected by https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/66130/rehearse-66130-pull-ci-openshift-cincinnati-master-verify-openapi/1957835484713455616