### PR TITLE
Avoid SIGPIPE by using "sed -n 1p" to get the first line

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -88,7 +88,7 @@ test_cincinnati: deploy_cincinnati
 	#!/usr/bin/env bash
 	set -euxo pipefail
 	oc -n "{{cincinnati_namespace}}" wait --timeout=600s --for=condition=Ready pod -l app=cincinnati
-	pod_name="$(oc -n "{{cincinnati_namespace}}" get pod -l app=cincinnati --no-headers -o custom-columns=":metadata.name" | head -n 1)"
+	pod_name="$(oc -n "{{cincinnati_namespace}}" get pod -l app=cincinnati --no-headers -o custom-columns=":metadata.name" | sed -n 1p)"
 	oc -n "{{cincinnati_namespace}}" exec "${pod_name}" -c cincinnati-policy-engine -- curl -f -s -v "localhost:8081/api/upgrades_info/graph?channel=a"
 	oc -n "{{cincinnati_namespace}}" exec "${pod_name}" -c cincinnati-policy-engine -- curl -f -s -v "cincinnati-policy-engine.{{cincinnati_namespace}}.svc.cluster.local/api/upgrades_info/graph?channel=a"
 	route_host="$(oc -n "{{cincinnati_namespace}}" get route {{route_name}} -o jsonpath='{.spec.host}')"


### PR DESCRIPTION
This is to avoid the following error (link to a failure CI [1])

```
error: Recipe `test_cincinnati` failed with exit code 141
```

According to [1], `sed -n 1p` is a better choice to get the first line from the output.

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/66130/rehearse-66130-pull-ci-openshift-cincinnati-master-osus-e2e/1957846930058907648

[2]. https://unix.stackexchange.com/questions/736743/getting-first-line-of-piped-output-sets-exist-status-141-which-fails-bash-script