### PR TITLE
Wait for crd/scaledobjects to be establised

### DIFF
--- a/hack/deploy_cincinnati.sh
+++ b/hack/deploy_cincinnati.sh
@@ -31,6 +31,7 @@ oc create secret generic cincinnati-credentials --from-literal="foo=bar" --dry-r
 # Install keda CRD required by cincinnati-deployment.yaml
 # --server-side is for https://github.com/kedacore/keda/issues/4740
 oc get crd scaledjobs.keda.sh || oc apply --server-side -f https://github.com/kedacore/keda/releases/download/v2.17.1/keda-2.17.1-crds.yaml
+oc wait --for=condition=Established crd scaledobjects.keda.sh
 
 # Apply oc template
 oc process -f dist/openshift/cincinnati-deployment.yaml \


### PR DESCRIPTION
This is to give API server more time to reconcile and avoid the error [1] like

```
unable to recognize no matches for kind "ScaledObject" in version "keda.sh/v1alpha1"
```

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68277/rehearse-68277-pull-ci-openshift-cincinnati-master-osus-e2e/1957901958522081280