### PR TITLE
Introduce the term of primary metadata explicitly

### DIFF
--- a/docs/design/openshift.md
+++ b/docs/design/openshift.md
@@ -147,7 +147,7 @@ The image field references the Update Image which contains the actual update to 
 
 ## Update Image ##
 
-The Update Image is a container image consisting of a series of Kubernetes manifests describing the First-Level Operators (FLOs) and the Second-Level Operators (SLOs), the `release-metadata` file required by Cincinnati, and a manifest specific to OpenShift. In the future, this image may be expanded to include other assets.
+The Update Image is a container image consisting of a series of Kubernetes manifests describing the First-Level Operators (FLOs) and the Second-Level Operators (SLOs), the `release-metadata` file which contains the _primary metadata_ and is required by Cincinnati, and a manifest specific to OpenShift. In the future, this image may be expanded to include other assets.
 The OpenShift manifest describes the format of the Update Image.
 
 ```

--- a/docs/user/running-cincinnati.md
+++ b/docs/user/running-cincinnati.md
@@ -102,7 +102,7 @@ Here is an example [bash script](../../hack/deploy_cincinnati.sh) to depoly Cinc
 
 ## Configure a container registry to scrape release payload information
 
-Cincinnati can fetch the release payload information (primary metadata) from any container registry compatible with [Docker registry API v2][registry-api-v2].
+Cincinnati can fetch the release payload information ([primary metadata](../design/openshift.md#update-image)) from any container registry compatible with [Docker registry API v2][registry-api-v2].
 
 You can change the default registry in Cincinnati deployment config when you start a deployment.
 


### PR DESCRIPTION
The term `primary metadata` has been used in several places in our documentation. Here we introduce its definition explicitly and add the link to it for its references.